### PR TITLE
Record connection death instead of letting it take down the process

### DIFF
--- a/packages/matrix/support/isolated-realm-server.ts
+++ b/packages/matrix/support/isolated-realm-server.ts
@@ -821,13 +821,32 @@ export class BasicSQLExecutor implements SQLExecutor {
       password: '', // trust auth, so no password needed
       database: db, // default database to connect to
     });
+    // The databases this pool connects to are dropped by the harness's own
+    // teardown, which terminates every backend on a database first. `pg`
+    // reports a connection dying as an `error` event, and an `error` event
+    // with no listener is an uncaught exception — which the runner attributes
+    // to whatever test happened to be in flight rather than to the teardown
+    // that caused it.
+    this.pool.on('error', (err: Error) => {
+      console.warn(`error on idle client of the ${this.db} pool: ${err}`);
+    });
   }
   async executeSQL(sql: string) {
     const client = await this.pool.connect();
+    // A pool removes its own idle listener for the duration of a checkout, so
+    // the listener above does not cover a client dying mid-query: that query
+    // rejects into the caller, and the socket's closing event then arrives
+    // with nobody left to hear it.
+    let onError = (err: Error) =>
+      console.warn(
+        `error on checked-out client of the ${this.db} pool: ${err}`,
+      );
+    client.on('error', onError);
     try {
       let { rows } = await client.query(sql);
       return rows;
     } finally {
+      client.removeListener('error', onError);
       client.release();
     }
   }

--- a/packages/postgres/pg-adapter.ts
+++ b/packages/postgres/pg-adapter.ts
@@ -120,11 +120,24 @@ type ChannelState = {
 };
 
 // `pg` reports a connection dying as an `error` event, and an `error` event
-// with no listener is an uncaught exception — so every connection this module
-// opens needs one, whether it lives for a query or for the life of a
-// subscription. A short-lived client is no less exposed: its in-flight query
-// rejects into the caller that can handle it, and the socket's closing event
-// arrives afterwards with nobody left to hear it.
+// with no listener is an uncaught exception — so every connection whose
+// lifecycle this module owns carries one, whether it lives for a query or for
+// the life of a subscription. A short-lived client is no less exposed: its
+// in-flight query rejects into the caller that can handle it, and the socket's
+// closing event arrives afterwards with nobody left to hear it.
+//
+// The migration runner is the deliberate exception. `migrate()` is given a
+// connection config rather than a client, so node-pg-migrate opens and owns
+// that connection, and a drop there has to stop startup rather than be logged
+// and continued: the rejection it raises already does that, and a listener
+// would only be racing it. Recording is for a process that should survive the
+// drop, which a half-applied schema is not.
+//
+// Severity says whether anything recovers. A pooled client is replaced on the
+// next checkout and a short-lived one reports through its caller, so those are
+// `warn`. A connection held for the life of a subscription has no reconnect
+// path — losing it degrades whatever depends on those notifications for the
+// rest of the process's life, which is worth alerting on.
 //
 // Returns a function that stops recording, for the callers that hand their
 // client back: a pool re-attaches its own idle listener on release, and this
@@ -132,9 +145,10 @@ type ChannelState = {
 function recordConnectionErrors(
   client: Client | PoolClient,
   label: string,
+  severity: 'warn' | 'error',
 ): () => void {
   let onError = (e: Error) => {
-    log.warn(`connection error on ${label}: ${String(e)}`);
+    log[severity](`connection error on ${label}: ${String(e)}`);
   };
   client.on('error', onError);
   return () => client.removeListener('error', onError);
@@ -371,7 +385,7 @@ export class PgAdapter implements DBAdapter {
     // own idle listener for the duration of the checkout, so the in-flight
     // query rejects into the caller that handles it and the socket's closing
     // event lands unheard.
-    let stopRecording = recordConnectionErrors(client, this.url);
+    let stopRecording = recordConnectionErrors(client, this.url, 'warn');
     log.debug(
       `executing sql: ${sql}, with bindings: ${JSON.stringify(opts?.bind)}`,
     );
@@ -418,7 +432,15 @@ export class PgAdapter implements DBAdapter {
     //   https://github.com/brianc/node-postgres/issues/1543#issuecomment-353622236
     // So for listen purposes, we establish a completely separate connection.
     let client = new Client(this.config);
-    recordConnectionErrors(client, `the LISTEN connection for ${channel}`);
+    recordConnectionErrors(
+      client,
+      `the LISTEN connection for ${channel}`,
+      // Nothing reconnects this: the subscription is dead for the life of the
+      // process, and every caller waiting on those notifications silently
+      // falls back to whatever polling it has. `error` so it can be alerted
+      // on rather than read afterwards.
+      'error',
+    );
     await client.connect();
     try {
       client.on('notification', (n) => {
@@ -608,7 +630,7 @@ export class PgAdapter implements DBAdapter {
     await this.started;
 
     let client = await this.pool.connect();
-    let stopRecording = recordConnectionErrors(client, this.url);
+    let stopRecording = recordConnectionErrors(client, this.url, 'warn');
     let query = async (expression: Expression) => {
       let sql = expressionToSql(this.kind, expression);
       log.debug('search: %s trace: %j', sql.text, sql.values);
@@ -664,7 +686,11 @@ export class PgAdapter implements DBAdapter {
     let client = new Client(
       Object.assign({}, config, { database: 'postgres' }),
     );
-    recordConnectionErrors(client, 'the migration bootstrap connection');
+    recordConnectionErrors(
+      client,
+      'the migration bootstrap connection',
+      'warn',
+    );
     try {
       await client.connect();
       let response = await client.query(
@@ -741,7 +767,11 @@ export class PgAdapter implements DBAdapter {
       .replace(/^-|-$/g, '');
 
     let client = new Client(config);
-    recordConnectionErrors(client, 'the environment-mode permission fixup');
+    recordConnectionErrors(
+      client,
+      'the environment-mode permission fixup',
+      'warn',
+    );
     try {
       await client.connect();
       let realmServerUrl = `http://realm-server.${slug}.localhost`;
@@ -784,7 +814,7 @@ export class PgAdapter implements DBAdapter {
     }
 
     let client = new Client(config);
-    recordConnectionErrors(client, 'the migration-rename fixup');
+    recordConnectionErrors(client, 'the migration-rename fixup', 'warn');
     try {
       await client.connect();
       let { rows } = await client.query(

--- a/packages/postgres/pg-adapter.ts
+++ b/packages/postgres/pg-adapter.ts
@@ -11,7 +11,7 @@ import {
 import { createHash } from 'crypto';
 import nodePgMigrate, { type RunnerOption } from 'node-pg-migrate';
 import { join } from 'path';
-import { Pool, Client, type Notification } from 'pg';
+import { Pool, Client, type PoolClient, type Notification } from 'pg';
 
 import { postgresConfig } from './pg-config.ts';
 import migrationNameFixes from './scripts/migration-name-fixes.cjs';
@@ -119,6 +119,27 @@ type ChannelState = {
   establishment: Promise<void>;
 };
 
+// `pg` reports a connection dying as an `error` event, and an `error` event
+// with no listener is an uncaught exception — so every connection this module
+// opens needs one, whether it lives for a query or for the life of a
+// subscription. A short-lived client is no less exposed: its in-flight query
+// rejects into the caller that can handle it, and the socket's closing event
+// arrives afterwards with nobody left to hear it.
+//
+// Returns a function that stops recording, for the callers that hand their
+// client back: a pool re-attaches its own idle listener on release, and this
+// one must come off so the client it owns again carries exactly one.
+function recordConnectionErrors(
+  client: Client | PoolClient,
+  label: string,
+): () => void {
+  let onError = (e: Error) => {
+    log.warn(`connection error on ${label}: ${String(e)}`);
+  };
+  client.on('error', onError);
+  return () => client.removeListener('error', onError);
+}
+
 export class PgAdapter implements DBAdapter {
   readonly kind = 'pg';
   #isClosed = false;
@@ -159,6 +180,15 @@ export class PgAdapter implements DBAdapter {
       password,
       port,
       max,
+    });
+    // An idle client whose connection dies — a failover, a restart, an
+    // administrator terminating the backend — emits `error` on the pool, and
+    // an `error` event nobody listens for is an uncaught exception. The pool
+    // has already discarded the client by the time this runs and stays
+    // usable, so recording it is the whole job: without this listener a
+    // process that was about to reconnect dies instead.
+    this.pool.on('error', (e: Error) => {
+      log.warn(`error on idle client of ${this.url}: ${String(e)}`);
     });
   }
 
@@ -337,6 +367,11 @@ export class PgAdapter implements DBAdapter {
   ): Promise<Record<string, PgPrimitive>[]> {
     await this.started;
     let client = await this.pool.connect();
+    // A checked-out client's death is nobody's event: the pool removes its
+    // own idle listener for the duration of the checkout, so the in-flight
+    // query rejects into the caller that handles it and the socket's closing
+    // event lands unheard.
+    let stopRecording = recordConnectionErrors(client, this.url);
     log.debug(
       `executing sql: ${sql}, with bindings: ${JSON.stringify(opts?.bind)}`,
     );
@@ -355,6 +390,7 @@ export class PgAdapter implements DBAdapter {
       );
       throw e;
     } finally {
+      stopRecording();
       client.release();
     }
   }
@@ -382,6 +418,7 @@ export class PgAdapter implements DBAdapter {
     //   https://github.com/brianc/node-postgres/issues/1543#issuecomment-353622236
     // So for listen purposes, we establish a completely separate connection.
     let client = new Client(this.config);
+    recordConnectionErrors(client, `the LISTEN connection for ${channel}`);
     await client.connect();
     try {
       client.on('notification', (n) => {
@@ -571,6 +608,7 @@ export class PgAdapter implements DBAdapter {
     await this.started;
 
     let client = await this.pool.connect();
+    let stopRecording = recordConnectionErrors(client, this.url);
     let query = async (expression: Expression) => {
       let sql = expressionToSql(this.kind, expression);
       log.debug('search: %s trace: %j', sql.text, sql.values);
@@ -602,6 +640,7 @@ export class PgAdapter implements DBAdapter {
       released = true;
       throw e;
     } finally {
+      stopRecording();
       if (!released) {
         client.release();
       }
@@ -625,6 +664,7 @@ export class PgAdapter implements DBAdapter {
     let client = new Client(
       Object.assign({}, config, { database: 'postgres' }),
     );
+    recordConnectionErrors(client, 'the migration bootstrap connection');
     try {
       await client.connect();
       let response = await client.query(
@@ -701,6 +741,7 @@ export class PgAdapter implements DBAdapter {
       .replace(/^-|-$/g, '');
 
     let client = new Client(config);
+    recordConnectionErrors(client, 'the environment-mode permission fixup');
     try {
       await client.connect();
       let realmServerUrl = `http://realm-server.${slug}.localhost`;
@@ -743,6 +784,7 @@ export class PgAdapter implements DBAdapter {
     }
 
     let client = new Client(config);
+    recordConnectionErrors(client, 'the migration-rename fixup');
     try {
       await client.connect();
       let { rows } = await client.query(

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -317,6 +317,7 @@ const ALL_TEST_FILES: string[] = [
   './jobs-finished-listener-test',
   './realm-routing-test',
   './module-cache-invalidation-listener-test',
+  './pg-adapter-connection-error-test',
   './pg-adapter-subscribe-test',
   './module-cache-coordination-test',
   './realm-endpoints/archived-seal-test',

--- a/packages/realm-server/tests/pg-adapter-connection-error-test.ts
+++ b/packages/realm-server/tests/pg-adapter-connection-error-test.ts
@@ -1,0 +1,104 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import type { PgAdapter } from '@cardstack/postgres';
+import { setupDB } from './helpers/index.ts';
+
+// A Postgres connection can die under a healthy process — a failover, a
+// restart, an administrator terminating the backend. `pg` reports that as an
+// `error` event on the client, and an `error` event with no listener is an
+// uncaught exception, so a pool that has already discarded the bad connection
+// and is ready to reconnect loses the process instead.
+//
+// Termination is the reachable way to produce that event on demand: it is the
+// same `57P01` a failover delivers, and it arrives at the same place.
+
+// Collect what reaches the process during `fn`, rather than letting it land on
+// whatever the suite happens to be running. An `uncaughtException` listener
+// also keeps the process alive, which is what lets the assertion run at all.
+async function processLevelErrors(fn: () => Promise<void>): Promise<string[]> {
+  let seen: string[] = [];
+  let onUncaught = (e: Error) => seen.push(`uncaughtException: ${e.message}`);
+  let onRejection = (e: unknown) =>
+    seen.push(`unhandledRejection: ${String(e)}`);
+  process.on('uncaughtException', onUncaught);
+  process.on('unhandledRejection', onRejection);
+  try {
+    await fn();
+    // Both events are delivered on a later turn than the socket read that
+    // produced them, so give them one to arrive.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  } finally {
+    process.off('uncaughtException', onUncaught);
+    process.off('unhandledRejection', onRejection);
+  }
+  return seen;
+}
+
+module(basename(import.meta.filename), function (hooks) {
+  let dbAdapter: PgAdapter;
+
+  setupDB(hooks, {
+    beforeEach: async (adapter) => {
+      dbAdapter = adapter;
+    },
+  });
+
+  test('a checked-out connection dying reaches its caller, not the process', async function (assert) {
+    let rejection: string | undefined;
+
+    let escaped = await processLevelErrors(async () => {
+      await dbAdapter.withConnection(async (query) => {
+        let [row] = await query([`SELECT pg_backend_pid() AS pid`]);
+        let pid = Number(row.pid);
+
+        // Kill this pinned connection from another one while a query is in
+        // flight on it, so the failure has to arrive as an error on a client
+        // the pool is not currently listening to.
+        let killed = dbAdapter.execute(`SELECT pg_terminate_backend(${pid})`);
+        try {
+          await query([`SELECT pg_sleep(3)`]);
+        } catch (e: any) {
+          rejection = e.message;
+        }
+        await killed;
+      });
+    });
+
+    assert.ok(
+      rejection,
+      `the in-flight query rejects, got ${JSON.stringify(rejection)}`,
+    );
+    assert.deepEqual(
+      escaped,
+      [],
+      'nothing reaches the process as an uncaught exception',
+    );
+  });
+
+  test('an idle pooled connection dying reaches the pool, not the process', async function (assert) {
+    let escaped = await processLevelErrors(async () => {
+      // The kill has to come from a connection that is not the one being
+      // killed. A pool hands back the client it released most recently, so
+      // terminating the pid an `execute` just reported, with another
+      // `execute`, terminates the connection carrying the request. Pinning
+      // one connection for the kill leaves the reported pid idle.
+      await dbAdapter.withConnection(async (query) => {
+        let [row] = await dbAdapter.execute(`SELECT pg_backend_pid() AS pid`);
+        await query([`SELECT pg_terminate_backend(${Number(row.pid)})`]);
+      });
+    });
+
+    assert.deepEqual(
+      escaped,
+      [],
+      'nothing reaches the process as an uncaught exception',
+    );
+    let [row] = await dbAdapter.execute(`SELECT 1 AS ok`);
+    assert.strictEqual(
+      Number(row.ok),
+      1,
+      'the pool is still usable afterwards',
+    );
+  });
+});


### PR DESCRIPTION
This is a diagnostic improvement related to the ongoing Boxel CLI CI failures.

Postgres errors have been registering as [unhandled](https://github.com/cardstack/boxel/actions/runs/33177745463/job/98871657984#step:12:24196):

```
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 6 unhandled errors during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
error: terminating connection due to administrator command
 ❯ parseErrorMessage ../../node_modules/.pnpm/pg-protocol@1.14.0/node_modules/pg-protocol/src/parser.ts:394:9
 ❯ Parser.handlePacket ../../node_modules/.pnpm/pg-protocol@1.14.0/node_modules/pg-protocol/src/parser.ts:212:19
 ❯ Parser.parse ../../node_modules/.pnpm/pg-protocol@1.14.0/node_modules/pg-protocol/src/parser.ts:105:30
 ❯ Socket.<anonymous> ../../node_modules/.pnpm/pg-protocol@1.14.0/node_modules/pg-protocol/src/index.ts:7:48
 ❯ Socket.emit node:events:509:28
 ❯ addChunk node:internal/streams/readable:563:12
 ❯ readableAddChunkPushByteMode node:internal/streams/readable:514:3
 ❯ Socket.Readable.push node:internal/streams/readable:394:5
 ❯ TCP.onStreamRead node:internal/stream_base_commons:189:23
```

Now when there are connection deaths the error is [logged](https://github.com/cardstack/boxel/actions/runs/33641034170/job/100288710277?pr=5977#step:12:18295):

```
error on idle client of postgres@localhost:55436/test_db_10273_1: error: terminating connection due to administrator command
connection error on the LISTEN connection for jobs: error: terminating connection due to administrator command
connection error on postgres@localhost:55436/test_db_10273_1: error: terminating connection due to administrator command
connection error on postgres@localhost:55436/test_db_10273_1: Error: Connection terminated unexpectedly
connection error on the LISTEN connection for jobs: Error: Connection terminated unexpectedly
```

The job still fails, but it’s more clear why.

Claude: A Postgres connection can die under a healthy process: a failover, a restart, an administrator terminating the backend. `pg` reports that as an `error` event, and an `error` event with no listener is an uncaught exception — so a pool that has already discarded the bad client and is ready to reconnect loses the process instead.

Neither state a client can be in was heard. Measured against a live server by terminating a backend from another connection:

  idle client, no listener     uncaught: terminating connection due to
                               administrator command  (57P01)
  idle client, pool listener   logged, nothing uncaught
  busy client, no listener     query rejects with the real cause, then
                               uncaught: Connection terminated unexpectedly
  busy client, pool listener   query rejects, still uncaught
  busy client, own listener    logged, nothing uncaught

An idle client's error belongs to the pool, so `pool.on('error')` hears it. A checked-out client's belongs to nobody: the pool removes its own idle listener for the duration of the checkout, so the in-flight query rejects into a caller that handles it and the socket's closing event arrives with no one left. Both checkout sites now listen for as long as they hold the client and drop the listener before releasing, so a client the pool owns again carries exactly one.

The standalone clients get the same treatment, including the LISTEN connection that the shared notification client's own comment already points at as having the same hazard. That one is the most exposed of them: it is held for as long as its subscription lives.

The tests terminate a backend and assert that nothing reaches the process, which is also how the table above was measured. They fail without this change — and the idle case only fails honestly when the kill arrives from a pinned second connection, since a pool hands back the client it released most recently and would otherwise be killing the connection carrying the request.

In the CLI integration suite this is the difference between a job whose database goes away while it is still running and a job that also fails the test file it is no longer part of, because vitest attributes an uncaught exception to whichever file is running. In a deployed realm server it is the difference between logging a dropped connection and losing the process to one.