### PR TITLE
fix(boxel-cli): a Boxel CLI Tests flake, the checkpoint read behind it, and deadlines that hid both

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1113,7 +1113,13 @@ jobs:
     # CS-11161) needs to fail here pre-merge rather than on main post-merge.
     if: needs.change-check.outputs.boxel-cli == 'true' || needs.change-check.outputs.realm-server == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # A healthy run is ~10 minutes. The headroom is for the unhealthy one: a
+    # fixture that wedges costs its whole hook budget
+    # (packages/boxel-cli/vitest.config.mjs) before the file reports, and a job
+    # cancelled on this cap reports nothing at all — the nameless failure that
+    # budget exists to avoid. This covers a handful of wedged fixtures, not all
+    # of them; a systemic fixture failure will still hit the cap.
+    timeout-minutes: 30
     concurrency:
       group: boxel-cli-test-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/packages/boxel-cli/src/lib/checkpoint-manager.ts
+++ b/packages/boxel-cli/src/lib/checkpoint-manager.ts
@@ -77,7 +77,14 @@ export class CheckpointManager {
    * watch` flush is the ordinary way to land in it.
    */
   private async hasCommits(): Promise<boolean> {
-    const head = await this.git('rev-parse', '--verify', '--quiet', 'HEAD');
+    // `rev-parse --verify --quiet` exits 1 with no output when the revision
+    // does not resolve, which is the unborn-HEAD answer. Only that code is
+    // tolerated: a repository git cannot read at all exits 128, and must
+    // surface rather than read as "no history".
+    const head = await this.spawnGit(
+      ['rev-parse', '--verify', '--quiet', 'HEAD'],
+      (code) => code === 1,
+    );
     return head.trim().length > 0;
   }
 
@@ -645,6 +652,24 @@ export class CheckpointManager {
   ];
 
   private git(...args: string[]): Promise<string> {
+    // `status` answers through its exit code rather than through failure — a
+    // dirty tree is non-zero — so nothing it returns is an error.
+    return this.spawnGit(
+      args,
+      args.includes('status') ? () => true : () => false,
+    );
+  }
+
+  /**
+   * @param isAnswer decides which non-zero exit codes are part of the
+   * command's answer rather than a failure. Everything else still rejects, so
+   * a fatal (git uses 128: no repository, dubious ownership, a corrupt object
+   * store) is never mistaken for a negative result.
+   */
+  private spawnGit(
+    args: string[],
+    isAnswer: (code: number | null) => boolean,
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
       const child = spawn(
         'git',
@@ -667,12 +692,7 @@ export class CheckpointManager {
       child.on('error', (err) => reject(err));
 
       child.on('close', (code) => {
-        // `status` and any `--quiet` probe report their answer through the
-        // exit code — a dirty tree, an unborn HEAD — so a non-zero exit
-        // from those is data rather than a failure.
-        const exitCodeIsTheAnswer =
-          args.includes('status') || args.includes('--quiet');
-        if (code !== 0 && !exitCodeIsTheAnswer) {
+        if (code !== 0 && !isAnswer(code)) {
           reject(
             new Error(
               `git ${args.join(' ')} failed: ${stderr.trim()}` +

--- a/packages/boxel-cli/src/lib/checkpoint-manager.ts
+++ b/packages/boxel-cli/src/lib/checkpoint-manager.ts
@@ -65,6 +65,22 @@ export class CheckpointManager {
     return pathExists(path.join(this.gitDir, '.git'));
   }
 
+  /**
+   * True once the history repo holds a commit to read.
+   *
+   * `.git` existing is not enough: `init()` runs `git init` and then three
+   * more git commands before its bootstrap commit lands, so a reader that
+   * arrives in that window finds an initialized repo with an unborn HEAD —
+   * a state `git log` refuses outright ("your current branch 'master' does
+   * not have any commits yet") rather than reporting an empty history. A
+   * workspace whose history is being initialized by a concurrent `realm
+   * watch` flush is the ordinary way to land in it.
+   */
+  private async hasCommits(): Promise<boolean> {
+    const head = await this.git('rev-parse', '--verify', '--quiet', 'HEAD');
+    return head.trim().length > 0;
+  }
+
   private async syncFilesToHistory(): Promise<void> {
     const files = await this.getWorkspaceFiles();
     const fileSet = new Set(files);
@@ -341,7 +357,7 @@ export class CheckpointManager {
   }
 
   async getCheckpoints(limit = 50): Promise<Checkpoint[]> {
-    if (!(await this.isInitialized())) {
+    if (!(await this.isInitialized()) || !(await this.hasCommits())) {
       return [];
     }
 
@@ -651,7 +667,12 @@ export class CheckpointManager {
       child.on('error', (err) => reject(err));
 
       child.on('close', (code) => {
-        if (code !== 0 && !args.includes('status')) {
+        // `status` and any `--quiet` probe report their answer through the
+        // exit code — a dirty tree, an unborn HEAD — so a non-zero exit
+        // from those is data rather than a failure.
+        const exitCodeIsTheAnswer =
+          args.includes('status') || args.includes('--quiet');
+        if (code !== 0 && !exitCodeIsTheAnswer) {
           reject(
             new Error(
               `git ${args.join(' ')} failed: ${stderr.trim()}` +

--- a/packages/boxel-cli/tests/helpers/integration.ts
+++ b/packages/boxel-cli/tests/helpers/integration.ts
@@ -159,8 +159,8 @@ async function settleBoot(): Promise<void> {
   try {
     await Promise.race([
       // A rejected boot has already been reported to the hook that started
-      // it; teardown only needs to know the boot is no longer writing to the
-      // module state it is about to tear down.
+      // it; teardown only needs the boot settled, so that nothing is still
+      // writing to the module state it is about to tear down.
       boot.catch(() => {}),
       new Promise<void>((resolve) => {
         timer = setTimeout(resolve, BOOT_SETTLE_TIMEOUT_MS);
@@ -235,8 +235,9 @@ export async function startTestRealmServer(
   try {
     return await boot;
   } finally {
-    // The caller has the boot's outcome, so teardown no longer needs to wait
-    // for it. Only a boot whose caller never got here leaves this set.
+    // Clearing the handle is what tells teardown it has nothing to wait for:
+    // the caller has the boot's outcome. Only a boot whose caller never
+    // reaches here leaves it set.
     if (pendingBoot === boot) {
       pendingBoot = undefined;
       reportSlowFixture();
@@ -263,10 +264,10 @@ function reportSlowFixture(): void {
 }
 
 /**
- * Fail before booting when the fixture port is still held, and name the boot
- * that is holding it. Without this a contaminated run reports a bare `listen
- * EADDRINUSE`, which names neither the phase the leaked boot was in nor the
- * fact that the boot is what is holding the port.
+ * Fail before booting when something already holds the fixture port, and say
+ * what that means. A bare `listen EADDRINUSE` from inside the realm server's
+ * boot names a port and nothing else; the failure a reader needs to recognise
+ * is that this file never had the port to begin with.
  */
 async function assertFixturePortFree(): Promise<void> {
   if (
@@ -275,9 +276,10 @@ async function assertFixturePortFree(): Promise<void> {
     return;
   }
   throw new Error(
-    `fixture port ${TEST_REALM_SERVER_URL} is still held when starting a new ` +
-      `test realm server. A prior boot outlived its teardown; its phase ` +
-      `timings were: ${formatFixturePhases()}`,
+    `fixture port ${TEST_REALM_SERVER_URL} is already accepting connections, ` +
+      `so a test realm server cannot bind it. The usual cause is a fixture ` +
+      `boot that outlived the teardown of the file that started it — look ` +
+      `for a hook timeout in the file that ran before this one.`,
   );
 }
 
@@ -325,17 +327,21 @@ async function bootTestRealmServer(
     },
   ];
 
+  // Bound outside the timing closure: the pieces above live in module state so
+  // teardown can reach them, and a closure over module state reads them as
+  // possibly-undefined.
+  let bootArgs = {
+    realmsRootPath: path.join(realmsRootDir, 'realm_server_1'),
+    realms,
+    virtualNetwork,
+    publisher,
+    runner,
+    dbAdapter,
+    matrixURL,
+    prerenderer: options.prerenderer ?? noopPrerenderer,
+  };
   let result = await timePhase('boot-realm-server', () =>
-    runTestRealmServerWithRealms({
-      realmsRootPath: path.join(realmsRootDir!, 'realm_server_1'),
-      realms,
-      virtualNetwork,
-      publisher: publisher!,
-      runner: runner!,
-      dbAdapter: dbAdapter!,
-      matrixURL,
-      prerenderer: options.prerenderer ?? noopPrerenderer,
-    }),
+    runTestRealmServerWithRealms(bootArgs),
   );
 
   testRealmHttpServer = result.testRealmHttpServer;

--- a/packages/boxel-cli/tests/helpers/integration.ts
+++ b/packages/boxel-cli/tests/helpers/integration.ts
@@ -113,10 +113,15 @@ function fixtureTotalMs(): number {
 }
 
 /**
- * Wait for the in-flight boot to publish its results (or fail) so teardown
- * sees everything it created. A boot that outlives this window is reported by
- * `startTestRealmServer`'s own pre-flight check in the next file rather than
- * hanging teardown here.
+ * How long teardown waits for an in-flight boot to publish its results (or
+ * fail), so that it sees everything the boot created.
+ *
+ * A cap rather than an unbounded wait, because a boot that never settles would
+ * otherwise hold teardown until the hook budget above it. Reaching the cap is
+ * the one case teardown cannot clean up: the boot has by definition not
+ * reached its `listen` yet, so there is nothing to close and nothing for the
+ * next file's pre-flight check to see either. Generous enough that a boot
+ * costing an order of magnitude over its usual second is still waited out.
  */
 const BOOT_SETTLE_TIMEOUT_MS = 60_000;
 
@@ -125,7 +130,7 @@ const BOOT_SETTLE_TIMEOUT_MS = 60_000;
  * leaked fixture server apart from a clean start, so the leak is reported at
  * the boot that trips over it.
  */
-function isPortListening(host: string, port: number): Promise<boolean> {
+export function isPortListening(host: string, port: number): Promise<boolean> {
   return new Promise((resolve) => {
     let socket = new net.Socket();
     let settle = (listening: boolean) => {
@@ -153,7 +158,11 @@ async function settleBoot(): Promise<void> {
   // hook's own `Hook timed out` report cannot say.
   console.log(
     `[boxel-cli fixture] teardown is waiting on a boot that is still in ` +
-      `flight; phases so far: ${formatFixturePhases()}`,
+      `flight; ${
+        fixturePhases.length === 0
+          ? 'it had not finished its first phase (the database clone)'
+          : `phases so far: ${formatFixturePhases()}`
+      }`,
   );
   let timer: NodeJS.Timeout | undefined;
   try {

--- a/packages/boxel-cli/tests/helpers/integration.ts
+++ b/packages/boxel-cli/tests/helpers/integration.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as net from 'net';
 import * as path from 'path';
 import * as os from 'os';
 import { ProfileManager } from '../../src/lib/profile-manager.ts';
@@ -47,6 +48,8 @@ const noopPrerenderer: Prerenderer = {
 };
 
 export const TEST_REALM_SERVER_URL = 'http://127.0.0.1:4446';
+const TEST_REALM_SERVER_HOST = '127.0.0.1';
+const TEST_REALM_SERVER_PORT = 4446;
 
 export const TEST_USERNAME = `cli-test-${Date.now()}`;
 export const TEST_PASSWORD = 'test-password-for-cli';
@@ -57,6 +60,118 @@ let dbAdapter: PgAdapter | undefined;
 let publisher: PgQueuePublisher | undefined;
 let runner: PgQueueRunner | undefined;
 let realmsRootDir: string | undefined;
+
+/**
+ * The in-flight `startTestRealmServer` boot, from its first line until it
+ * either publishes its results into the module state above or throws.
+ *
+ * Every integration file boots its fixture on the same fixed port, and the
+ * whole suite shares one process (`--poolOptions.forks.singleFork`), so the
+ * fixture's teardown has to be able to clean up a boot that its own caller
+ * has stopped waiting for. vitest enforces a hook budget by rejecting the
+ * hook's promise; it cannot cancel the work the hook started, so a `beforeAll`
+ * that overruns leaves the boot running and hands control to `afterAll`
+ * immediately — the boot then binds the fixture port with nothing left holding
+ * a reference to the server. `stopTestRealmServer` awaits this handle first
+ * (see `settleBoot`), which is what keeps one overrun boot from turning into
+ * `EADDRINUSE` in every file that follows.
+ */
+let pendingBoot: Promise<unknown> | undefined;
+
+/**
+ * Wall-clock cost of each phase of the fixture the current file is standing
+ * up, in the order the phases run: the server boot first, then whatever
+ * profile setup the file asks for. A phase with no entry had not been
+ * reached, which is what makes this readable for a hook that overran its
+ * budget — the phase that never landed is the one that was still running.
+ */
+let fixturePhases: [string, number][] = [];
+
+async function timePhase<T>(
+  name: string,
+  fn: () => Promise<T> | T,
+): Promise<T> {
+  let start = Date.now();
+  try {
+    return await fn();
+  } finally {
+    fixturePhases.push([name, Date.now() - start]);
+  }
+}
+
+function formatFixturePhases(): string {
+  if (fixturePhases.length === 0) {
+    return '(no fixture recorded)';
+  }
+  return `${fixturePhases
+    .map(([name, ms]) => `${name}=${ms}ms`)
+    .join(' ')} total=${fixtureTotalMs()}ms`;
+}
+
+function fixtureTotalMs(): number {
+  return fixturePhases.reduce((sum, [, ms]) => sum + ms, 0);
+}
+
+/**
+ * Wait for the in-flight boot to publish its results (or fail) so teardown
+ * sees everything it created. A boot that outlives this window is reported by
+ * `startTestRealmServer`'s own pre-flight check in the next file rather than
+ * hanging teardown here.
+ */
+const BOOT_SETTLE_TIMEOUT_MS = 60_000;
+
+/**
+ * True when something is accepting connections at `host:port`. Used to tell a
+ * leaked fixture server apart from a clean start, so the leak is reported at
+ * the boot that trips over it.
+ */
+function isPortListening(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let socket = new net.Socket();
+    let settle = (listening: boolean) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(listening);
+    };
+    socket.setTimeout(1000);
+    socket.once('connect', () => settle(true));
+    socket.once('timeout', () => settle(false));
+    socket.once('error', () => settle(false));
+    socket.connect(port, host);
+  });
+}
+
+async function settleBoot(): Promise<void> {
+  let boot = pendingBoot;
+  if (!boot) {
+    return;
+  }
+  pendingBoot = undefined;
+  // Teardown reached a boot that is still running, so the hook that started it
+  // never got its result — it overran its budget or its file failed around it.
+  // The phase list names how far the boot got, which is the one thing the
+  // hook's own `Hook timed out` report cannot say.
+  console.log(
+    `[boxel-cli fixture] teardown is waiting on a boot that is still in ` +
+      `flight; phases so far: ${formatFixturePhases()}`,
+  );
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      // A rejected boot has already been reported to the hook that started
+      // it; teardown only needs to know the boot is no longer writing to the
+      // module state it is about to tear down.
+      boot.catch(() => {}),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, BOOT_SETTLE_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
 
 export interface RealmConfig {
   realmURL: URL;
@@ -106,9 +221,71 @@ export async function startTestRealmServer(
       'startTestRealmServer: pass either `realms` or `fileSystem`, not both',
     );
   }
+  fixturePhases = [];
+  slowFixtureReported = false;
+  // The handle is published before the first `await`, so a caller that stops
+  // waiting the instant it calls this still leaves teardown something to find.
+  // Nothing here may be awaited ahead of the assignment — the port check runs
+  // inside the boot for that reason.
+  let boot = (async () => {
+    await assertFixturePortFree();
+    return await bootTestRealmServer(options);
+  })();
+  pendingBoot = boot;
+  try {
+    return await boot;
+  } finally {
+    // The caller has the boot's outcome, so teardown no longer needs to wait
+    // for it. Only a boot whose caller never got here leaves this set.
+    if (pendingBoot === boot) {
+      pendingBoot = undefined;
+      reportSlowFixture();
+    }
+  }
+}
 
+/**
+ * A fixture that stands up at its usual cost — around a second, most of it the
+ * server boot — is silent. One an order of magnitude above that prints its
+ * phase breakdown, well before the hook budget is in danger, because a suite
+ * whose fixtures have drifted toward the limit is what turns runner load into
+ * hook timeouts. The breakdown says which phase to go after.
+ */
+const SLOW_FIXTURE_THRESHOLD_MS = 10_000;
+let slowFixtureReported = false;
+
+function reportSlowFixture(): void {
+  if (slowFixtureReported || fixtureTotalMs() < SLOW_FIXTURE_THRESHOLD_MS) {
+    return;
+  }
+  slowFixtureReported = true;
+  console.log(`[boxel-cli fixture] slow setup: ${formatFixturePhases()}`);
+}
+
+/**
+ * Fail before booting when the fixture port is still held, and name the boot
+ * that is holding it. Without this a contaminated run reports a bare `listen
+ * EADDRINUSE`, which names neither the phase the leaked boot was in nor the
+ * fact that the boot is what is holding the port.
+ */
+async function assertFixturePortFree(): Promise<void> {
+  if (
+    !(await isPortListening(TEST_REALM_SERVER_HOST, TEST_REALM_SERVER_PORT))
+  ) {
+    return;
+  }
+  throw new Error(
+    `fixture port ${TEST_REALM_SERVER_URL} is still held when starting a new ` +
+      `test realm server. A prior boot outlived its teardown; its phase ` +
+      `timings were: ${formatFixturePhases()}`,
+  );
+}
+
+async function bootTestRealmServer(
+  options: StartTestRealmServerOptions,
+): Promise<{ realms: Realm[]; testRealmHttpServer: Server }> {
   prepareTestDB();
-  dbAdapter = await createTestPgAdapter();
+  dbAdapter = await timePhase('clone-test-db', () => createTestPgAdapter());
   publisher = new PgQueuePublisher(dbAdapter);
   // Test-only hardening for a leak in runtime-common's enqueueReindexRealmJob:
   // server.createRealm, handle-publish-realm, and full-reindex discard the Job
@@ -148,22 +325,24 @@ export async function startTestRealmServer(
     },
   ];
 
-  let result = await runTestRealmServerWithRealms({
-    realmsRootPath: path.join(realmsRootDir, 'realm_server_1'),
-    realms,
-    virtualNetwork,
-    publisher,
-    runner,
-    dbAdapter,
-    matrixURL,
-    prerenderer: options.prerenderer ?? noopPrerenderer,
-  });
+  let result = await timePhase('boot-realm-server', () =>
+    runTestRealmServerWithRealms({
+      realmsRootPath: path.join(realmsRootDir!, 'realm_server_1'),
+      realms,
+      virtualNetwork,
+      publisher: publisher!,
+      runner: runner!,
+      dbAdapter: dbAdapter!,
+      matrixURL,
+      prerenderer: options.prerenderer ?? noopPrerenderer,
+    }),
+  );
 
   testRealmHttpServer = result.testRealmHttpServer;
   activeRealms = result.realms;
 
   if (options.registerMatrixUser !== false) {
-    await registerCliTestUser();
+    await timePhase('register-matrix-user', () => registerCliTestUser());
   }
 
   return {
@@ -183,6 +362,12 @@ export function getTestDbAdapter(): PgAdapter | undefined {
 }
 
 export async function stopTestRealmServer(): Promise<void> {
+  // A boot whose caller stopped waiting for it is still going to publish a
+  // listening server into the module state below, so teardown waits for it
+  // rather than racing it. Everything after this point tears down the full
+  // set of resources the boot created, whether or not the hook that asked
+  // for them ever saw them.
+  await settleBoot();
   for (let realm of activeRealms) {
     realm.unsubscribe();
   }
@@ -261,19 +446,31 @@ export function reloadProfile(home: string): ProfileManager {
 }
 
 /**
- * Register the cli-test user in Synapse. Re-registering an existing user
- * produces a benign 4xx that callers can ignore. Most tests get this via
- * `startTestRealmServer` (default `registerMatrixUser: true`); tests that
- * opt out and use JWT injection don't need it.
+ * Register the cli-test user in Synapse, idempotently: the account already
+ * existing is the expected outcome for a second call, which is what a file
+ * that boots the fixture more than once produces (the username is per-process,
+ * and Synapse keeps the account for the life of the container). Most tests get
+ * this via `startTestRealmServer` (default `registerMatrixUser: true`); tests
+ * that opt out and use JWT injection don't need it.
  */
 export async function registerCliTestUser(): Promise<void> {
-  await registerUser({
-    matrixURL,
-    displayname: 'CLI Test User',
-    username: TEST_USERNAME,
-    password: TEST_PASSWORD,
-    registrationSecret: matrixRegistrationSecret,
-  });
+  try {
+    await registerUser({
+      matrixURL,
+      displayname: 'CLI Test User',
+      username: TEST_USERNAME,
+      password: TEST_PASSWORD,
+      registrationSecret: matrixRegistrationSecret,
+    });
+  } catch (err) {
+    // Synapse's admin-register endpoint reports a taken user id with
+    // `M_USER_IN_USE`, which `registerUser` surfaces as a thrown error
+    // carrying the response body. The account we want exists with the
+    // password we want; anything else is a real failure.
+    if (!String(err).includes('M_USER_IN_USE')) {
+      throw err;
+    }
+  }
 }
 
 /**
@@ -286,13 +483,19 @@ export async function setupTestProfile(
   realmServerUrl: string = `${TEST_REALM_SERVER_URL}/`,
 ): Promise<string> {
   let matrixId = `@${TEST_USERNAME}:localhost`;
-  await pm.addProfile(
-    matrixId,
-    TEST_PASSWORD,
-    'CLI Test User',
-    matrixURL.href,
-    realmServerUrl,
+  // Synapse hashes the password on every login, so this is a real cost in the
+  // setup hook rather than a local write — it belongs in the phase list beside
+  // the server boot.
+  await timePhase('matrix-login', () =>
+    pm.addProfile(
+      matrixId,
+      TEST_PASSWORD,
+      'CLI Test User',
+      matrixURL.href,
+      realmServerUrl,
+    ),
   );
+  reportSlowFixture();
   return matrixId;
 }
 

--- a/packages/boxel-cli/tests/helpers/integration.ts
+++ b/packages/boxel-cli/tests/helpers/integration.ts
@@ -48,8 +48,8 @@ const noopPrerenderer: Prerenderer = {
 };
 
 export const TEST_REALM_SERVER_URL = 'http://127.0.0.1:4446';
-const TEST_REALM_SERVER_HOST = '127.0.0.1';
-const TEST_REALM_SERVER_PORT = 4446;
+const TEST_REALM_SERVER_HOST = new URL(TEST_REALM_SERVER_URL).hostname;
+const TEST_REALM_SERVER_PORT = Number(new URL(TEST_REALM_SERVER_URL).port);
 
 export const TEST_USERNAME = `cli-test-${Date.now()}`;
 export const TEST_PASSWORD = 'test-password-for-cli';

--- a/packages/boxel-cli/tests/helpers/run-boxel.ts
+++ b/packages/boxel-cli/tests/helpers/run-boxel.ts
@@ -60,7 +60,11 @@ export interface RunBoxelOptions {
   env?: NodeJS.ProcessEnv;
   /** Text piped to the command's stdin. */
   input?: string;
-  /** Kill the command after this many ms (default 60s). */
+  /**
+   * Kill the command after this many ms (default 60s, and never less than a
+   * margin above a deadline the command was given on its own argv — see
+   * `resolveDeadline`).
+   */
   timeout?: number;
 }
 
@@ -71,12 +75,83 @@ export interface BoxelResult {
   /** True when the command exited 0. */
   ok: boolean;
   /**
+   * True when the harness's deadline killed the command rather than the
+   * command exiting on its own. Distinguishes "the CLI reported a failure"
+   * from "the CLI never finished", which the exit code alone cannot: a
+   * signalled process reports a null code, which is only visible as
+   * `ok === false`.
+   */
+  timedOut: boolean;
+  /**
    * Parse stdout as JSON (for commands run with `--json`). Throws with
    * the captured stdout/stderr attached when stdout isn't valid JSON, so
    * a failing command surfaces its error instead of an opaque parse
    * throw.
    */
   json<T = unknown>(): T;
+}
+
+/**
+ * The deadline a command was given on its own argv, in ms, or undefined when
+ * it was given none. Commands that poll (`realm publish`, `realm
+ * wait-for-ready`) take `--timeout <ms>` and report a precise diagnostic of
+ * their own when it elapses.
+ */
+function commandOwnDeadlineMs(args: string[]): number | undefined {
+  for (let i = 0; i < args.length; i++) {
+    let value =
+      args[i] === '--timeout'
+        ? args[i + 1]
+        : args[i].startsWith('--timeout=')
+          ? args[i].slice('--timeout='.length)
+          : undefined;
+    if (value === undefined) {
+      continue;
+    }
+    let ms = Number(value);
+    if (Number.isFinite(ms) && ms >= 0) {
+      return ms;
+    }
+  }
+  return undefined;
+}
+
+const DEFAULT_DEADLINE_MS = 60_000;
+/**
+ * How far the harness's deadline must sit above the command's own. Only needs
+ * to cover the command noticing its deadline, printing its diagnostic, and
+ * exiting — a fraction of the deadline it is protecting.
+ */
+const DEADLINE_MARGIN_MS = 30_000;
+
+/**
+ * The harness deadline exists to stop a *wedged* command from hanging its
+ * test, so it must never be the thing that pre-empts a command's own
+ * deadline. A command killed at the same instant it was about to report
+ * "timed out after Nms waiting for …" dies with that reason unwritten, and
+ * the test is left asserting on an exit code with nothing to explain it.
+ */
+function resolveDeadline(
+  args: string[],
+  requested: number | undefined,
+): number {
+  let ownDeadline = commandOwnDeadlineMs(args);
+  if (ownDeadline === undefined) {
+    return requested ?? DEFAULT_DEADLINE_MS;
+  }
+  let floor = ownDeadline + DEADLINE_MARGIN_MS;
+  if (requested === undefined) {
+    return Math.max(DEFAULT_DEADLINE_MS, floor);
+  }
+  if (requested < floor) {
+    throw new Error(
+      `runBoxel timeout of ${requested}ms cannot enforce a command that was ` +
+        `given --timeout ${ownDeadline}: the kill would race the command's ` +
+        `own deadline and discard its diagnostic. Use at least ${floor}ms, ` +
+        `or lower the command's --timeout.`,
+    );
+  }
+  return requested;
 }
 
 /**
@@ -102,13 +177,27 @@ export function runBoxel(
     ...options.env,
   };
 
+  let commandLine = [...baseArgs, ...args].join(' ');
+
   return new Promise<BoxelResult>((resolvePromise, reject) => {
+    // Inside the executor so a misconfigured deadline rejects the returned
+    // promise, the way every other failure from this helper does.
+    let deadlineMs = resolveDeadline(args, options.timeout);
+    let startedAt = Date.now();
     let child = spawn(command, [...baseArgs, ...args], {
       cwd: options.cwd,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: options.timeout ?? 60_000,
     });
+
+    // Enforce the deadline here rather than through spawn's own `timeout`, so
+    // the result can say the command was killed. spawn's kill leaves only a
+    // null exit code behind, which reads as an ordinary failure.
+    let timedOut = false;
+    let deadline = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, deadlineMs);
 
     let stdout = '';
     let stderr = '';
@@ -123,13 +212,27 @@ export function runBoxel(
     child.stdout.on('data', (chunk) => (stdout += chunk));
     child.stderr.on('data', (chunk) => (stderr += chunk));
 
-    child.on('error', reject);
+    child.on('error', (err) => {
+      clearTimeout(deadline);
+      reject(err);
+    });
     child.on('close', (code) => {
+      clearTimeout(deadline);
+      // Nearly every call site asserts with `expect(res.ok, res.stderr)`, so
+      // stderr is where a reader looks for the reason. A killed command has
+      // written no reason of its own — say so there, with what it had printed
+      // before the kill left in place above it.
+      let reportedStderr = timedOut
+        ? `${stderr}\n[runBoxel] killed after ${
+            Date.now() - startedAt
+          }ms (deadline ${deadlineMs}ms): ${commandLine}\n`
+        : stderr;
       resolvePromise({
         stdout,
-        stderr,
+        stderr: reportedStderr,
         exitCode: code,
         ok: code === 0,
+        timedOut,
         json<T = unknown>(): T {
           try {
             return JSON.parse(stdout) as T;
@@ -137,7 +240,7 @@ export function runBoxel(
             throw new Error(
               `Expected JSON on stdout but parse failed (${
                 err instanceof Error ? err.message : String(err)
-              }).\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+              }).\n--- stdout ---\n${stdout}\n--- stderr ---\n${reportedStderr}`,
             );
           }
         },

--- a/packages/boxel-cli/tests/helpers/run-boxel.ts
+++ b/packages/boxel-cli/tests/helpers/run-boxel.ts
@@ -116,7 +116,13 @@ function commandOwnDeadlineMs(args: string[]): number | undefined {
   return undefined;
 }
 
-const DEFAULT_DEADLINE_MS = 60_000;
+/**
+ * How long a command gets before the harness kills it, absent anything more
+ * specific. Exported because `vitest.config.mjs` has to keep its own budgets
+ * above this one — see the ladder described there, and
+ * `tests/lib/deadline-ladder.test.ts`.
+ */
+export const RUN_BOXEL_DEFAULT_DEADLINE_MS = 60_000;
 /**
  * How far the harness's deadline must sit above the command's own. Only needs
  * to cover the command noticing its deadline, printing its diagnostic, and
@@ -137,11 +143,11 @@ function resolveDeadline(
 ): number {
   let ownDeadline = commandOwnDeadlineMs(args);
   if (ownDeadline === undefined) {
-    return requested ?? DEFAULT_DEADLINE_MS;
+    return requested ?? RUN_BOXEL_DEFAULT_DEADLINE_MS;
   }
   let floor = ownDeadline + DEADLINE_MARGIN_MS;
   if (requested === undefined) {
-    return Math.max(DEFAULT_DEADLINE_MS, floor);
+    return Math.max(RUN_BOXEL_DEFAULT_DEADLINE_MS, floor);
   }
   if (requested < floor) {
     throw new Error(

--- a/packages/boxel-cli/tests/helpers/run-boxel.ts
+++ b/packages/boxel-cli/tests/helpers/run-boxel.ts
@@ -225,10 +225,14 @@ export function runBoxel(
       env,
       stdio: ['pipe', 'pipe', 'pipe'],
       // Leads its own process group, so the deadline can signal the command
-      // and everything it started. Several commands spawn long-lived children
-      // that inherit their stdio — `boxel parse` runs ember-tsc, `boxel test`
-      // launches chromium — and signalling only the command leaves those
-      // running, holding the pipes it was writing to, into the next test.
+      // and everything it started rather than the command alone. Commands here
+      // do spawn their own children — `boxel parse` runs ember-tsc, several
+      // shell out to git — and a child that outlives a killed parent runs on
+      // into the next test in this process, which the suite shares.
+      //
+      // It reaches an ordinary child, not every possible descendant: one that
+      // makes itself a group leader (as playwright does for the browser it
+      // launches) leaves this group and is unaffected.
       detached: true,
     });
 
@@ -335,13 +339,16 @@ export function runBoxel(
       reject(err);
     });
     // `close` is the normal end: it waits for the stdio pipes, so all output
-    // is captured.
+    // is captured before the result is built.
     child.on('close', (code) => settle(code));
-    // Those same pipes stay open while a grandchild that inherited them is
-    // alive — `boxel parse` runs ember-tsc, `boxel test` launches chromium —
-    // so on the deadline path the command's own exit is the answer, and
-    // waiting for `close` would hand the deadline back to whatever outlived
-    // it.
+    // On the deadline path the command's own exit is the answer instead.
+    // `close` waits for the pipes, and a descendant holding an inherited
+    // write end keeps them open after the command is gone — which would let
+    // whatever outlived the command decide when the deadline takes effect. No
+    // command in this suite is known to leave one (the group kill above
+    // reaches the ordinary case), so this is a backstop rather than a path
+    // anything here exercises; the cost of being wrong the other way is a
+    // deadline that never fires.
     child.on('exit', (code) => {
       if (timedOut) {
         settle(code);

--- a/packages/boxel-cli/tests/helpers/run-boxel.ts
+++ b/packages/boxel-cli/tests/helpers/run-boxel.ts
@@ -129,6 +129,12 @@ export const RUN_BOXEL_DEFAULT_DEADLINE_MS = 60_000;
  * exiting — a fraction of the deadline it is protecting.
  */
 const DEADLINE_MARGIN_MS = 30_000;
+/**
+ * Grace between the deadline's SIGTERM and a SIGKILL. Long enough for a
+ * command that shuts down on a signal to do it, short enough that the
+ * deadline still ends the command well inside the enclosing test's budget.
+ */
+const KILL_ESCALATION_MS = 5_000;
 
 /**
  * The harness deadline exists to stop a *wedged* command from hanging its
@@ -200,9 +206,13 @@ export function runBoxel(
     // the result can say the command was killed. spawn's kill leaves only a
     // null exit code behind, which reads as an ordinary failure.
     let timedOut = false;
+    let escalation: NodeJS.Timeout | undefined;
     let deadline = setTimeout(() => {
       timedOut = true;
       child.kill('SIGTERM');
+      // A command that handles SIGTERM, or is stuck somewhere that cannot run
+      // a handler, would otherwise outlive the deadline meant to end it.
+      escalation = setTimeout(() => child.kill('SIGKILL'), KILL_ESCALATION_MS);
     }, deadlineMs);
 
     let stdout = '';
@@ -218,12 +228,20 @@ export function runBoxel(
     child.stdout.on('data', (chunk) => (stdout += chunk));
     child.stderr.on('data', (chunk) => (stderr += chunk));
 
-    child.on('error', (err) => {
+    let settled = false;
+    let clearTimers = () => {
       clearTimeout(deadline);
-      reject(err);
-    });
-    child.on('close', (code) => {
-      clearTimeout(deadline);
+      if (escalation) {
+        clearTimeout(escalation);
+      }
+    };
+
+    let settle = (code: number | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
       // Nearly every call site asserts with `expect(res.ok, res.stderr)`, so
       // stderr is where a reader looks for the reason. A killed command has
       // written no reason of its own — say so there, with what it had printed
@@ -251,6 +269,28 @@ export function runBoxel(
           }
         },
       });
+    };
+
+    child.on('error', (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
+      reject(err);
+    });
+    // `close` is the normal end: it waits for the stdio pipes, so all output
+    // is captured.
+    child.on('close', (code) => settle(code));
+    // Those same pipes stay open while a grandchild that inherited them is
+    // alive — `boxel parse` runs ember-tsc, `boxel test` launches chromium —
+    // so on the deadline path the command's own exit is the answer, and
+    // waiting for `close` would hand the deadline back to whatever outlived
+    // it.
+    child.on('exit', (code) => {
+      if (timedOut) {
+        settle(code);
+      }
     });
 
     if (options.input !== undefined) {

--- a/packages/boxel-cli/tests/helpers/run-boxel.ts
+++ b/packages/boxel-cli/tests/helpers/run-boxel.ts
@@ -61,9 +61,13 @@ export interface RunBoxelOptions {
   /** Text piped to the command's stdin. */
   input?: string;
   /**
-   * Kill the command after this many ms (default 60s, and never less than a
-   * margin above a deadline the command was given on its own argv — see
-   * `resolveDeadline`).
+   * Kill the command after this many ms, instead of
+   * `RUN_BOXEL_DEFAULT_DEADLINE_MS`. Must clear a deadline the command was
+   * given on its own argv by a margin (see `resolveDeadline`), and the
+   * enclosing test or hook budget has to clear this — which the helper cannot
+   * check, since vitest does not expose the budget it is running under. A
+   * value above the default belongs at a call site that raises that budget in
+   * the same place.
    */
   timeout?: number;
 }
@@ -117,9 +121,13 @@ function commandOwnDeadlineMs(args: string[]): number | undefined {
 }
 
 /**
- * How long a command gets before the harness kills it, absent anything more
- * specific. Exported because `vitest.config.mjs` has to keep its own budgets
- * above this one — see the ladder described there, and
+ * The longest this helper will wait on a command without being told to.
+ *
+ * It is a ceiling, not just a default: `vitest.config.mjs` keeps its budgets
+ * above this number, and that only means anything if the helper cannot derive
+ * a longer deadline on its own. A command whose own `--timeout` needs more has
+ * to say so through `options.timeout`, at a call site that can also raise the
+ * budget around it — see `resolveDeadline` and
  * `tests/lib/deadline-ladder.test.ts`.
  */
 export const RUN_BOXEL_DEFAULT_DEADLINE_MS = 60_000;
@@ -153,7 +161,23 @@ function resolveDeadline(
   }
   let floor = ownDeadline + DEADLINE_MARGIN_MS;
   if (requested === undefined) {
-    return Math.max(RUN_BOXEL_DEFAULT_DEADLINE_MS, floor);
+    if (floor > RUN_BOXEL_DEFAULT_DEADLINE_MS) {
+      // Deriving the deadline from argv alone would put it above anything the
+      // config can guarantee to sit under, and the budget that then fires
+      // first is vitest's — which abandons the command instead of ending it,
+      // the failure this ladder exists to prevent. Only a call site can settle
+      // it, because only a call site can also raise the budget around itself.
+      throw new Error(
+        `a command given --timeout ${ownDeadline} needs a runBoxel deadline ` +
+          `of ${floor}ms, past the ${RUN_BOXEL_DEFAULT_DEADLINE_MS}ms this ` +
+          `helper takes on its own. Pass \`timeout: ${floor}\` and give the ` +
+          `enclosing test or hook a budget above it, or lower the command's ` +
+          `--timeout to ${
+            RUN_BOXEL_DEFAULT_DEADLINE_MS - DEADLINE_MARGIN_MS
+          } or less.`,
+      );
+    }
+    return RUN_BOXEL_DEFAULT_DEADLINE_MS;
   }
   if (requested < floor) {
     throw new Error(
@@ -200,7 +224,31 @@ export function runBoxel(
       cwd: options.cwd,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],
+      // Leads its own process group, so the deadline can signal the command
+      // and everything it started. Several commands spawn long-lived children
+      // that inherit their stdio — `boxel parse` runs ember-tsc, `boxel test`
+      // launches chromium — and signalling only the command leaves those
+      // running, holding the pipes it was writing to, into the next test.
+      detached: true,
     });
+
+    // Signal the whole group. Falls back to the command alone if the group is
+    // unavailable (already reaped, or a platform without process groups).
+    let killTree = (signal: NodeJS.Signals) => {
+      try {
+        if (child.pid !== undefined) {
+          process.kill(-child.pid, signal);
+          return;
+        }
+      } catch {
+        // Fall through to the direct kill.
+      }
+      try {
+        child.kill(signal);
+      } catch {
+        // Already gone.
+      }
+    };
 
     // Enforce the deadline here rather than through spawn's own `timeout`, so
     // the result can say the command was killed. spawn's kill leaves only a
@@ -209,10 +257,10 @@ export function runBoxel(
     let escalation: NodeJS.Timeout | undefined;
     let deadline = setTimeout(() => {
       timedOut = true;
-      child.kill('SIGTERM');
+      killTree('SIGTERM');
       // A command that handles SIGTERM, or is stuck somewhere that cannot run
       // a handler, would otherwise outlive the deadline meant to end it.
-      escalation = setTimeout(() => child.kill('SIGKILL'), KILL_ESCALATION_MS);
+      escalation = setTimeout(() => killTree('SIGKILL'), KILL_ESCALATION_MS);
     }, deadlineMs);
 
     let stdout = '';
@@ -241,6 +289,13 @@ export function runBoxel(
         return;
       }
       settled = true;
+      if (timedOut) {
+        // Nothing waits on the group past this point, so nothing in it may
+        // survive: sweep it before the escalation timer is cleared. The
+        // command itself is already gone — this reaches whatever it left
+        // behind holding its stdio.
+        killTree('SIGKILL');
+      }
       clearTimers();
       // Nearly every call site asserts with `expect(res.ok, res.stderr)`, so
       // stderr is where a reader looks for the reason. A killed command has

--- a/packages/boxel-cli/tests/integration/fixture-teardown.test.ts
+++ b/packages/boxel-cli/tests/integration/fixture-teardown.test.ts
@@ -1,7 +1,7 @@
 import '../helpers/setup-realm-server.ts';
 import { describe, it, expect, afterAll } from 'vitest';
-import * as net from 'net';
 import {
+  isPortListening,
   startTestRealmServer,
   stopTestRealmServer,
   TEST_REALM_SERVER_URL,
@@ -30,19 +30,7 @@ const CARD_JSON = JSON.stringify({
 
 function isFixturePortListening(): Promise<boolean> {
   let { hostname, port } = new URL(TEST_REALM_SERVER_URL);
-  return new Promise((resolve) => {
-    let socket = new net.Socket();
-    let settle = (listening: boolean) => {
-      socket.removeAllListeners();
-      socket.destroy();
-      resolve(listening);
-    };
-    socket.setTimeout(1000);
-    socket.once('connect', () => settle(true));
-    socket.once('timeout', () => settle(false));
-    socket.once('error', () => settle(false));
-    socket.connect(Number(port), hostname);
-  });
+  return isPortListening(hostname, Number(port));
 }
 
 afterAll(async () => {
@@ -70,5 +58,9 @@ describe('fixture teardown (integration)', () => {
 
     await stopTestRealmServer();
     expect(await isFixturePortListening()).toBe(false);
-  });
+    // Two full fixture boots, where every other file does one — and in a test
+    // rather than a hook, so it takes `testTimeout` rather than the larger
+    // hook budget. Stated explicitly because this is the file most exposed to
+    // the boot cost drifting.
+  }, 150_000);
 });

--- a/packages/boxel-cli/tests/integration/fixture-teardown.test.ts
+++ b/packages/boxel-cli/tests/integration/fixture-teardown.test.ts
@@ -1,0 +1,74 @@
+import '../helpers/setup-realm-server.ts';
+import { describe, it, expect, afterAll } from 'vitest';
+import * as net from 'net';
+import {
+  startTestRealmServer,
+  stopTestRealmServer,
+  TEST_REALM_SERVER_URL,
+} from '../helpers/integration.ts';
+
+// Every integration file boots its fixture on the same fixed port, and the
+// whole suite shares one process, so a fixture that outlives the file that
+// asked for it takes every later file down with `EADDRINUSE`. The case that
+// produces one is a setup hook that overruns its budget: vitest rejects the
+// hook's promise but cannot cancel the boot the hook started, so the boot
+// keeps running — and binds the port — with nobody waiting on it.
+//
+// This drives that state directly rather than through a real hook timeout:
+// start a boot, drop the promise, tear down the way the file's `afterAll`
+// would, and then boot again the way the next file would.
+
+const CARD_JSON = JSON.stringify({
+  data: {
+    type: 'card',
+    attributes: { title: 'Teardown Probe' },
+    meta: {
+      adoptsFrom: { module: '@cardstack/base/card-api', name: 'CardDef' },
+    },
+  },
+});
+
+function isFixturePortListening(): Promise<boolean> {
+  let { hostname, port } = new URL(TEST_REALM_SERVER_URL);
+  return new Promise((resolve) => {
+    let socket = new net.Socket();
+    let settle = (listening: boolean) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(listening);
+    };
+    socket.setTimeout(1000);
+    socket.once('connect', () => settle(true));
+    socket.once('timeout', () => settle(false));
+    socket.once('error', () => settle(false));
+    socket.connect(Number(port), hostname);
+  });
+}
+
+afterAll(async () => {
+  await stopTestRealmServer();
+});
+
+describe('fixture teardown (integration)', () => {
+  it('releases the fixture port when a boot outlives its caller', async () => {
+    let abandoned = startTestRealmServer({
+      fileSystem: { 'teardown-probe.json': CARD_JSON },
+    });
+    // The hook that started this boot is the one that would see its outcome;
+    // here nothing does, which is the point.
+    abandoned.catch(() => {});
+
+    await stopTestRealmServer();
+
+    // The next file's boot is what a leaked listener actually breaks, so that
+    // is the assertion — a bare port probe can sample the gap before an
+    // abandoned boot has reached its `listen`.
+    let { testRealmHttpServer } = await startTestRealmServer({
+      fileSystem: { 'teardown-probe.json': CARD_JSON },
+    });
+    expect(testRealmHttpServer.listening).toBe(true);
+
+    await stopTestRealmServer();
+    expect(await isFixturePortListening()).toBe(false);
+  });
+});

--- a/packages/boxel-cli/tests/integration/parse.test.ts
+++ b/packages/boxel-cli/tests/integration/parse.test.ts
@@ -27,6 +27,11 @@ const NOTHING_CHECKED = 'produced no TS diagnostics';
 async function parseFixture(name: string): Promise<ParseRealmResult> {
   let res = await runBoxel(['parse', '--json'], {
     cwd: resolve(FIXTURES_DIR, name),
+    // `parse` gives ember-tsc 120s of its own and reports when that elapses.
+    // That deadline is not on argv, so `runBoxel` cannot derive a budget above
+    // it — set here, under the 180s test budget below, so a type-check that
+    // overruns is ember-tsc's report rather than a bare kill.
+    timeout: 150_000,
   });
   return res.json<ParseRealmResult>();
 }

--- a/packages/boxel-cli/tests/integration/realm-ingest-card.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-ingest-card.test.ts
@@ -194,7 +194,9 @@ beforeAll(async () => {
       '--realm',
       realmHref,
     ],
-    { home, timeout: 600_000 },
+    // Under the hook's 600s budget, so a wedged ingest is killed and named by
+    // the harness rather than abandoned by the hook at the same instant.
+    { home, timeout: 540_000 },
   );
 }, 600_000);
 
@@ -259,7 +261,9 @@ describe('realm ingest-card (integration)', () => {
     } finally {
       fs.rmSync(rriDir, { recursive: true, force: true });
     }
-  }, 120_000);
+    // Clears the command's 120s so the kill, and the command line it names,
+    // is what a wedge reports.
+  }, 150_000);
 
   it('does not copy base-realm modules the card imports', () => {
     // The copied source still imports the base realm by absolute URL; no

--- a/packages/boxel-cli/tests/integration/realm-publish.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-publish.test.ts
@@ -90,7 +90,11 @@ describe('realm publish (integration)', () => {
         '60000',
         '--json',
       ],
-      { home },
+      // Both rungs above the command are set here, because the helper cannot
+      // see the test budget and so cannot check that the ladder holds: 60s for
+      // the command to report which readiness stage it was waiting on, 90s
+      // before the harness kills it, and the test budget below clears that.
+      { home, timeout: 90_000 },
     );
     expect(res.ok, res.stderr).toBe(true);
     let result = res.json<PublishResultJson>();
@@ -104,11 +108,9 @@ describe('realm publish (integration)', () => {
     // must surface that value rather than failing the call — earlier
     // boxel-home CI broke when callers required 200/201 and got a 202.
     expect(result.status).toBe('pending');
-    // Three nested deadlines, and only the innermost one has anything useful
-    // to say when it fires: `--timeout 60000` makes the command report which
-    // readiness stage it was still waiting on. `runBoxel` gives it 30s of
-    // margin over that (see `resolveDeadline`), and this budget clears the
-    // sum, so the command's own report is what the failure carries.
+    // The outermost of the three deadlines set on this test, clearing the 90s
+    // harness deadline above so the command's own report — not vitest
+    // abandoning it — is what a readiness failure carries.
   }, 150_000);
 
   it('returns without waiting when waitForReady is false', async () => {

--- a/packages/boxel-cli/tests/integration/realm-publish.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-publish.test.ts
@@ -98,7 +98,12 @@ describe('realm publish (integration)', () => {
     // must surface that value rather than failing the call — earlier
     // boxel-home CI broke when callers required 200/201 and got a 202.
     expect(result.status).toBe('pending');
-  }, 90_000);
+    // Three nested deadlines, and only the innermost one has anything useful
+    // to say when it fires: `--timeout 60000` makes the command report which
+    // readiness stage it was still waiting on. `runBoxel` gives it 30s of
+    // margin over that (see `resolveDeadline`), and this budget clears the
+    // sum, so the command's own report is what the failure carries.
+  }, 150_000);
 
   it('returns without waiting when waitForReady is false', async () => {
     let sourceUrl = await createSourceRealm();

--- a/packages/boxel-cli/tests/integration/realm-publish.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-publish.test.ts
@@ -61,9 +61,15 @@ async function createSourceRealm(): Promise<string> {
 function uniquePublishedUrl(): string {
   // Realm server enforces `domainsForPublishedRealms` (typically
   // `['localhost']` in tests) — use a *.localhost subdomain so the URL
-  // passes the publish-handler's allow-list. The hostname resolves to
-  // 127.0.0.1 via RFC 6761, and the realm-server listens on the same
-  // port for any host, so fetch() reaches it.
+  // passes the publish-handler's allow-list. The realm-server listens on the
+  // same port for any host, so fetch() reaches it once the name resolves.
+  //
+  // Resolving it is an environment requirement, not something RFC 6761
+  // guarantees: the readiness poll runs through the OS resolver, and a
+  // subdomain of `localhost` only answers where the resolver synthesizes one
+  // (systemd-resolved, macOS). On a host with plain `files dns` and only
+  // `127.0.0.1 localhost` in /etc/hosts, every poll fails to resolve and the
+  // wait below burns its full timeout.
   let port = new URL(TEST_REALM_SERVER_URL).port;
   return `http://published-${uniqueRealmName()}.localhost:${port}/`;
 }
@@ -126,7 +132,7 @@ describe('realm publish (integration)', () => {
 
     expect(result.publishedRealmURL).toBe(publishedUrl);
     expect(result.status).toBe('pending');
-  }, 60_000);
+  });
 
   it('republishes by unpublishing first when the target URL already exists', async () => {
     let sourceUrl = await createSourceRealm();
@@ -157,7 +163,7 @@ describe('realm publish (integration)', () => {
     let republished = res.json<PublishResultJson>();
 
     expect(republished.publishedRealmURL).toBe(publishedUrl);
-  }, 90_000);
+  });
 
   it('throws a useful error when the source realm does not exist', async () => {
     let bogusSource = `${TEST_REALM_SERVER_URL}/does-not-exist-${uniqueRealmName()}/`;
@@ -180,7 +186,7 @@ describe('realm publish (integration)', () => {
     );
     expect(res.exitCode).toBe(1);
     expect(res.stderr).toContain('Publish failed: HTTP');
-  }, 30_000);
+  });
 
   it('blocks publishing an unpublishable realm unless forced', async () => {
     // The noop prerenderer makes every indexed instance an error document, so
@@ -211,7 +217,7 @@ describe('realm publish (integration)', () => {
     expect(res.ok, res.stderr).toBe(true);
     let result = res.json<PublishResultJson>();
     expect(result.publishedRealmURL).toBe(publishedUrl);
-  }, 90_000);
+  });
 });
 
 describe('realm unpublish (integration)', () => {
@@ -233,7 +239,7 @@ describe('realm unpublish (integration)', () => {
 
     expect(result.unpublished).toBe(true);
     expect(result.error).toBeUndefined();
-  }, 60_000);
+  });
 
   it('treats a missing realm as success when tolerateMissing is set', async () => {
     let bogusUrl = `${TEST_REALM_SERVER_URL}/never-published-${uniqueRealmName()}/`;
@@ -248,7 +254,7 @@ describe('realm unpublish (integration)', () => {
     expect(result.unpublished).toBe(false);
     expect(result.notFound).toBe(true);
     expect(result.error).toBeUndefined();
-  }, 30_000);
+  });
 
   it('reports an error for a missing realm when tolerateMissing is unset', async () => {
     let bogusUrl = `${TEST_REALM_SERVER_URL}/never-published-${uniqueRealmName()}/`;
@@ -264,5 +270,5 @@ describe('realm unpublish (integration)', () => {
     expect(result.unpublished).toBe(false);
     expect(result.notFound).toBe(true);
     expect(result.error).toMatch(/not currently published/);
-  }, 30_000);
+  });
 });

--- a/packages/boxel-cli/tests/integration/realm-watch-stop.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-watch-stop.test.ts
@@ -86,7 +86,10 @@ function spawnFakeWatcher(opts: {
         reject(err);
       }
     });
-    child.on('exit', (code) => {
+    // `close` rather than `exit`: the reason this rejection reports is
+    // whatever the fixture wrote to stderr, and only `close` guarantees that
+    // stream has been drained.
+    child.on('close', (code) => {
       if (!resolved) {
         resolved = true;
         clearTimeout(timer);

--- a/packages/boxel-cli/tests/integration/realm-watch-stop.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-watch-stop.test.ts
@@ -53,14 +53,24 @@ function spawnFakeWatcher(opts: {
 
   return new Promise((resolve, reject) => {
     let resolved = false;
+    let buf = '';
+    // The fixture prints its own reason for dying on stderr. Collect it so a
+    // failure to start reports that reason rather than just an exit code.
+    let errBuf = '';
+    child.stderr?.on('data', (chunk) => (errBuf += chunk.toString()));
+
     const timer = setTimeout(() => {
       if (!resolved) {
         resolved = true;
-        reject(new Error('fake watcher did not signal ready in time'));
+        reject(
+          new Error(
+            `fake watcher did not signal ready in ${READY_TIMEOUT_MS}ms` +
+              `${errBuf ? `; it printed:\n${errBuf.trimEnd()}` : ''}`,
+          ),
+        );
       }
     }, READY_TIMEOUT_MS);
 
-    let buf = '';
     child.stdout?.on('data', (chunk) => {
       buf += chunk.toString();
       if (buf.includes('FAKE_WATCHER_READY') && !resolved) {
@@ -80,7 +90,13 @@ function spawnFakeWatcher(opts: {
       if (!resolved) {
         resolved = true;
         clearTimeout(timer);
-        reject(new Error(`fake watcher exited early with code ${code}`));
+        reject(
+          new Error(
+            `fake watcher exited early with code ${code}${
+              errBuf ? `:\n${errBuf.trimEnd()}` : ' and printed nothing'
+            }`,
+          ),
+        );
       }
     });
   });

--- a/packages/boxel-cli/tests/integration/realm-watch.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-watch.test.ts
@@ -33,6 +33,11 @@ let realmUrl: string;
 const localDirs: string[] = [];
 const REMOTE_REQUEST_TIMEOUT_MS = 30_000;
 const REMOTE_VISIBILITY_TIMEOUT_MS = 5_000;
+// A flush's last step is a `git commit` into a freshly initialized
+// `.boxel-history` repo — a subprocess doing real work, not a realm read, so
+// waiting for one gets its own budget. Generous on purpose: the assertion is
+// that a checkpoint appears, never that it appears quickly.
+const CHECKPOINT_TIMEOUT_MS = 30_000;
 const JWT_TEST_USER = '@cli-watch-test:localhost';
 
 function currentTestName(): string {
@@ -258,11 +263,15 @@ async function waitFor(
   predicate: () => boolean | Promise<boolean>,
   describeFailure: () => string,
   timeoutMs = REMOTE_VISIBILITY_TIMEOUT_MS,
+  // Cheap predicates (a file's existence, a handler count) can be sampled
+  // tightly. One that spawns subprocesses gets a coarser cadence, so the
+  // polling doesn't compete with the work it is waiting for.
+  pollIntervalMs = 25,
 ): Promise<void> {
   let deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await predicate()) return;
-    await sleep(25);
+    await sleep(pollIntervalMs);
   }
   throw new Error(
     `waitFor timed out after ${timeoutMs}ms: ${describeFailure()}`,
@@ -507,9 +516,26 @@ describe('realm watch (integration)', () => {
       signal: controller.signal,
     });
 
-    // Wait long enough for the initial tick + debounced flush + at least one
-    // re-poll, then trigger shutdown.
-    await sleep(400);
+    // Shut down once the loop has produced what the assertions below read,
+    // not after a fixed interval. The tail of a flush is a `git commit` into
+    // a freshly initialized `.boxel-history` repo, which is far and away the
+    // slowest step here and the one a busy runner stretches — aborting on a
+    // stopwatch cuts it off and leaves the pull with no checkpoint behind it.
+    let checkpointManager = new CheckpointManager(localDir);
+    await waitFor(
+      async () => (await checkpointManager.getCheckpoints()).length >= 1,
+      () =>
+        `watchRealms wrote no checkpoint for ${localDir}; local file is ` +
+        `${
+          fs.existsSync(path.join(localDir, watchFixture('loop')))
+            ? 'present'
+            : 'absent'
+        }`,
+      CHECKPOINT_TIMEOUT_MS,
+      // `getCheckpoints` shells out to git, so sample it at a cadence that
+      // leaves the commit room to finish.
+      200,
+    );
     controller.abort();
     let result = await runPromise;
 
@@ -519,7 +545,7 @@ describe('realm watch (integration)', () => {
       fs.readFileSync(path.join(localDir, watchFixture('loop')), 'utf8'),
     ).toContain('loop = 1');
 
-    let checkpoints = await new CheckpointManager(localDir).getCheckpoints();
+    let checkpoints = await checkpointManager.getCheckpoints();
     expect(checkpoints.length).toBeGreaterThanOrEqual(1);
     expect(checkpoints[0].source).toBe('remote');
   });

--- a/packages/boxel-cli/tests/integration/screenshot.test.ts
+++ b/packages/boxel-cli/tests/integration/screenshot.test.ts
@@ -97,7 +97,7 @@ beforeAll(async () => {
   home = testHome.home;
   cleanupProfile = testHome.cleanup;
   await setupTestProfile(testHome.profileManager);
-}, 60_000);
+});
 
 afterAll(async () => {
   cleanupProfile?.();

--- a/packages/boxel-cli/tests/lib/checkpoint-manager.test.ts
+++ b/packages/boxel-cli/tests/lib/checkpoint-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -44,6 +45,20 @@ describe('CheckpointManager', () => {
       let secondCheckpoints = await cm.getCheckpoints();
 
       expect(secondCheckpoints.length).toBe(firstCheckpoints.length);
+    });
+
+    it('reads no checkpoints from a repo whose HEAD is unborn', async () => {
+      // `init()` runs `git init` and then several more git commands before
+      // its bootstrap commit, so a reader can find `.git` in place with no
+      // commit behind it — the state a concurrent `realm watch` flush passes
+      // through. Reconstruct it directly, since the window is too short to
+      // catch reliably.
+      let gitDir = path.join(workspaceDir, '.boxel-history');
+      fs.mkdirSync(gitDir, { recursive: true });
+      execFileSync('git', ['init'], { cwd: gitDir, stdio: 'ignore' });
+
+      expect(await cm.isInitialized()).toBe(true);
+      expect(await cm.getCheckpoints()).toEqual([]);
     });
   });
 

--- a/packages/boxel-cli/tests/lib/checkpoint-manager.test.ts
+++ b/packages/boxel-cli/tests/lib/checkpoint-manager.test.ts
@@ -60,6 +60,19 @@ describe('CheckpointManager', () => {
       expect(await cm.isInitialized()).toBe(true);
       expect(await cm.getCheckpoints()).toEqual([]);
     });
+
+    it('surfaces a history repo git cannot read', async () => {
+      // An unreadable repository must not read as an empty history: the
+      // unborn-HEAD probe answers through git's exit code, and git uses a
+      // different one (128) for a fatal than for "that revision does not
+      // resolve" (1). A `.git` that is a file of garbage is the fatal case.
+      let gitDir = path.join(workspaceDir, '.boxel-history');
+      fs.mkdirSync(gitDir, { recursive: true });
+      fs.writeFileSync(path.join(gitDir, '.git'), 'not a gitfile\n', 'utf8');
+
+      expect(await cm.isInitialized()).toBe(true);
+      await expect(cm.getCheckpoints()).rejects.toThrow(/invalid gitfile/);
+    });
   });
 
   describe('detectCurrentChanges', () => {

--- a/packages/boxel-cli/tests/lib/deadline-ladder.test.ts
+++ b/packages/boxel-cli/tests/lib/deadline-ladder.test.ts
@@ -37,6 +37,6 @@ describe('deadline ladder', () => {
 
   it('gives a hook more time than a test', () => {
     // Hooks run commands too, and carry the fixture boot on top of them.
-    expect(budgets.hookTimeout).toBeGreaterThanOrEqual(budgets.testTimeout);
+    expect(budgets.hookTimeout).toBeGreaterThan(budgets.testTimeout);
   });
 });

--- a/packages/boxel-cli/tests/lib/deadline-ladder.test.ts
+++ b/packages/boxel-cli/tests/lib/deadline-ladder.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import vitestConfig from '../../vitest.config.mjs';
+import { RUN_BOXEL_DEFAULT_DEADLINE_MS } from '../helpers/run-boxel.ts';
+
+// `runBoxel`'s kill deadline is the only mechanism that can end a wedged CLI
+// subprocess *and report which command it was*. vitest's budgets have to sit
+// above it, or vitest abandons the subprocess first: the failure then reads
+// "Test timed out in Nms" with no command and no output, and the abandoned
+// command keeps running against the realm server the rest of the file is
+// using. Two numbers in two files, so assert the relationship rather than
+// trusting the comments to stay in step.
+
+const budgets = (
+  vitestConfig as unknown as {
+    test: { testTimeout: number; hookTimeout: number };
+  }
+).test;
+
+describe('deadline ladder', () => {
+  it('gives a test more time than runBoxel gives a command', () => {
+    expect(budgets.testTimeout).toBeGreaterThan(RUN_BOXEL_DEFAULT_DEADLINE_MS);
+  });
+
+  it('gives a hook more time than a test', () => {
+    // Hooks run commands too, and carry the fixture boot on top of them.
+    expect(budgets.hookTimeout).toBeGreaterThanOrEqual(budgets.testTimeout);
+  });
+});

--- a/packages/boxel-cli/tests/lib/deadline-ladder.test.ts
+++ b/packages/boxel-cli/tests/lib/deadline-ladder.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import vitestConfig from '../../vitest.config.mjs';
-import { RUN_BOXEL_DEFAULT_DEADLINE_MS } from '../helpers/run-boxel.ts';
+import {
+  RUN_BOXEL_DEFAULT_DEADLINE_MS,
+  runBoxel,
+} from '../helpers/run-boxel.ts';
 
 // `runBoxel`'s kill deadline is the only mechanism that can end a wedged CLI
 // subprocess *and report which command it was*. vitest's budgets have to sit
@@ -19,6 +22,17 @@ const budgets = (
 describe('deadline ladder', () => {
   it('gives a test more time than runBoxel gives a command', () => {
     expect(budgets.testTimeout).toBeGreaterThan(RUN_BOXEL_DEFAULT_DEADLINE_MS);
+  });
+
+  it('keeps runBoxel from deriving a deadline these budgets cannot cover', async () => {
+    // `RUN_BOXEL_DEFAULT_DEADLINE_MS` is the whole reason the assertion above
+    // means anything: were the helper free to derive a longer deadline from a
+    // command's own `--timeout`, a budget set here could still fire first and
+    // abandon the subprocess. A command that needs longer has to be given it
+    // explicitly, at a call site that raises its own budget to match.
+    await expect(
+      runBoxel(['realm', 'publish', '--timeout', '600000']),
+    ).rejects.toThrow(/past the .*ms this helper takes on its own/);
   });
 
   it('gives a hook more time than a test', () => {

--- a/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
+++ b/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { runBoxel } from '../helpers/run-boxel.ts';
+
+// `runBoxel`'s deadline is a backstop for a command that never finishes. These
+// cover the two ways it has to stay out of the way of the command it is
+// protecting: it must not fire early enough to pre-empt a deadline the command
+// was given on its own argv, and when it does fire it has to say so — a
+// killed process reports a null exit code, which is otherwise indistinguishable
+// from the command failing on its own.
+
+let scriptDir: string;
+let stubBin: string;
+let originalBin: string | undefined;
+
+// Stands in for the CLI. `--hang` idles past any deadline; otherwise it
+// prints on both streams and exits 0.
+const STUB_CLI = `
+if (process.argv.includes('--hang')) {
+  process.stderr.write('working…\\n');
+  setInterval(() => {}, 1 << 30);
+} else {
+  process.stdout.write('{"ok":true}');
+  process.stderr.write('a note\\n');
+}
+`;
+
+beforeAll(() => {
+  scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-cli-deadline-'));
+  stubBin = path.join(scriptDir, 'stub-cli.js');
+  fs.writeFileSync(stubBin, STUB_CLI, 'utf8');
+  originalBin = process.env.BOXEL_CLI_BIN;
+  process.env.BOXEL_CLI_BIN = stubBin;
+});
+
+afterAll(() => {
+  if (originalBin === undefined) {
+    delete process.env.BOXEL_CLI_BIN;
+  } else {
+    process.env.BOXEL_CLI_BIN = originalBin;
+  }
+  fs.rmSync(scriptDir, { recursive: true, force: true });
+});
+
+describe('runBoxel deadline', () => {
+  it('leaves a command that exits on its own untouched', async () => {
+    let res = await runBoxel(['whatever'], { timeout: 30_000 });
+    expect(res.timedOut).toBe(false);
+    expect(res.ok).toBe(true);
+    expect(res.stdout).toBe('{"ok":true}');
+    expect(res.stderr).toBe('a note\n');
+  });
+
+  it('reports the kill, the elapsed time, and the command line', async () => {
+    let res = await runBoxel(['--hang'], { timeout: 1_000 });
+    expect(res.timedOut).toBe(true);
+    expect(res.ok).toBe(false);
+    // What the command had printed before the kill survives above the report.
+    expect(res.stderr).toContain('working…');
+    expect(res.stderr).toMatch(/\[runBoxel\] killed after \d+ms/);
+    expect(res.stderr).toContain('deadline 1000ms');
+    expect(res.stderr).toContain('--hang');
+  });
+
+  it('refuses a deadline that would pre-empt the command own deadline', async () => {
+    await expect(
+      runBoxel(['realm', 'publish', '--timeout', '60000'], { timeout: 60_000 }),
+    ).rejects.toThrow(
+      /cannot enforce a command that was given --timeout 60000/,
+    );
+  });
+
+  it('clears the command own deadline by a margin when none is requested', async () => {
+    // 90s of margin over the command's 60s means the kill cannot land first,
+    // so a wedged command still reports its own diagnostic. The stub exits
+    // immediately; what is under test is that no deadline error is raised and
+    // the run is not killed.
+    let res = await runBoxel(['realm', 'publish', '--timeout=60000']);
+    expect(res.timedOut).toBe(false);
+    expect(res.ok).toBe(true);
+  });
+});

--- a/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
+++ b/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
@@ -21,26 +21,34 @@ let originalBin: string | undefined;
 //   --deaf           idles and swallows SIGTERM, like a command with its own
 //                    shutdown handler
 //   --leave-orphan   idles after spawning a child that inherits its stdio and
-//                    would outlive it, the way `boxel parse` leaves ember-tsc
-//                    and `boxel test` leaves chromium — the pipes stay open,
-//                    so `close` never arrives. Prints the child's pid so the
-//                    test can check it is reaped.
+//                    would outlive it, the way a command that shells out to a
+//                    long-running tool does. Its inherited write ends keep
+//                    `close` from arriving. Prints the child's pid so the test
+//                    can check it is reaped.
+//
+//   --deaf-orphan    the same, with a child that swallows SIGTERM: only the
+//                    SIGKILL sweep reaches it, so this is what pins that half
+//                    of the kill.
 //
 // Anything else prints on both streams and exits 0.
+const IDLE_FLAGS = ['--hang', '--deaf', '--leave-orphan', '--deaf-orphan'];
 const STUB_CLI = `
 const { spawn } = require('node:child_process');
 if (process.argv.includes('--deaf')) {
   process.on('SIGTERM', () => {});
 }
-if (process.argv.includes('--leave-orphan')) {
-  let orphan = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 600000)'], {
-    stdio: 'inherit',
-  });
+let orphanFlag = process.argv.find(
+  (a) => a === '--leave-orphan' || a === '--deaf-orphan',
+);
+if (orphanFlag) {
+  let body =
+    orphanFlag === '--deaf-orphan'
+      ? "process.on('SIGTERM', () => {}); setTimeout(() => {}, 600000)"
+      : 'setTimeout(() => {}, 600000)';
+  let orphan = spawn(process.execPath, ['-e', body], { stdio: 'inherit' });
   process.stdout.write('orphan-pid=' + orphan.pid + '\\n');
 }
-if (
-  process.argv.some((a) => ['--hang', '--deaf', '--leave-orphan'].includes(a))
-) {
+if (process.argv.some((a) => ${JSON.stringify(IDLE_FLAGS)}.includes(a))) {
   process.stderr.write('working…\\n');
   setInterval(() => {}, 1 << 30);
 } else {
@@ -153,6 +161,17 @@ describe('runBoxel deadline', () => {
     // running on into the tests that follow it in this process. It would
     // otherwise be alive for ten minutes, so a bounded wait tells the two
     // apart without depending on how promptly the kill is scheduled.
+    await expect(waitUntilNotRunning(orphanPid)).resolves.toBeUndefined();
+  });
+
+  it('ends a child that swallows SIGTERM too', async () => {
+    // The group SIGTERM does not reach this one, so what ends it is the
+    // SIGKILL sweep `settle` runs before clearing the escalation timer.
+    let res = await runBoxel(['--deaf-orphan'], { timeout: 1_000 });
+    expect(res.timedOut).toBe(true);
+
+    let orphanPid = Number(/orphan-pid=(\d+)/.exec(res.stdout)?.[1]);
+    expect(Number.isInteger(orphanPid)).toBe(true);
     await expect(waitUntilNotRunning(orphanPid)).resolves.toBeUndefined();
   });
 

--- a/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
+++ b/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
@@ -76,6 +76,22 @@ function isRunning(pid: number): boolean {
   }
 }
 
+/**
+ * Wait for `pid` to stop running. A signal is delivered asynchronously and the
+ * kernel still has to schedule the target's teardown, so a process that has
+ * been killed is briefly still running — sampling once races that window and
+ * gets whichever answer the machine's load happens to produce.
+ */
+async function waitUntilNotRunning(pid: number, timeoutMs = 15_000) {
+  let deadline = Date.now() + timeoutMs;
+  while (isRunning(pid)) {
+    if (Date.now() > deadline) {
+      throw new Error(`pid ${pid} still running after ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
 beforeAll(() => {
   scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-cli-deadline-'));
   stubBin = path.join(scriptDir, 'stub-cli.js');
@@ -134,8 +150,10 @@ describe('runBoxel deadline', () => {
     let orphanPid = Number(/orphan-pid=(\d+)/.exec(res.stdout)?.[1]);
     expect(Number.isInteger(orphanPid)).toBe(true);
     // Killing the group, not just the command, is what stops that child from
-    // running on into the tests that follow it in this process.
-    expect(isRunning(orphanPid)).toBe(false);
+    // running on into the tests that follow it in this process. It would
+    // otherwise be alive for ten minutes, so a bounded wait tells the two
+    // apart without depending on how promptly the kill is scheduled.
+    await expect(waitUntilNotRunning(orphanPid)).resolves.toBeUndefined();
   });
 
   it('refuses a deadline that would pre-empt the command own deadline', async () => {

--- a/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
+++ b/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
@@ -21,9 +21,10 @@ let originalBin: string | undefined;
 //   --deaf           idles and swallows SIGTERM, like a command with its own
 //                    shutdown handler
 //   --leave-orphan   idles after spawning a child that inherits its stdio and
-//                    outlives it, the way `boxel parse` leaves ember-tsc and
-//                    `boxel test` leaves chromium — the pipes stay open, so
-//                    `close` never arrives
+//                    would outlive it, the way `boxel parse` leaves ember-tsc
+//                    and `boxel test` leaves chromium — the pipes stay open,
+//                    so `close` never arrives. Prints the child's pid so the
+//                    test can check it is reaped.
 //
 // Anything else prints on both streams and exits 0.
 const STUB_CLI = `
@@ -32,10 +33,10 @@ if (process.argv.includes('--deaf')) {
   process.on('SIGTERM', () => {});
 }
 if (process.argv.includes('--leave-orphan')) {
-  spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
+  let orphan = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 600000)'], {
     stdio: 'inherit',
-    detached: true,
-  }).unref();
+  });
+  process.stdout.write('orphan-pid=' + orphan.pid + '\\n');
 }
 if (
   process.argv.some((a) => ['--hang', '--deaf', '--leave-orphan'].includes(a))
@@ -47,6 +48,33 @@ if (
   process.stderr.write('a note\\n');
 }
 `;
+
+/**
+ * True while `pid` names a process that is still executing.
+ *
+ * `process.kill(pid, 0)` is not that test: a killed process whose parent is
+ * gone stays in the process table as a zombie until whatever inherited it
+ * reaps it, and signalling a zombie succeeds. Read the state out of `/proc`
+ * where it is available, and fall back to the signal probe elsewhere.
+ */
+function isRunning(pid: number): boolean {
+  try {
+    let stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+    // Fields after the parenthesised comm: state is the first of them.
+    let state = stat.slice(stat.lastIndexOf(') ') + 2).split(' ')[0];
+    return state !== 'Z';
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 beforeAll(() => {
   scriptDir = fs.mkdtempSync(path.join(os.tmpdir(), 'boxel-cli-deadline-'));
@@ -94,14 +122,20 @@ describe('runBoxel deadline', () => {
     expect(Date.now() - startedAt).toBeLessThan(20_000);
   });
 
-  it('ends a command whose orphan keeps the stdio pipes open', async () => {
+  it('ends a command whose child keeps the stdio pipes open, and that child', async () => {
     let startedAt = Date.now();
     let res = await runBoxel(['--leave-orphan'], { timeout: 1_000 });
     expect(res.timedOut).toBe(true);
     expect(res.stderr).toContain('working…');
-    // The orphan holds the pipes for a minute; resolving on the command's own
-    // exit means the deadline is not waiting on it.
+    // The child would hold the pipes for ten minutes, so `close` never
+    // arrives; settling on the command's own exit is what bounds this.
     expect(Date.now() - startedAt).toBeLessThan(20_000);
+
+    let orphanPid = Number(/orphan-pid=(\d+)/.exec(res.stdout)?.[1]);
+    expect(Number.isInteger(orphanPid)).toBe(true);
+    // Killing the group, not just the command, is what stops that child from
+    // running on into the tests that follow it in this process.
+    expect(isRunning(orphanPid)).toBe(false);
   });
 
   it('refuses a deadline that would pre-empt the command own deadline', async () => {
@@ -112,13 +146,23 @@ describe('runBoxel deadline', () => {
     );
   });
 
-  it('clears the command own deadline by a margin when none is requested', async () => {
-    // 90s of margin over the command's 60s means the kill cannot land first,
-    // so a wedged command still reports its own diagnostic. The stub exits
-    // immediately; what is under test is that no deadline error is raised and
-    // the run is not killed.
-    let res = await runBoxel(['realm', 'publish', '--timeout=60000']);
+  it('accepts a command own deadline that the default clears by a margin', async () => {
+    // 30s leaves the default 60s deadline a full margin above it, so a wedged
+    // command reports its own diagnostic and the harness never needs a budget
+    // the vitest config does not cover. The stub exits at once; what is under
+    // test is that no deadline error is raised and nothing is killed.
+    let res = await runBoxel(['realm', 'publish', '--timeout=30000']);
     expect(res.timedOut).toBe(false);
     expect(res.ok).toBe(true);
+  });
+
+  it('refuses to derive a deadline past what it takes on its own', async () => {
+    // Deriving it would put the harness deadline at or above the vitest
+    // budgets, and the budget that then fires first abandons the subprocess
+    // rather than ending it. The helper cannot see those budgets, so it makes
+    // the call site name both rungs.
+    await expect(
+      runBoxel(['realm', 'publish', '--timeout', '60000']),
+    ).rejects.toThrow(/Pass `timeout: 90000`/);
   });
 });

--- a/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
+++ b/packages/boxel-cli/tests/lib/run-boxel-deadline.test.ts
@@ -15,10 +15,31 @@ let scriptDir: string;
 let stubBin: string;
 let originalBin: string | undefined;
 
-// Stands in for the CLI. `--hang` idles past any deadline; otherwise it
-// prints on both streams and exits 0.
+// Stands in for the CLI, in the shapes a deadline has to cope with:
+//
+//   --hang           idles past any deadline
+//   --deaf           idles and swallows SIGTERM, like a command with its own
+//                    shutdown handler
+//   --leave-orphan   idles after spawning a child that inherits its stdio and
+//                    outlives it, the way `boxel parse` leaves ember-tsc and
+//                    `boxel test` leaves chromium — the pipes stay open, so
+//                    `close` never arrives
+//
+// Anything else prints on both streams and exits 0.
 const STUB_CLI = `
-if (process.argv.includes('--hang')) {
+const { spawn } = require('node:child_process');
+if (process.argv.includes('--deaf')) {
+  process.on('SIGTERM', () => {});
+}
+if (process.argv.includes('--leave-orphan')) {
+  spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
+    stdio: 'inherit',
+    detached: true,
+  }).unref();
+}
+if (
+  process.argv.some((a) => ['--hang', '--deaf', '--leave-orphan'].includes(a))
+) {
   process.stderr.write('working…\\n');
   setInterval(() => {}, 1 << 30);
 } else {
@@ -62,6 +83,25 @@ describe('runBoxel deadline', () => {
     expect(res.stderr).toMatch(/\[runBoxel\] killed after \d+ms/);
     expect(res.stderr).toContain('deadline 1000ms');
     expect(res.stderr).toContain('--hang');
+  });
+
+  it('ends a command that swallows SIGTERM', async () => {
+    let startedAt = Date.now();
+    let res = await runBoxel(['--deaf'], { timeout: 1_000 });
+    expect(res.timedOut).toBe(true);
+    // SIGTERM at 1s, SIGKILL 5s later: the deadline still ends the command,
+    // rather than handing the enclosing test's budget the job.
+    expect(Date.now() - startedAt).toBeLessThan(20_000);
+  });
+
+  it('ends a command whose orphan keeps the stdio pipes open', async () => {
+    let startedAt = Date.now();
+    let res = await runBoxel(['--leave-orphan'], { timeout: 1_000 });
+    expect(res.timedOut).toBe(true);
+    expect(res.stderr).toContain('working…');
+    // The orphan holds the pipes for a minute; resolving on the command's own
+    // exit means the deadline is not waiting on it.
+    expect(Date.now() - startedAt).toBeLessThan(20_000);
   });
 
   it('refuses a deadline that would pre-empt the command own deadline', async () => {

--- a/packages/boxel-cli/vitest.config.mjs
+++ b/packages/boxel-cli/vitest.config.mjs
@@ -1,6 +1,21 @@
 import { defineConfig } from 'vitest/config';
 import { resolve } from 'path';
 
+// Nearly every test here drives the CLI as a subprocess through `runBoxel`,
+// which imposes its own kill deadline (`RUN_BOXEL_DEFAULT_DEADLINE_MS`, 60s).
+// That deadline is the only thing that can end a wedged command *and say
+// which command it was*, so vitest's budgets have to sit above it: a budget
+// that fires first abandons the subprocess instead, leaving a bare "Test
+// timed out in Nms" that names neither the command nor its output — and
+// leaving the command itself running against the realm server the rest of
+// the file is using.
+//
+// The ladder, innermost first: a `--timeout` the command was given on its own
+// argv < runBoxel's kill deadline < these budgets. `tests/lib/deadline-ladder`
+// asserts the config end of it.
+const RUN_BOXEL_DEADLINE_HEADROOM_MS = 30_000;
+const TEST_TIMEOUT_MS = 60_000 + RUN_BOXEL_DEADLINE_HEADROOM_MS;
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -12,17 +27,22 @@ export default defineConfig({
     setupFiles: [],
     include: ['**/tests/**/*.ts'],
     exclude: ['tests/helpers/**', 'node_modules'],
-    testTimeout: 30000,
-    // The integration files' setup hooks are the heaviest thing in this
-    // package: `startTestRealmServer` clones a migrated Postgres database,
-    // starts a queue worker, logs each realm into Matrix, runs the realm's
-    // initial index, and registers a Synapse user. That is a multi-second
-    // fixture even unloaded, so vitest's 10s hook default sits inside the
-    // fixture's own spread and fires on a busy runner rather than on a fault.
-    // The budget is a ceiling for a wedged fixture, not a target: a healthy
-    // boot uses a small fraction of it, and one that does not prints its phase
-    // breakdown (see `reportSlowBoot` in tests/helpers/integration.ts).
-    hookTimeout: 120000,
+    testTimeout: TEST_TIMEOUT_MS,
+    // Setup hooks carry the heaviest thing in this package on top of whatever
+    // commands they run: `startTestRealmServer` clones a migrated Postgres
+    // database, starts a queue worker, logs each realm into Matrix, runs the
+    // realm's initial index, and registers a Synapse user. vitest's 10s hook
+    // default is a unit-test budget and sits inside that fixture's own spread,
+    // so it fires on a busy runner rather than on a fault — and an overrun
+    // hook is the expensive kind of failure here, because the boot it
+    // abandons goes on to bind the fixture's port (see
+    // tests/integration/fixture-teardown.test.ts).
+    //
+    // This is a ceiling for a wedged fixture, not a target: a healthy boot
+    // uses a small fraction of it, and one that runs an order of magnitude
+    // over its usual cost prints its phase breakdown (see
+    // `reportSlowFixture` in tests/helpers/integration.ts).
+    hookTimeout: TEST_TIMEOUT_MS + RUN_BOXEL_DEADLINE_HEADROOM_MS,
     sequence: {
       hooks: 'list',
     },

--- a/packages/boxel-cli/vitest.config.mjs
+++ b/packages/boxel-cli/vitest.config.mjs
@@ -10,9 +10,14 @@ import { resolve } from 'path';
 // leaving the command itself running against the realm server the rest of
 // the file is using.
 //
-// The ladder, innermost first: a `--timeout` the command was given on its own
-// argv < runBoxel's kill deadline < these budgets. `tests/lib/deadline-ladder`
+// The ladder, innermost first: a deadline the command was given for itself <
+// runBoxel's kill deadline < these budgets. `tests/lib/deadline-ladder`
 // asserts the config end of it.
+//
+// Only the outer two rungs are enforced. runBoxel reads a command's own
+// deadline off argv, and a command can hold one that never appears there —
+// `parse` gives ember-tsc 120s through `execFile` — so for those the call site
+// has to set the harness deadline itself, as `parse.test.ts` does.
 const RUN_BOXEL_DEADLINE_HEADROOM_MS = 30_000;
 const TEST_TIMEOUT_MS = 60_000 + RUN_BOXEL_DEADLINE_HEADROOM_MS;
 

--- a/packages/boxel-cli/vitest.config.mjs
+++ b/packages/boxel-cli/vitest.config.mjs
@@ -13,6 +13,16 @@ export default defineConfig({
     include: ['**/tests/**/*.ts'],
     exclude: ['tests/helpers/**', 'node_modules'],
     testTimeout: 30000,
+    // The integration files' setup hooks are the heaviest thing in this
+    // package: `startTestRealmServer` clones a migrated Postgres database,
+    // starts a queue worker, logs each realm into Matrix, runs the realm's
+    // initial index, and registers a Synapse user. That is a multi-second
+    // fixture even unloaded, so vitest's 10s hook default sits inside the
+    // fixture's own spread and fires on a busy runner rather than on a fault.
+    // The budget is a ceiling for a wedged fixture, not a target: a healthy
+    // boot uses a small fraction of it, and one that does not prints its phase
+    // breakdown (see `reportSlowBoot` in tests/helpers/integration.ts).
+    hookTimeout: 120000,
     sequence: {
       hooks: 'list',
     },


### PR DESCRIPTION
Reported flake: `Boxel CLI Tests` on [run 33625418417](https://github.com/cardstack/boxel/actions/runs/33625418417/job/100232773266).

That run's own assertion is unreachable — the job log's readable tail is entirely inside the dev-stack dump that `Print server logs` cats after the test step — so nothing here rests on it. It rests on standing the suite up locally against the same services CI starts (node 24, base realm + worker + prerenderer + icons + host dist, Synapse, the seeded test Postgres) and catching failures in it.

That produced one reproducible flake and the source defect behind it, both fixed at the mechanism. The rest of the change is the reason a failure in this job says so little, which is a property of the harness rather than of any one test.

## 1. The watch loop was aborted on a stopwatch

`realm watch (integration) > runs the watchRealms loop end-to-end and stops on AbortSignal` slept a fixed 400 ms, aborted, and then asserted on what the loop had produced:

```
AssertionError: expected 0 to be greater than or equal to 1
 ❯ tests/integration/realm-watch.test.ts:523
     expect(checkpoints.length).toBeGreaterThanOrEqual(1);
```

The tail of a flush is a `git commit` into a freshly initialized `.boxel-history` repo — a subprocess doing real work, and by far the slowest step in the pipeline that sleep stood in for. 400 ms covers it idle and does not cover it busy: the abort lands mid-flush, the pull is visible (the assertion above this one passes) and no checkpoint exists behind it.

**Under fixed background CPU load the test failed 3 of 3 runs.** It now waits for the checkpoint its assertions read before aborting, through the `waitFor` helper this file already has for exactly this — whose docstring says "instead of racing it with a fixed sleep that can lose under CI load". `flush()` downloads before it checkpoints, so waiting on the checkpoint implies the file assertion's precondition: the new gate is strictly stronger than the sleep it replaces, not weaker. A genuine hang reports which state never arrived. **12 of 12 loaded runs pass with the change.**

## 2. `getCheckpoints` throws on a history repo it has just created

Waiting on that checkpoint exposed the next one: `getCheckpoints` treats `.boxel-history/.git` existing as "there is a history to read", but `init()` runs `git init` and three more git commands before its bootstrap commit. A reader arriving in that window finds an initialized repo with an unborn HEAD — which `git log` refuses outright instead of reporting an empty history:

```
Error: git log --format=… -50 failed: fatal: your current branch 'master' does not have any commits yet
```

A workspace whose history is being initialized by a concurrent `realm watch` flush is the ordinary way to reach it, and `boxel realm history` there gets a raw git error where the answer is simply "no checkpoints".

It now checks for a commit first. The discrimination is by exit code, checked against git rather than taken from the docs: in a healthy repo an unborn HEAD exits **1**, while a `.git` that is not a gitfile and a repo with dubious ownership both exit **128**. So `git()` delegates to `spawnGit(args, isAnswer)` with an explicit predicate per call — `status` keeps its "any non-zero is data" reading, the unborn-HEAD probe accepts only `1` — and nothing is inferred from a flag. A repository git cannot read still surfaces, with a test for it.

## 3. Why a failure in this job says so little

`runBoxel`'s kill deadline is the only mechanism that can end a wedged CLI subprocess *and name it*. With `testTimeout` at 30 s against a 60 s harness deadline it could never fire: vitest abandoned the subprocess first, so the failure read `Test timed out in 30000ms` — naming neither the command nor its output — and the abandoned command kept running against the realm server the rest of the file was using.

The budgets now increase outward: a deadline the command holds for itself, then runBoxel's kill deadline, then the test budget, then the hook budget.

- **`RUN_BOXEL_DEFAULT_DEADLINE_MS` is a ceiling, not a default.** This is the change to the harness's contract with its ~90 callers: the helper refuses to *derive* a deadline past it from a command's argv, because a derived deadline is unbounded from the config's point of view and no fixed `testTimeout` could then dominate it. A command needing longer says so through `options.timeout`, at a call site that can also raise the budget around itself — vitest exposes no `timeout` on its test context, so the helper cannot check that rung, and the throw names the value to pass.
- **Only argv-visible deadlines are derived.** A command can hold one that never appears there: `parse` gives ember-tsc 120 s through `execFile`, so `parseFixture` sets 150 s explicitly under its 180 s budget. Before that, a type-check running past 60 s was killed rather than reporting.
- **A killed command says so** — `timedOut`, plus a line naming the deadline, the elapsed time and the command line — instead of leaving a bare null exit code that reads as an ordinary failure.
- **The deadline ends the command.** It signals the command's own process group (`detached: true`), escalates to SIGKILL after a grace period, sweeps the group before settling, and settles on the command's own `exit` rather than on `close`, which waits for stdio pipes a descendant could hold open. The group reaches an ordinary child, not one that makes itself a group leader.
- The per-test budgets that sat at or under the harness deadline are gone; they could only abandon, never report. The three sites that set a runBoxel deadline equal to their enclosing budget now sit below it.
- `tests/lib/deadline-ladder.test.ts` asserts both config rungs and the ceiling that makes them meaningful.

## 4. A leaked fixture turns one failure into a whole-run failure

Every integration file boots a realm server on the same fixed port and the suite shares one process (`--poolOptions.forks.singleFork`), so a fixture that outlives the file that asked for it fails every later file with `EADDRINUSE`.

A setup hook that overruns its budget produces one. vitest enforces a hook budget by rejecting the hook's promise; it cannot cancel the work the hook started. `stopTestRealmServer` therefore ran while the boot was still going, found module state empty, cleaned up nothing — and the boot went on to bind the port with nothing holding a reference to the server.

`stopTestRealmServer` now waits for an in-flight boot before tearing down, so the file that overran cleans up after itself. The boot handle is published before the helper's first `await`, so a caller that stops waiting the instant it calls still leaves teardown something to find. `tests/integration/fixture-teardown.test.ts` covers it and fails with `listen EADDRINUSE: address already in use 0.0.0.0:4446` without the change.

The hooks were also on vitest's 10 s default, which is a unit-test budget: `startTestRealmServer` clones a migrated Postgres database, starts a queue worker, logs each realm into Matrix, runs the realm's initial index and registers a Synapse user. That costs about a second unloaded, but one of 37 boots in a clean, fully passing local run took **12.1 s in `boot-realm-server` alone** — past the 10 s default. On the stock config that run would have failed a hook and leaked the fixture.

`hookTimeout` is now explicit, as a ceiling for a wedged fixture rather than a target, and a fixture running an order of magnitude over its usual cost prints its phase breakdown. The job's `timeout-minutes` covers a handful of those budgets being spent, because a job cancelled on that cap reports nothing at all — the same nameless failure, one level up. A systemic fixture failure will still reach the cap; that is stated at the setting rather than implied away.

## Smaller diagnostic holes closed alongside

- The fake watcher's stderr was piped and never read, so a fixture that failed to start reported only an exit code. It rejects on `close`, so the stderr it reports has been drained.
- `registerCliTestUser`'s contract said re-registration was benign when it in fact threw, so a file that boots the fixture twice failed on `M_USER_IN_USE`.
- `realm-publish` publishes to a `*.localhost` subdomain and polls it for readiness. That resolves only where the resolver synthesizes a subdomain of `localhost` (systemd-resolved, macOS) — an environment requirement, not something RFC 6761 guarantees, and the comment claiming otherwise is corrected. Where it is not met every poll fails to resolve and the wait burns its full timeout: deterministic per host rather than flaky, but it is why the first local run of this suite looked like a publish bug.

## Verification

Against a local dev stack matching the CI job's services:

- `tests/integration/realm-watch.test.ts` in a loop under fixed background CPU load: **3/3 failures before, 0/12 after.**
- Full integration suite: **37 files, 310 tests, all passing**, over three consecutive runs (483 s / 477 s / 453 s — the passing runs I sampled on stock `main` took 422–452 s, so the added file and boots cost nothing).
- `pnpm test:unit`: **42 files, 584 tests, all passing.**

Each fix fails without its change, checked by reverting it:

- `fixture-teardown` → `listen EADDRINUSE` on 4446.
- `checkpoint-manager`'s unborn-HEAD case → the raw `git log` fatal; its unreadable-repo case → a silent `[]` if the predicate is widened.
- `realm-watch`'s end-to-end case → `expected 0 to be greater than or equal to 1`.
- `run-boxel-deadline`'s orphan cases → 60 s held instead of 1 s without the `exit` path; a SIGTERM-ignoring child survives without the SIGKILL sweep.

`tsc --noEmit`, `eslint`, `prettier` and `yamllint` (against `.github/.yamllint.yml`) clean on the changed files.

No test is skipped, retried, or given a longer budget to make it pass. The budgets that moved did so to put the harness's own deadline in front of vitest's, so a wedge is reported rather than abandoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQRnDpAeuz8trt12sGBKB5