### PR TITLE
Classify a prefix-form module reference as absolute

### DIFF
--- a/packages/host/tests/unit/code-ref-test.ts
+++ b/packages/host/tests/unit/code-ref-test.ts
@@ -6,6 +6,7 @@ import { module, test } from 'qunit';
 
 import type { Loader, LooseCardResource } from '@cardstack/runtime-common';
 import { loadCardDef, rri, visitModuleDeps } from '@cardstack/runtime-common';
+import { isRelativePath } from '@cardstack/runtime-common/code-ref';
 import * as CodeRefSerializer from '@cardstack/runtime-common/serializers/code-ref';
 
 import {
@@ -224,5 +225,37 @@ module('code-ref', function (hooks) {
       '@cardstack/catalog/Listing/person',
       'deserializeAbsolute resolves the relative module against the prefix base',
     );
+  });
+
+  test('classifies module references by form, not by whether they parse', function (assert) {
+    // `URL.canParse` answers false for a prefix-form RRI, so asking only
+    // whether a value parses reads the canonical spelling of every base-realm
+    // module as a relative path. `resolveAdoptsFrom` then sends it down
+    // relative resolution.
+    //
+    // Nothing breaks today because that path passes a prefix form through
+    // unchanged — which is why this is asserted directly rather than through
+    // behaviour: both routes agree, so a regression would be invisible.
+    for (let absolute of [
+      '@cardstack/base/card-api',
+      '@cardstack/catalog/Listing/author',
+      'https://cardstack.com/base/card-api',
+      'http://test-realm/test/person',
+      'data:text/javascript,export default 1',
+    ]) {
+      assert.false(
+        isRelativePath(absolute),
+        `${absolute} is an absolute reference`,
+      );
+    }
+
+    for (let relative of ['./person', '../person', 'person', '/person']) {
+      assert.true(
+        isRelativePath(relative),
+        `${relative} is a relative reference`,
+      );
+    }
+
+    assert.false(isRelativePath(undefined), 'a non-string is not a path');
   });
 });

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -556,8 +556,20 @@ function hasRelativeModule(ref: CodeRef): boolean {
   return hasRelativeModule(ref.card);
 }
 
-function isRelativePath(moduleId: unknown): moduleId is string {
+// Exported for testing: both branches of `resolveAdoptsFrom` currently agree
+// for a prefix-form module — the relative branch passes it through unchanged —
+// so the classification has no observable behaviour of its own to assert
+// against, and a regression would be silent.
+export function isRelativePath(moduleId: unknown): moduleId is string {
   if (typeof moduleId !== 'string') {
+    return false;
+  }
+  // A prefix-form RRI (`@scope/name/…`) is absolute, but no URL parser knows
+  // that: `URL.canParse` answers false for it, which would classify the
+  // canonical spelling of a base-realm module as a relative path.
+  // `resolveRRIReference`, which receives whatever this classifies, draws the
+  // same line the same way.
+  if (moduleId.startsWith('@')) {
     return false;
   }
   if (typeof URL.canParse === 'function') {


### PR DESCRIPTION
This is continued cleanup for the `@cardstack/base`/RRI journey.

`isRelativePath` asked only whether a value parses as a URL. `URL.canParse` says no for a registered prefix, so the canonical spelling of every base-realm module read as a relative path and `resolveAdoptsFrom` sent it down relative resolution.

Nothing breaks today: that path passes a prefix form through unchanged, and `resolveModuleHref` admits one before resolving. The classification was wrong while the outcome was right, resting on a downstream tolerance rather than on knowing what the value was.

The `@` discriminator is the one the codebase already uses for this question — `resolveRRIReference`, which receives whatever this classifies, opens with the same test, and `isLocalId` records why it needs no VirtualNetwork: the two remote forms are syntactically distinguishable.

Since both routes agree, no behaviour distinguishes them and a regression would be silent, so the classifier is asserted directly and exported for that.