### PR TITLE
Report only realms from `knownRealms()`

### DIFF
--- a/packages/realm-server/tests/realm-identifiers-test.ts
+++ b/packages/realm-server/tests/realm-identifiers-test.ts
@@ -366,6 +366,46 @@ module(basename(import.meta.filename), function () {
       assert.true(realms.includes(ri('@test/realm/')));
       assert.true(realms.includes(ri('@test/other/')));
     });
+
+    test('knownRealms omits shimmed package namespaces', function (assert) {
+      // Both kinds share the mapping table because both have to resolve, so
+      // the table alone cannot answer which realms exist. A caller that
+      // enumerates realms — a picker, a permissions check — would otherwise
+      // receive a Host package namespace indistinguishable from a realm.
+      vn.addPackageMapping('@test/pkg/', 'http://localhost:9100/pkg/');
+
+      assert.deepEqual(
+        vn.knownRealms(),
+        [ri('@test/realm/')],
+        'the package namespace is not a realm',
+      );
+      assert.true(
+        vn.isPackageNamespace('@test/pkg/'),
+        'and reports as a package namespace',
+      );
+      assert.strictEqual(
+        vn.resolveImport('@test/pkg/components'),
+        'http://localhost:9100/pkg/components',
+        'while resolving exactly as a realm mapping would',
+      );
+    });
+
+    test('registering a prefix as a realm reclaims it from the package set', function (assert) {
+      // The annotation must not outlive the registration that set it, or a
+      // prefix later registered as a realm would stay hidden from
+      // `knownRealms` for the rest of the process.
+      vn.addPackageMapping('@test/reclaimed/', 'http://localhost:9200/pkg/');
+      vn.addRealmMapping('@test/reclaimed/', 'http://localhost:9200/realm/');
+
+      assert.false(
+        vn.isPackageNamespace('@test/reclaimed/'),
+        'it is a realm now',
+      );
+      assert.true(
+        vn.knownRealms().includes(ri('@test/reclaimed/')),
+        'and knownRealms reports it',
+      );
+    });
   });
 
   module('VirtualNetwork resolver methods', function () {

--- a/packages/realm-server/tests/realm-identifiers-test.ts
+++ b/packages/realm-server/tests/realm-identifiers-test.ts
@@ -379,8 +379,9 @@ module(basename(import.meta.filename), function () {
         [ri('@test/realm/')],
         'the package namespace is not a realm',
       );
-      assert.true(
-        vn.isPackageNamespace('@test/pkg/'),
+      assert.strictEqual(
+        vn.prefixKind('@test/pkg/'),
+        'package',
         'and reports as a package namespace',
       );
       assert.strictEqual(
@@ -397,14 +398,23 @@ module(basename(import.meta.filename), function () {
       vn.addPackageMapping('@test/reclaimed/', 'http://localhost:9200/pkg/');
       vn.addRealmMapping('@test/reclaimed/', 'http://localhost:9200/realm/');
 
-      assert.false(
-        vn.isPackageNamespace('@test/reclaimed/'),
+      assert.strictEqual(
+        vn.prefixKind('@test/reclaimed/'),
+        'realm',
         'it is a realm now',
       );
       assert.true(
         vn.knownRealms().includes(ri('@test/reclaimed/')),
         'and knownRealms reports it',
       );
+    });
+
+    test('prefixKind separates unregistered from realm', function (assert) {
+      // The distinction a boolean could not carry: a prefix this network has
+      // never seen is not a realm, and a caller deciding how to treat one must
+      // not read the absence as "realm".
+      assert.strictEqual(vn.prefixKind('@test/realm/'), 'realm');
+      assert.strictEqual(vn.prefixKind('@never/registered/'), undefined);
     });
   });
 

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -263,6 +263,11 @@ export class VirtualNetwork {
   removeRealmMapping(realmIdentifier: string): void {
     let normalizedId = ensureTrailingSlash(realmIdentifier);
     this.realmMappings.delete(normalizedId);
+    // Hygiene rather than correctness: `prefixKind` checks `realmMappings`
+    // first, so an annotation left behind here is already unobservable, and
+    // both registration doors set the kind for whatever they register. What
+    // this prevents is the set outliving every mapping that justified it and
+    // growing for the life of the process.
     this.packageNamespacePrefixes.delete(normalizedId);
     this.importMap.delete(normalizedId);
     this.toURLHrefCache.clear();
@@ -286,11 +291,23 @@ export class VirtualNetwork {
   }
 
   /**
-   * Whether a registered prefix names a shimmed package namespace rather than a
-   * realm. For callers that hold a prefix and need to know which it is.
+   * Which kind of thing a prefix was registered as, or undefined when this
+   * network has not registered it.
+   *
+   * Three-valued rather than a boolean, because "not a package" and "not
+   * registered at all" are the two answers a caller most needs to keep apart —
+   * collapsing them is the same conflation `knownRealms()` exists to undo, and
+   * a boolean would put it back one call further along. Nothing else recovers
+   * the third case: `isRegisteredPrefix` tests a *reference* with `startsWith`,
+   * so it answers true for a descendant of a registered prefix and cannot
+   * distinguish an exact key from a path beneath one.
    */
-  isPackageNamespace(prefix: string): boolean {
-    return this.packageNamespacePrefixes.has(ensureTrailingSlash(prefix));
+  prefixKind(prefix: string): 'realm' | 'package' | undefined {
+    let normalized = ensureTrailingSlash(prefix);
+    if (!this.realmMappings.has(normalized)) {
+      return undefined;
+    }
+    return this.packageNamespacePrefixes.has(normalized) ? 'package' : 'realm';
   }
 
   /**

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -30,6 +30,17 @@ export class VirtualNetwork {
   private urlMappings: [string, string][] = [];
   private importMap: Map<string, (rest: string) => string> = new Map();
   private realmMappings = new Map<string, string>();
+  // Which keys of `realmMappings` are shimmed package namespaces rather than
+  // realms. Both kinds live in one table because both have to resolve — a
+  // prefix that does not resolve cannot serve `CodeRef.moduleHref` — so the
+  // table alone cannot answer "which realms does this network know?".
+  //
+  // An annotation rather than a kind on each entry, so no resolution path
+  // changes: everything that iterates `realmMappings` keeps reading a target
+  // directly. Both shapes fail the same way if this drifts — a realm omitted
+  // from a report, never a prefix that stops resolving — and this way the
+  // resolution code has nothing to get wrong.
+  private packageNamespacePrefixes = new Set<string>();
   // Memo for toURLHref. Hot paths (module-graph walks, per-instance realm
   // membership checks) resolve the same identifiers over and over and only
   // ever need the href STRING, yet toURL pays a native `new URL()` per call —
@@ -205,6 +216,9 @@ export class VirtualNetwork {
           `use a prefix outside the @cardstack scope.`,
       );
     }
+    // Registering the same prefix as a realm reclaims it: the annotation must
+    // never outlive the registration that set it.
+    this.packageNamespacePrefixes.delete(ensureTrailingSlash(realmIdentifier));
     this.addPrefixMapping(realmIdentifier, targetURL);
   }
 
@@ -222,6 +236,7 @@ export class VirtualNetwork {
    * looking at the mapping, so the caller has to say which it registered.
    */
   addPackageMapping(packageNamespace: string, targetURL: string): void {
+    this.packageNamespacePrefixes.add(ensureTrailingSlash(packageNamespace));
     this.addPrefixMapping(packageNamespace, targetURL);
   }
 
@@ -248,6 +263,7 @@ export class VirtualNetwork {
   removeRealmMapping(realmIdentifier: string): void {
     let normalizedId = ensureTrailingSlash(realmIdentifier);
     this.realmMappings.delete(normalizedId);
+    this.packageNamespacePrefixes.delete(normalizedId);
     this.importMap.delete(normalizedId);
     this.toURLHrefCache.clear();
     this.unresolveURLCache.clear();
@@ -255,8 +271,26 @@ export class VirtualNetwork {
     this.notifyMappingChange();
   }
 
+  /**
+   * The realms this network can resolve — the mapping table less the shimmed
+   * package namespaces, which resolve the same way but are the Host's own
+   * modules rather than a realm's authored content.
+   *
+   * Every other reader of the table wants resolvable prefixes and so wants both
+   * kinds; this is the one that means realms.
+   */
   knownRealms(): RealmIdentifier[] {
-    return [...this.realmMappings.keys()] as RealmIdentifier[];
+    return [...this.realmMappings.keys()].filter(
+      (prefix) => !this.packageNamespacePrefixes.has(prefix),
+    ) as RealmIdentifier[];
+  }
+
+  /**
+   * Whether a registered prefix names a shimmed package namespace rather than a
+   * realm. For callers that hold a prefix and need to know which it is.
+   */
+  isPackageNamespace(prefix: string): boolean {
+    return this.packageNamespacePrefixes.has(ensureTrailingSlash(prefix));
   }
 
   /**


### PR DESCRIPTION
Realm mappings and shimmed package namespaces share one table because both have to resolve — a prefix that does not resolve cannot serve `CodeRef.moduleHref` — so the table alone cannot answer which realms a network knows. `knownRealms()` returned its keys, which meant `@cardstack/boxel-ui/` was reported as a realm, indistinguishable from one to any caller enumerating them.

Nothing outside tests enumerates realms that way today, so this is a latent hazard rather than a live fault: a picker or a permissions check added later would silently receive a Host package namespace.

An annotation recording which keys are package namespaces, rather than a kind on each entry. Both shapes fail the same way if the annotation drifts — a realm missing from a report, never a prefix that stops resolving — and this way no resolution path changes at all, where a kind on the value would have touched ten iteration sites in the resolution code to fix a reporting bug.

The annotation cannot outlive the registration that set it: registering a prefix as a realm reclaims it, and removal clears both. Otherwise a prefix registered as a package and later as a realm would stay hidden from `knownRealms` for the life of the process.

`isPackageNamespace` is exposed for callers holding a prefix that need to know which kind it is.