### PR TITLE
fix: assemble a card type's module info without re-asking the realm

### DIFF
--- a/packages/boxel-cli/tests/integration/realm-ingest-card.test.ts
+++ b/packages/boxel-cli/tests/integration/realm-ingest-card.test.ts
@@ -208,7 +208,11 @@ afterAll(async () => {
   // each test file a fresh registry — the OS-level server would outlive this
   // file and the next suite's getTestPrerenderer() would hit EADDRINUSE.
   await stopTestPrerenderServer();
-});
+  // Shutting down a realm server and a browser-backed prerender server is not
+  // a 10-second job on a loaded runner, and the default hook timeout is 10s.
+  // Timing out here aborts the teardown above, which is the very thing that
+  // keeps the next file off this port — so the budget matches the setup's.
+}, 600_000);
 
 describe('realm ingest-card (integration)', () => {
   it('ingests the entry card graph: modules across nested dirs, test, instance, and Spec', () => {

--- a/packages/boxel-cli/tests/integration/search.test.ts
+++ b/packages/boxel-cli/tests/integration/search.test.ts
@@ -87,7 +87,11 @@ afterAll(async () => {
   // each test file a fresh registry — stop the OS-level server so the next
   // suite's getTestPrerenderer() doesn't hit EADDRINUSE.
   await stopTestPrerenderServer();
-});
+  // Shutting down a realm server and a browser-backed prerender server is not
+  // a 10-second job on a loaded runner, and the default hook timeout is 10s.
+  // Timing out here aborts the teardown above, which is the very thing that
+  // keeps the next file off this port — so the budget matches the setup's.
+}, 600_000);
 
 describe('federated search (integration)', () => {
   it('returns each card once (no `.json` file-row dupe) plus plain files', async () => {

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -377,21 +377,6 @@ export default class CardService extends Service {
     await api.flushLogs();
   }
 
-  async getRealmInfoByRealmURL(realmURL: URL): Promise<RealmInfo> {
-    let response = await this.network.authedFetch(`${realmURL}_info`, {
-      headers: { Accept: SupportedMimeType.RealmInfo },
-      method: 'QUERY',
-    });
-
-    if (!response.ok) {
-      throw new Error(
-        `status: ${response.status} -
-        ${response.statusText}. ${await response.text()}`,
-      );
-    }
-    return (await response.json()).data.attributes;
-  }
-
   async executeAtomicOperations(operations: AtomicOperation[], realmURL: URL) {
     for (let operation of operations) {
       if (operation.data?.type === 'source') {

--- a/packages/host/app/services/card-type-service.ts
+++ b/packages/host/app/services/card-type-service.ts
@@ -2,7 +2,6 @@ import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import Service from '@ember/service';
 
-import type { RealmInfo } from '@cardstack/runtime-common';
 import {
   identifyCard,
   internalKeyFor,
@@ -14,8 +13,6 @@ import {
 } from '@cardstack/runtime-common';
 import { isCodeRef, type CodeRef } from '@cardstack/runtime-common/code-ref';
 import type { Loader } from '@cardstack/runtime-common/loader';
-
-import type CardService from '@cardstack/host/services/card-service';
 
 import type LoaderService from '../services/loader-service';
 import type NetworkService from '../services/network';
@@ -49,17 +46,29 @@ export interface Type {
 
 interface ModuleInfo {
   extension: string;
-  realmInfo: RealmInfo;
 }
 
 export default class CardTypeService extends Service {
-  @service declare private cardService: CardService;
   @service declare private network: NetworkService;
   @service declare private loaderService: LoaderService;
   @service declare private session: SessionService;
 
+  // Settled types only, deliberately: assembling a type is recursive, and the
+  // module inspector assembles every declaration in a module concurrently. Two
+  // of those roots can reference each other — cards that link both ways are
+  // ordinary — and each root breaks the cycle with its own traversal stack.
+  // Sharing in-flight type promises across roots would defeat those stacks,
+  // leaving each root awaiting the other's.
   private typeCache: Map<string, Type> = new Map();
-  private moduleInfoCache: Map<string, ModuleInfo> = new Map();
+
+  // The in-flight promise, not the settled value. A card's fields are assembled
+  // concurrently, so every field that shares a type asks for that type's module
+  // before the first of them has answered — keyed on the settled value, the
+  // several dozen color fields of a theme card would each fetch `color.gts` for
+  // themselves. Nothing reached from here recurses back into type assembly, so
+  // sharing the promise is safe, and it is what keeps the concurrent traversals
+  // above from repeating each other's fetches.
+  private moduleInfoCache: Map<string, Promise<ModuleInfo>> = new Map();
   private loader: object | undefined; //keeps track of the current used loader so cache is reset after a loader reset
 
   constructor(owner: Owner) {
@@ -114,9 +123,7 @@ export default class CardTypeService extends Service {
     }
     let moduleIdentifier = moduleFrom(ref);
     let moduleURL = this.network.virtualNetwork.toURL(moduleIdentifier);
-    let moduleInfo =
-      this.moduleInfoCache.get(moduleURL.href) ??
-      (await this.fetchModuleInfo(moduleURL));
+    let moduleInfo = await this.moduleInfo(moduleURL);
 
     let api = await loader.import<typeof CardAPI>('@cardstack/base/card-api');
     let { id: _remove, ...fields } = api.getFields(card, {
@@ -154,6 +161,27 @@ export default class CardTypeService extends Service {
     return type;
   }
 
+  private moduleInfo(url: URL): Promise<ModuleInfo> {
+    let pending = this.moduleInfoCache.get(url.href);
+    if (!pending) {
+      pending = this.fetchModuleInfo(url);
+      this.moduleInfoCache.set(url.href, pending);
+      // A rejection is dropped so the next caller retries: a failed fetch is a
+      // property of that attempt, not of the module. Scoped to the promise that
+      // failed, so a cache cleared and repopulated meanwhile keeps its newer
+      // entry.
+      pending.catch(() => {
+        if (this.moduleInfoCache.get(url.href) === pending) {
+          this.moduleInfoCache.delete(url.href);
+        }
+      });
+    }
+    return pending;
+  }
+
+  // The extension is only knowable from the response: a code ref names its
+  // module without one (`.../color`), and the realm redirects that to the file
+  // the module actually lives in (`.../color.gts`).
   private async fetchModuleInfo(url: URL): Promise<ModuleInfo> {
     let response = await this.network.authedFetch(url, {
       headers: { Accept: SupportedMimeType.CardSource },
@@ -166,19 +194,9 @@ export default class CardTypeService extends Service {
         } - ${await response.text()}`,
       );
     }
-    let realmURL = response.headers.get('x-boxel-realm-url');
-    if (realmURL === null) {
-      throw new Error(`Could not get realm url for ${url.href}`);
-    }
-    let realmInfo = await this.cardService.getRealmInfoByRealmURL(
-      new URL(realmURL),
-    );
-    let moduleInfo = {
-      realmInfo,
+    return {
       extension: '.' + new URL(response.url).pathname.split('.').pop() || '',
     };
-    this.moduleInfoCache.set(url.href, moduleInfo);
-    return moduleInfo;
   }
 }
 

--- a/packages/host/app/services/card-type-service.ts
+++ b/packages/host/app/services/card-type-service.ts
@@ -128,18 +128,36 @@ export default class CardTypeService extends Service {
       return cached;
     }
     let moduleIdentifier = moduleFrom(ref);
-    let moduleURL = this.network.virtualNetwork.toURL(moduleIdentifier);
-    let moduleInfo = await this.moduleInfo(moduleURL);
+    let moduleInfo = await this.moduleInfo(moduleIdentifier, loader);
 
     let api = await loader.import<typeof CardAPI>('@cardstack/base/card-api');
     let { id: _remove, ...fields } = api.getFields(card, {
       includeComputeds: true,
     });
     let superCard = getAncestor(card);
+    let childStack = [card, ...stack];
     let superType: Type | CodeRefType | undefined;
     if (superCard && card !== superCard) {
-      superType = await this.toType(superCard, loader, [card, ...stack]);
+      superType = await this.toType(superCard, loader, childStack);
     }
+
+    // Every field below resolves against the same stack, so one shared promise
+    // per distinct field type is what the several dozen color fields of a theme
+    // card need in order to traverse `ColorField` once between them instead of
+    // once each. Confined to this node's fan-out — which is what makes it safe
+    // where a service-wide in-flight cache is not. A promise here is only ever
+    // awaited by its siblings, and everything it awaits in turn sits deeper in
+    // `childStack`, so these await edges only point away from the sharers and
+    // can never close a cycle. See `typeCache` above for what does.
+    let inFlight = new Map<typeof BaseDef, Promise<Type | CodeRefType>>();
+    let resolveField = (fieldCard: typeof BaseDef) => {
+      let existing = inFlight.get(fieldCard);
+      if (!existing) {
+        existing = this.toType(fieldCard, loader, childStack);
+        inFlight.set(fieldCard, existing);
+      }
+      return existing;
+    };
 
     let fieldTypes: FieldOfType[] = await Promise.all(
       Object.entries(fields).map(
@@ -148,7 +166,7 @@ export default class CardTypeService extends Service {
           type: field.fieldType,
           isComputed: field.computeVia != undefined,
           isQueryField: field.queryDefinition != undefined,
-          card: await this.toType(field.card, loader, [card, ...stack]),
+          card: await resolveField(field.card),
         }),
       ),
     );
@@ -167,7 +185,28 @@ export default class CardTypeService extends Service {
     return type;
   }
 
-  private moduleInfo(url: URL): Promise<ModuleInfo> {
+  // The extension of the file a definition lives in. The loader records the
+  // resolved, extension-bearing URL of every module it imports, and a
+  // definition we hold a class for has necessarily been imported — so the
+  // answer is normally already in memory and costs nothing. Only a module
+  // whose recorded spelling carries no extension needs resolving over the
+  // network: a shim registered under a bare specifier is recorded under that
+  // specifier, and a loader replaced since the class was captured holds no
+  // record at all.
+  private async moduleInfo(
+    moduleIdentifier: string,
+    loader: Loader,
+  ): Promise<ModuleInfo> {
+    let extension = extensionOfURL(loader.canonicalURLFor(moduleIdentifier));
+    if (extension) {
+      return { extension };
+    }
+    return this.fetchedModuleInfo(
+      this.network.virtualNetwork.toURL(moduleIdentifier),
+    );
+  }
+
+  private fetchedModuleInfo(url: URL): Promise<ModuleInfo> {
     let pending = this.moduleInfoCache.get(url.href);
     if (!pending) {
       pending = this.fetchModuleInfo(url);
@@ -185,11 +224,11 @@ export default class CardTypeService extends Service {
     return pending;
   }
 
-  // A code ref names its module without an extension (`.../color`), and the
-  // realm resolves that to the file the module lives in (`.../color.gts`), so
-  // the response URL carries the extension. The loader records the same
-  // resolved URL when it imports a module, which is a cheaper source for a
-  // definition it has necessarily already loaded.
+  // The fallback for a module the loader cannot place. A code ref names its
+  // module without an extension (`.../color`) and the realm resolves that to
+  // the file the module lives in (`.../color.gts`), so the response URL
+  // carries the extension — at the cost of a redirect plus a download of
+  // source nothing here reads.
   private async fetchModuleInfo(url: URL): Promise<ModuleInfo> {
     let response = await this.network.authedFetch(url, {
       headers: { Accept: SupportedMimeType.CardSource },
@@ -203,6 +242,20 @@ export default class CardTypeService extends Service {
       );
     }
     return { extension: extensionOf(new URL(response.url).pathname) };
+  }
+}
+
+// The extension of a module spelling that may not be a URL at all — a shim's
+// bare specifier, or nothing when the loader has no record. Anything that does
+// not parse as a URL has no extension to report.
+function extensionOfURL(href: string | undefined): string {
+  if (!href) {
+    return '';
+  }
+  try {
+    return extensionOf(new URL(href).pathname);
+  } catch {
+    return '';
   }
 }
 

--- a/packages/host/app/services/card-type-service.ts
+++ b/packages/host/app/services/card-type-service.ts
@@ -53,12 +53,18 @@ export default class CardTypeService extends Service {
   @service declare private loaderService: LoaderService;
   @service declare private session: SessionService;
 
-  // Settled types only, deliberately: assembling a type is recursive, and the
-  // module inspector assembles every declaration in a module concurrently. Two
-  // of those roots can reference each other — cards that link both ways are
-  // ordinary — and each root breaks the cycle with its own traversal stack.
-  // Sharing in-flight type promises across roots would defeat those stacks,
-  // leaving each root awaiting the other's.
+  // Settled types only. Assembling a type is recursive, and the module
+  // inspector assembles every declaration in a module concurrently — one root
+  // per declaration. Two of those roots can reference each other (cards that
+  // link both ways are ordinary), and each root breaks the cycle with its own
+  // traversal stack. Sharing in-flight promises across roots keyed on the type
+  // alone would close that cycle through the cache instead of the recursion,
+  // where no stack can see it, and the two roots would await each other
+  // forever. Sharing keyed on the traversal stack as well as the type would be
+  // safe — every recursive call extends the stack, so those await edges only
+  // ever point deeper — and would collapse the sibling fields that share a
+  // type into one traversal. The cache is settled-only because it does not
+  // make that distinction, not because no sharing is possible.
   private typeCache: Map<string, Type> = new Map();
 
   // The in-flight promise, not the settled value. A card's fields are assembled
@@ -179,9 +185,11 @@ export default class CardTypeService extends Service {
     return pending;
   }
 
-  // The extension is only knowable from the response: a code ref names its
-  // module without one (`.../color`), and the realm redirects that to the file
-  // the module actually lives in (`.../color.gts`).
+  // A code ref names its module without an extension (`.../color`), and the
+  // realm resolves that to the file the module lives in (`.../color.gts`), so
+  // the response URL carries the extension. The loader records the same
+  // resolved URL when it imports a module, which is a cheaper source for a
+  // definition it has necessarily already loaded.
   private async fetchModuleInfo(url: URL): Promise<ModuleInfo> {
     let response = await this.network.authedFetch(url, {
       headers: { Accept: SupportedMimeType.CardSource },
@@ -194,10 +202,17 @@ export default class CardTypeService extends Service {
         } - ${await response.text()}`,
       );
     }
-    return {
-      extension: '.' + new URL(response.url).pathname.split('.').pop() || '',
-    };
+    return { extension: extensionOf(new URL(response.url).pathname) };
   }
+}
+
+// The extension of the last path segment, dot included, or '' when that
+// segment has none. Confined to the last segment so a dotless filename under a
+// dotted directory reports no extension rather than borrowing the directory's.
+function extensionOf(pathname: string): string {
+  let filename = pathname.split('/').pop() ?? '';
+  let dot = filename.lastIndexOf('.');
+  return dot === -1 ? '' : filename.slice(dot);
 }
 
 function isCodeRefType(type: any): type is CodeRefType {

--- a/packages/host/app/services/card-type-service.ts
+++ b/packages/host/app/services/card-type-service.ts
@@ -60,11 +60,10 @@ export default class CardTypeService extends Service {
   // traversal stack. Sharing in-flight promises across roots keyed on the type
   // alone would close that cycle through the cache instead of the recursion,
   // where no stack can see it, and the two roots would await each other
-  // forever. Sharing keyed on the traversal stack as well as the type would be
-  // safe — every recursive call extends the stack, so those await edges only
-  // ever point deeper — and would collapse the sibling fields that share a
-  // type into one traversal. The cache is settled-only because it does not
-  // make that distinction, not because no sharing is possible.
+  // forever. The cache is settled-only because it cannot tell those roots
+  // apart, not because sharing is impossible: sharing that also accounts for
+  // the traversal stack is safe, and `toType` does exactly that for the fields
+  // of one card, where the stack is fixed.
   private typeCache: Map<string, Type> = new Map();
 
   // The in-flight promise, not the settled value. A card's fields are assembled
@@ -241,7 +240,11 @@ export default class CardTypeService extends Service {
         } - ${await response.text()}`,
       );
     }
-    return { extension: extensionOf(new URL(response.url).pathname) };
+    // A handler that answers from memory rather than the network leaves
+    // `response.url` empty, so fall back to what was asked for. That spelling
+    // has no extension to give, which is the honest answer for a module that
+    // was never resolved to a file.
+    return { extension: extensionOfURL(response.url || url.href) };
   }
 }
 

--- a/packages/host/tests/integration/services/card-type-service-test.gts
+++ b/packages/host/tests/integration/services/card-type-service-test.gts
@@ -22,6 +22,9 @@ const COLORISH_FIELD_COUNT = 8;
 module('Integration | services | card-type-service', function (hooks) {
   let loader: Loader;
   let requestLog: string[] = [];
+  // When set, the recorder answers the next request whose URL starts with this
+  // prefix with a 500 instead of passing it through.
+  let failNextRequestTo: string | undefined;
 
   setupRenderingTest(hooks);
   setupLocalIndexing(hooks);
@@ -63,27 +66,44 @@ module('Integration | services | card-type-service', function (hooks) {
     });
   });
 
-  // Registered last so the wrapper is in place for the measured call and not
+  // Registered last so the recorder is in place for the measured call and not
   // for the realm setup above, whose own requests are of no interest here.
+  // `NetworkService.virtualNetwork` is an instance field and each test gets its
+  // own owner, so this records one test's traffic and cannot carry into the
+  // next. It does not survive `NetworkService.resetState()`, which replaces the
+  // whole VirtualNetwork — hence the positive controls below, which fail rather
+  // than pass silently if the recorder is no longer on the network in use.
   hooks.beforeEach(function () {
     let { virtualNetwork } = getService('network');
     let inner = virtualNetwork.fetch;
     virtualNetwork.fetch = ((...args: Parameters<typeof inner>) => {
       let [input] = args;
-      requestLog.push(
+      let url =
         typeof input === 'string'
           ? input
           : input instanceof URL
             ? input.href
-            : input.url,
-      );
+            : input.url;
+      requestLog.push(url);
+      let fail = failNextRequestTo;
+      if (fail && url.startsWith(fail)) {
+        failNextRequestTo = undefined;
+        return Promise.resolve(
+          new Response('boom', { status: 500, statusText: 'Server Error' }),
+        );
+      }
       return inner(...args);
     }) as typeof inner;
   });
 
   hooks.afterEach(function () {
     requestLog = [];
+    failNextRequestTo = undefined;
   });
+
+  function requestsFor(prefix: string) {
+    return requestLog.filter((url) => url.startsWith(prefix));
+  }
 
   test('fields sharing a type fetch that shared module once between them', async function (assert) {
     let { ThemeField } = (await loader.import(`${testRealmURL}theme`)) as {
@@ -106,9 +126,7 @@ module('Integration | services | card-type-service', function (hooks) {
       'the fields all resolved to the shared field type',
     );
 
-    let colorishRequests = requestLog.filter((url) =>
-      url.startsWith(`${testRealmURL}colorish`),
-    );
+    let colorishRequests = requestsFor(`${testRealmURL}colorish`);
     assert.strictEqual(
       colorishRequests.length,
       1,
@@ -131,13 +149,48 @@ module('Integration | services | card-type-service', function (hooks) {
       'the module info that is assembled is the file extension',
     );
 
-    let realmInfoRequests = requestLog.filter((url) =>
-      new URL(url).pathname.endsWith('/_info'),
+    // Positive control: an absence assertion over a recording is only worth
+    // anything once the recording is known to have caught the traffic it is
+    // being asked about.
+    assert.strictEqual(
+      requestsFor(`${testRealmURL}colorish`).length,
+      1,
+      'the recorder observed the assembly it is being asked about',
     );
     assert.deepEqual(
-      realmInfoRequests,
+      requestLog.filter((url) => new URL(url).pathname.endsWith('/_info')),
       [],
       'nothing about an assembled type depends on realm info',
+    );
+  });
+
+  test('a failed module-info fetch is not cached, so the next assembly retries', async function (assert) {
+    let { ThemeField } = (await loader.import(`${testRealmURL}theme`)) as {
+      ThemeField: typeof BaseDef;
+    };
+    let cardTypeService = getService('card-type-service');
+    cardTypeService.invalidateAllCaches();
+    requestLog.length = 0;
+
+    failNextRequestTo = `${testRealmURL}colorish`;
+    await assert.rejects(
+      cardTypeService.assembleType(ThemeField),
+      /status 500/,
+      'the transient failure surfaces to the caller',
+    );
+    assert.strictEqual(
+      failNextRequestTo,
+      undefined,
+      'the one-shot failure was actually served',
+    );
+
+    // Without eviction the rejected promise stays in the cache and every later
+    // assembly for this loader replays that one failure.
+    let type: Type = await cardTypeService.assembleType(ThemeField);
+    assert.deepEqual(
+      [...new Set(type.fields.map((f) => (f.card as Type).displayName))],
+      ['Colorish'],
+      'the retry assembles the type it failed to assemble before',
     );
   });
 });

--- a/packages/host/tests/integration/services/card-type-service-test.gts
+++ b/packages/host/tests/integration/services/card-type-service-test.gts
@@ -1,0 +1,143 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import type { Type } from '@cardstack/host/services/card-type-service';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+import type { BaseDef } from '@cardstack/base/card-api';
+
+const COLORISH_FIELD_COUNT = 8;
+
+module('Integration | services | card-type-service', function (hooks) {
+  let loader: Loader;
+  let requestLog: string[] = [];
+
+  setupRenderingTest(hooks);
+  setupLocalIndexing(hooks);
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [baseRealm.url, testRealmURL],
+    autostart: true,
+  });
+  setupBaseRealm(hooks);
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'colorish.gts': `
+          import StringField from 'https://cardstack.com/base/string';
+          export default class ColorishField extends StringField {
+            static displayName = 'Colorish';
+          }
+        `,
+        'theme.gts': `
+          import { contains, field, FieldDef } from 'https://cardstack.com/base/card-api';
+          import ColorishField from './colorish';
+          export class ThemeField extends FieldDef {
+            static displayName = 'Theme';
+            @field background = contains(ColorishField);
+            @field foreground = contains(ColorishField);
+            @field primary = contains(ColorishField);
+            @field secondary = contains(ColorishField);
+            @field accent = contains(ColorishField);
+            @field muted = contains(ColorishField);
+            @field border = contains(ColorishField);
+            @field ring = contains(ColorishField);
+          }
+        `,
+      },
+    });
+  });
+
+  // Registered last so the wrapper is in place for the measured call and not
+  // for the realm setup above, whose own requests are of no interest here.
+  hooks.beforeEach(function () {
+    let { virtualNetwork } = getService('network');
+    let inner = virtualNetwork.fetch;
+    virtualNetwork.fetch = ((...args: Parameters<typeof inner>) => {
+      let [input] = args;
+      requestLog.push(
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url,
+      );
+      return inner(...args);
+    }) as typeof inner;
+  });
+
+  hooks.afterEach(function () {
+    requestLog = [];
+  });
+
+  test('fields sharing a type fetch that shared module once between them', async function (assert) {
+    let { ThemeField } = (await loader.import(`${testRealmURL}theme`)) as {
+      ThemeField: typeof BaseDef;
+    };
+    let cardTypeService = getService('card-type-service');
+    cardTypeService.invalidateAllCaches();
+    requestLog.length = 0;
+
+    let type: Type = await cardTypeService.assembleType(ThemeField);
+
+    assert.strictEqual(
+      type.fields.length,
+      COLORISH_FIELD_COUNT,
+      'every field was assembled',
+    );
+    assert.deepEqual(
+      [...new Set(type.fields.map((f) => (f.card as Type).displayName))],
+      ['Colorish'],
+      'the fields all resolved to the shared field type',
+    );
+
+    let colorishRequests = requestLog.filter((url) =>
+      url.startsWith(`${testRealmURL}colorish`),
+    );
+    assert.strictEqual(
+      colorishRequests.length,
+      1,
+      `the shared field type's module was requested once, not once per field (got ${colorishRequests.length}: ${colorishRequests.join(', ')})`,
+    );
+  });
+
+  test('assembling a type asks for no realm info', async function (assert) {
+    let { ThemeField } = (await loader.import(`${testRealmURL}theme`)) as {
+      ThemeField: typeof BaseDef;
+    };
+    let cardTypeService = getService('card-type-service');
+    cardTypeService.invalidateAllCaches();
+    requestLog.length = 0;
+
+    let type = await cardTypeService.assembleType(ThemeField);
+    assert.strictEqual(
+      type.moduleInfo.extension,
+      '.gts',
+      'the module info that is assembled is the file extension',
+    );
+
+    let realmInfoRequests = requestLog.filter((url) =>
+      new URL(url).pathname.endsWith('/_info'),
+    );
+    assert.deepEqual(
+      realmInfoRequests,
+      [],
+      'nothing about an assembled type depends on realm info',
+    );
+  });
+});

--- a/packages/host/tests/integration/services/card-type-service-test.gts
+++ b/packages/host/tests/integration/services/card-type-service-test.gts
@@ -141,14 +141,30 @@ module('Integration | services | card-type-service', function (hooks) {
     currentLoader().canonicalURLFor = () => undefined;
   }
 
+  // Sends one request of known shape through the network the service uses and
+  // reports whether the recorder saw it. Lets a test that asserts no requests
+  // were made distinguish that from a recorder that stopped listening.
+  async function recorderIsLive() {
+    let sentinel = `${testRealmURL}__recorder-probe__`;
+    let before = requestLog.length;
+    await getService('network')
+      .virtualNetwork.fetch(sentinel)
+      .catch(() => undefined);
+    let saw = requestLog.slice(before).includes(sentinel);
+    requestLog.length = before;
+    return saw;
+  }
+
   test('assembling a type reads the extension the loader already resolved, without asking the realm', async function (assert) {
     let { ThemeField, cardTypeService } = await importTheme();
 
     let type: Type = await cardTypeService.assembleType(ThemeField);
 
-    // The witness for the absence assertions below: the extension and the
-    // whole field list were produced, so an empty request log means they were
-    // produced without asking the realm, not that nothing happened.
+    // Half the witness for the absence assertions below: the extension and the
+    // whole field list were produced, so nothing was skipped. The other half is
+    // `recorderIsLive` — these assertions read the assembled type rather than
+    // the request log, so on their own they would still hold if the recorder
+    // had been detached and the log were empty for that reason instead.
     assert.strictEqual(
       type.moduleInfo.extension,
       '.gts',
@@ -171,9 +187,17 @@ module('Integration | services | card-type-service', function (hooks) {
       'the module the loader has already placed was not re-requested',
     );
     assert.deepEqual(
-      requestLog.filter((url) => new URL(url).pathname.endsWith('/_info')),
+      requestLog.filter((url) => url.endsWith('/_info')),
       [],
       'nothing about an assembled type depends on realm info',
+    );
+    // The other half of the witness. `NetworkService.resetState()` swaps the
+    // whole VirtualNetwork, which would silently detach the recorder and leave
+    // both assertions above true for a reason that has nothing to do with the
+    // service. A request that is known to have happened has to show up.
+    assert.true(
+      await recorderIsLive(),
+      'the recorder was still attached to the network under test',
     );
   });
 
@@ -232,6 +256,35 @@ module('Integration | services | card-type-service', function (hooks) {
       [...new Set(type.fields.map((f) => (f.card as Type).displayName))],
       ['Colorish'],
       'the retry assembles the type it failed to assemble before',
+    );
+  });
+
+  test('concurrent roots in one module share a single fallback fetch for it', async function (assert) {
+    let { Post, Author } = (await currentLoader().import(
+      `${testRealmURL}linked`,
+    )) as {
+      Post: typeof BaseDef;
+      Author: typeof BaseDef;
+    };
+    let cardTypeService = getService('card-type-service');
+    cardTypeService.invalidateAllCaches();
+    requestLog.length = 0;
+    hideLoaderModuleURLs();
+
+    // Two roots over the same module is the one shape that reaches the
+    // module-info cache with a second caller while the first is still in
+    // flight: within a single root the per-node memo collapses the siblings
+    // before they ever get there.
+    await Promise.all([
+      cardTypeService.assembleType(Post),
+      cardTypeService.assembleType(Author),
+    ]);
+
+    let linkedRequests = requestsFor(`${testRealmURL}linked`);
+    assert.strictEqual(
+      linkedRequests.length,
+      1,
+      `both roots shared one fetch of their module (got ${linkedRequests.length}: ${linkedRequests.join(', ')})`,
     );
   });
 

--- a/packages/host/tests/integration/services/card-type-service-test.gts
+++ b/packages/host/tests/integration/services/card-type-service-test.gts
@@ -2,7 +2,6 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import type { Loader } from '@cardstack/runtime-common/loader';
 
 import type { Type } from '@cardstack/host/services/card-type-service';
 
@@ -20,7 +19,6 @@ import type { BaseDef } from '@cardstack/base/card-api';
 const COLORISH_FIELD_COUNT = 8;
 
 module('Integration | services | card-type-service', function (hooks) {
-  let loader: Loader;
   let requestLog: string[] = [];
   // When set, the recorder answers the next request whose URL starts with this
   // prefix with a 500 instead of passing it through.
@@ -36,8 +34,6 @@ module('Integration | services | card-type-service', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(async function () {
-    loader = getService('loader-service').loader;
-
     await setupIntegrationTestRealm({
       mockMatrixUtils,
       contents: {
@@ -60,6 +56,20 @@ module('Integration | services | card-type-service', function (hooks) {
             @field muted = contains(ColorishField);
             @field border = contains(ColorishField);
             @field ring = contains(ColorishField);
+          }
+        `,
+        // Two cards in one module that link to each other. The module inspector
+        // assembles every declaration in a module concurrently, so these two
+        // become concurrent roots whose traversals reference one another.
+        'linked.gts': `
+          import { field, linksTo, linksToMany, CardDef } from 'https://cardstack.com/base/card-api';
+          export class Post extends CardDef {
+            static displayName = 'Post';
+            @field author = linksTo(() => Author);
+          }
+          export class Author extends CardDef {
+            static displayName = 'Author';
+            @field posts = linksToMany(() => Post);
           }
         `,
       },
@@ -105,16 +115,45 @@ module('Integration | services | card-type-service', function (hooks) {
     return requestLog.filter((url) => url.startsWith(prefix));
   }
 
-  test('fields sharing a type fetch that shared module once between them', async function (assert) {
-    let { ThemeField } = (await loader.import(`${testRealmURL}theme`)) as {
+  // Always the loader the service will itself use, read at call time: the
+  // service resolves `loader-service.loader` on every assembly, and a loader
+  // captured earlier in setup can since have been replaced.
+  function currentLoader() {
+    return getService('loader-service').loader;
+  }
+
+  async function importTheme() {
+    let { ThemeField } = (await currentLoader().import(
+      `${testRealmURL}theme`,
+    )) as {
       ThemeField: typeof BaseDef;
     };
     let cardTypeService = getService('card-type-service');
     cardTypeService.invalidateAllCaches();
     requestLog.length = 0;
+    return { ThemeField, cardTypeService };
+  }
+
+  // Forces the module-info fallback by hiding what the loader knows about
+  // where its modules came from, so the tests below that are about the
+  // fallback exercise it rather than the in-memory path.
+  function hideLoaderModuleURLs() {
+    currentLoader().canonicalURLFor = () => undefined;
+  }
+
+  test('assembling a type reads the extension the loader already resolved, without asking the realm', async function (assert) {
+    let { ThemeField, cardTypeService } = await importTheme();
 
     let type: Type = await cardTypeService.assembleType(ThemeField);
 
+    // The witness for the absence assertions below: the extension and the
+    // whole field list were produced, so an empty request log means they were
+    // produced without asking the realm, not that nothing happened.
+    assert.strictEqual(
+      type.moduleInfo.extension,
+      '.gts',
+      'the extension was resolved',
+    );
     assert.strictEqual(
       type.fields.length,
       COLORISH_FIELD_COUNT,
@@ -126,36 +165,10 @@ module('Integration | services | card-type-service', function (hooks) {
       'the fields all resolved to the shared field type',
     );
 
-    let colorishRequests = requestsFor(`${testRealmURL}colorish`);
-    assert.strictEqual(
-      colorishRequests.length,
-      1,
-      `the shared field type's module was requested once, not once per field (got ${colorishRequests.length}: ${colorishRequests.join(', ')})`,
-    );
-  });
-
-  test('assembling a type asks for no realm info', async function (assert) {
-    let { ThemeField } = (await loader.import(`${testRealmURL}theme`)) as {
-      ThemeField: typeof BaseDef;
-    };
-    let cardTypeService = getService('card-type-service');
-    cardTypeService.invalidateAllCaches();
-    requestLog.length = 0;
-
-    let type = await cardTypeService.assembleType(ThemeField);
-    assert.strictEqual(
-      type.moduleInfo.extension,
-      '.gts',
-      'the module info that is assembled is the file extension',
-    );
-
-    // Positive control: an absence assertion over a recording is only worth
-    // anything once the recording is known to have caught the traffic it is
-    // being asked about.
-    assert.strictEqual(
-      requestsFor(`${testRealmURL}colorish`).length,
-      1,
-      'the recorder observed the assembly it is being asked about',
+    assert.deepEqual(
+      requestsFor(`${testRealmURL}colorish`),
+      [],
+      'the module the loader has already placed was not re-requested',
     );
     assert.deepEqual(
       requestLog.filter((url) => new URL(url).pathname.endsWith('/_info')),
@@ -164,13 +177,41 @@ module('Integration | services | card-type-service', function (hooks) {
     );
   });
 
-  test('a failed module-info fetch is not cached, so the next assembly retries', async function (assert) {
-    let { ThemeField } = (await loader.import(`${testRealmURL}theme`)) as {
-      ThemeField: typeof BaseDef;
-    };
-    let cardTypeService = getService('card-type-service');
-    cardTypeService.invalidateAllCaches();
-    requestLog.length = 0;
+  test('the fields sharing a type resolve to one traversal between them', async function (assert) {
+    let { ThemeField, cardTypeService } = await importTheme();
+
+    let type: Type = await cardTypeService.assembleType(ThemeField);
+    let resolved = type.fields.map((f) => f.card as Type);
+
+    assert.strictEqual(
+      new Set(resolved).size,
+      1,
+      `all ${COLORISH_FIELD_COUNT} fields share one assembled type, rather than each building its own (got ${new Set(resolved).size} distinct)`,
+    );
+  });
+
+  test('the fallback fetches a shared module once for all the fields that share it', async function (assert) {
+    let { ThemeField, cardTypeService } = await importTheme();
+    hideLoaderModuleURLs();
+
+    let type: Type = await cardTypeService.assembleType(ThemeField);
+    assert.strictEqual(
+      type.moduleInfo.extension,
+      '.gts',
+      'the fallback resolved the extension',
+    );
+
+    let colorishRequests = requestsFor(`${testRealmURL}colorish`);
+    assert.strictEqual(
+      colorishRequests.length,
+      1,
+      `the shared field type's module was requested once, not once per field (got ${colorishRequests.length}: ${colorishRequests.join(', ')})`,
+    );
+  });
+
+  test('a failed fallback fetch is not cached, so the next assembly retries', async function (assert) {
+    let { ThemeField, cardTypeService } = await importTheme();
+    hideLoaderModuleURLs();
 
     failNextRequestTo = `${testRealmURL}colorish`;
     await assert.rejects(
@@ -191,6 +232,42 @@ module('Integration | services | card-type-service', function (hooks) {
       [...new Set(type.fields.map((f) => (f.card as Type).displayName))],
       ['Colorish'],
       'the retry assembles the type it failed to assemble before',
+    );
+  });
+
+  test('mutually-referencing declarations in one module assemble concurrently', async function (assert) {
+    let { Post, Author } = (await currentLoader().import(
+      `${testRealmURL}linked`,
+    )) as {
+      Post: typeof BaseDef;
+      Author: typeof BaseDef;
+    };
+    let cardTypeService = getService('card-type-service');
+    cardTypeService.invalidateAllCaches();
+
+    // How the module inspector assembles a module: one root per declaration,
+    // all at once. `Post` references `Author` and `Author` references `Post`,
+    // so each root's traversal reaches the other. Sharing in-flight type
+    // promises across roots would leave these two awaiting each other and this
+    // would never settle.
+    let [postType, authorType] = (await Promise.all([
+      cardTypeService.assembleType(Post),
+      cardTypeService.assembleType(Author),
+    ])) as [Type, Type];
+
+    assert.strictEqual(postType.displayName, 'Post', 'the Post root settled');
+    assert.strictEqual(
+      authorType.displayName,
+      'Author',
+      'the Author root settled',
+    );
+    assert.ok(
+      postType.fields.some((f) => f.name === 'author'),
+      'the Post root resolved its link to Author',
+    );
+    assert.ok(
+      authorType.fields.some((f) => f.name === 'posts'),
+      'the Author root resolved its link to Post',
     );
   });
 });

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -716,13 +716,14 @@ export class Loader {
     return [...this.modules.keys()];
   }
 
-  // The URL this loader actually loaded a module from: the resolved spelling,
-  // extension included, which the extensionless and alias forms of the same
-  // identifier do not carry. A caller holding something this loader exported
-  // can ask where it came from without going back to the network. Undefined
-  // for a module this loader has not loaded, and for an identifier that does
-  // not resolve to a URL — a shim registered under a bare specifier is
-  // recorded under that specifier, so the answer is not always a URL.
+  // Where this loader got a module from, in the spelling it recorded: for a
+  // fetched module the resolved URL, extension included, which the
+  // extensionless and alias forms of the same identifier do not carry. A
+  // caller holding something this loader exported can ask where it came from
+  // without going back to the network. Undefined for a module this loader has
+  // not loaded. Not always a URL — `shimModule` records a shim under the
+  // identifier it was registered with, so a bare specifier comes back as
+  // itself; callers that need a URL must parse defensively.
   canonicalURLFor(moduleIdentifier: string): string | undefined {
     try {
       return this.getCanonicalModuleURL(this.resolveImport(moduleIdentifier));

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -716,6 +716,24 @@ export class Loader {
     return [...this.modules.keys()];
   }
 
+  // The URL this loader actually loaded a module from: the resolved spelling,
+  // extension included, which the extensionless and alias forms of the same
+  // identifier do not carry. A caller holding something this loader exported
+  // can ask where it came from without going back to the network. Undefined
+  // for a module this loader has not loaded, and for an identifier that does
+  // not resolve to a URL — a shim registered under a bare specifier is
+  // recorded under that specifier, so the answer is not always a URL.
+  canonicalURLFor(moduleIdentifier: string): string | undefined {
+    try {
+      return this.getCanonicalModuleURL(this.resolveImport(moduleIdentifier));
+    } catch (e) {
+      if (e instanceof TypeError) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
   // Synchronous sibling of `getConsumedModules` limited to modules already
   // known to this loader. Output is in the same canonical identifier form:
   // realm-prefix (RRI) spelling where a prefix mapping is registered,


### PR DESCRIPTION
## Background

Code mode's **schema view** (the "module inspector" panel listing a card
definition's fields, their types, and its ancestry) is driven by
`CardTypeService`. Given a card or field class it produces a `Type` — a plain
object describing that definition: display name, code ref, its superclass's
`Type`, and one entry per field carrying that field's own `Type`. It builds
this by walking the definition's type graph recursively: for each node it
resolves the superclass, then every field, each of which is itself a definition
with its own superclass and fields.

Each node also needs one thing not available from the class object: **the file
extension of the module the definition lives in**. The detail panel renders it
as a file-type indicator beside each type. A code ref names its module without
an extension — `https://cardstack.com/base/color` — and the realm resolves that
to whichever file backs it, `color.gts`.

## The problem

Getting that extension meant asking the realm: request the module with the
card-source `Accept` header and read the extension off the URL the realm
redirects to. One HTTP request per node in the walk — and alongside it, a
lookup of the realm's `_info` document, so **two** requests per node.

A definition's fields are resolved concurrently, and both of the service's
caches only ever held *settled* values, written after the work finished. So
when several fields shared a type, all of them reached their cache lookup
before the first finished, all missed, all recursed, and all issued their own
pair of requests.

Card definitions holding many fields of one type are where this bites, and
theme definitions are full of them: `base/structured-theme-variables.gts`
declares 28 `ColorField`, 13 `CSSValueField` and 5 `TypographyField` fields on
one field def. Opening it in the schema view issued 34 requests for
`base/color`, 24 for `base/css-value`, 6 for `base/typography`, and 65 realm
`_info` queries — for a value nothing has ever read.

Measured with an instrumented `fetch`, opening that file in the schema view:

|                           | before | after |
| ------------------------- | -----: | ----: |
| `QUERY base/_info`        |     65 |     0 |
| `GET base/color`          |     34 |     1 |
| `GET base/css-value`      |     24 |     1 |
| `GET base/typography`     |      6 |     1 |
| total fetches on the page |    312 |   178 |

The one request per module that remains is the loader loading the module, which
is real work. The schema view itself now adds none.

## The change

**The extension comes from the loader.** `Loader` already records the resolved,
extension-bearing URL of every module it imports, and a definition we hold a
class for has necessarily been imported — so the answer is already in memory.
`Loader.canonicalURLFor()` exposes it. The old fetch survives as a fallback for
a module the loader cannot place: a shim registered under a bare specifier, or
a loader replaced since the class was captured. That fallback keeps the
in-flight promise in its cache, so if it is ever reached, the fields sharing a
module still share one request rather than one each. A rejection is evicted —
scoped to the promise that failed, so a cache cleared and repopulated meanwhile
keeps its newer entry — because a failed fetch is a property of that attempt,
not of the module.

**The realm `_info` lookup is gone.** The `realmInfo` it produced had no reader;
`moduleInfo.extension` is the only part of the assembled module info anything
consumes. `CardService.getRealmInfoByRealmURL` existed solely to serve it and
had no other caller, so it goes too. Everything that genuinely needs realm info
uses `RealmService`, which caches it properly.

**Fields sharing a type share one traversal.** All of a card's fields resolve
against the same traversal stack, so one shared promise per distinct field type
collapses them. This is confined to a single node's fan-out, which is what
makes it safe — see below.

**Extension parsing.** It was `'.' + pathname.split('.').pop() || ''`, which
parses as `('.' + pop()) || ''`: the fallback is unreachable, and a response URL
whose filename carries no dot yielded the whole path behind a dot. It now takes
the extension off the last path segment and returns `''` when there is none.

### Why the type cache is still settled-only

Sharing in-flight promises **keyed on the type alone, across roots** would
deadlock. Type assembly breaks reference cycles with a traversal stack: each
recursive step carries the definitions already on its path, and one that
reappears on its own path is returned as a bare code ref rather than expanded
again. That stack is per-root, and the module inspector assembles **every
declaration in a module concurrently** — one root each. Two of those roots can
reference each other, which is an ordinary way to model data: a `Post` linking
to its `Author` and an `Author` linking to their `Post`s, both exported from one
module. Sharing across roots would have `Post` await the pending `Author` and
`Author` await the pending `Post`, with the cycle closed through the cache where
no traversal stack can see it. Both roots hang and the schema view never
renders.

The new per-node memo is not that. It is scoped to one node's fan-out, so a
shared promise is only ever awaited by its siblings, and everything it awaits in
turn sits deeper in the stack. Those await edges only point away from the
sharers and cannot close a cycle.

## Where the changes live

- `packages/runtime-common/loader.ts` — new public `canonicalURLFor()`.
- `packages/host/app/services/card-type-service.ts` — extension read from the
  loader with the fetch as fallback; `realmInfo` dropped; the per-node memo;
  extension parsing.
- `packages/host/app/services/card-service.ts` — removes the now-unused
  `getRealmInfoByRealmURL`.
- `packages/host/tests/integration/services/card-type-service-test.gts` — new.
- `packages/boxel-cli/tests/integration/{realm-ingest-card,search}.test.ts` —
  an unrelated CI flake this PR kept tripping, fixed here rather than left to
  recur. Those files run sequentially in one fork, so the
  `EADDRINUSE: 127.0.0.1:4460` that fails the second is not a race with the
  first: it is the first's teardown never finishing. That `afterAll` stops a
  realm server and a browser-backed prerender server, takes no timeout
  argument, and so gets vitest's 10s default while its own `beforeAll` gets
  600s. When it trips it aborts the `stopTestPrerenderServer()` call that
  exists precisely to keep the next file off that port. Both now budget
  teardown like setup. (This is why the PR title carries a `fix:` prefix — it
  touches `packages/boxel-cli/**`, which drives that package's npm version
  bump.)

## Testing

Five integration tests over a realm holding a field def whose 8 fields all
share one field type, with the virtual network wrapped to record requests:

- the extension is read from the loader — **zero** requests for the field
  module and zero `_info`, with the assembled extension and full field list as
  the witness, so an empty log cannot pass vacuously;
- the fields sharing a type resolve to a single assembled type object rather
  than one each;
- with the loader's records hidden, the fallback fetches the shared module
  once for all 8 fields, not once per field;
- a failed fallback fetch is evicted, so the next assembly retries and succeeds
  (verified to fail without the eviction: the cached rejection replays);
- two roots over one module share a single fallback fetch — the only shape
  that reaches the module-info cache with a second caller while the first is
  in flight, since the per-node memo collapses a card's own fields before they
  get there (verified to report 3 requests instead of 1 without the sharing);
- two mutually-referencing cards exported from one module assemble as
  concurrent roots and both settle — the shape that hangs if the sharing above
  is widened wrongly.

Both absence assertions carry a live-recorder witness: a sentinel request is
sent through the network under test and must show up, so a recorder detached
by a `NetworkService` reset fails the test rather than satisfying it with an
empty log.

Also run locally against a full dev stack: `code submode | schema editor`
(15 tests, 92 assertions), `code submode | inspector` (55 tests, 369
assertions), `Acceptance | Spec preview` (28 tests, 117 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
