### PR TITLE
Report a missing linked file as that file

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -7,6 +7,7 @@ import {
   BrokenLinkTemplate,
   CopyButton,
   type BrokenLinkFormat,
+  type BrokenLinkItemType,
 } from '@cardstack/boxel-ui/components';
 import {
   markdownEscape,
@@ -104,6 +105,7 @@ import {
   type VirtualNetwork,
   isDirectIndexedFieldKey,
   cardTypeName,
+  fileNameFromUrl,
   isDeclaredScreenshotFormat,
   isValidScreenshotName,
   DECLARED_SCREENSHOT_FORMATS,
@@ -1747,7 +1749,11 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
                   @errorDoc={{broken.errorDoc}}
                   @state={{broken.kind}}
                   @format={{brokenLinkFormat @format defaultFormats.cardDef}}
-                  @displayName={{cardTypeName broken.reference}}
+                  @itemType={{brokenLinkItemType linksToField}}
+                  @displayName={{brokenLinkDisplayName
+                    linksToField
+                    broken.reference
+                  }}
                   @viewCard={{cardCrudFunctions.viewCard}}
                   ...attributes
                 />
@@ -2403,6 +2409,29 @@ export function brokenLinkFormat(
     default:
       return 'embedded';
   }
+}
+
+// What the placeholder says is missing. A `linksTo(FileDef)` slot holds a file,
+// so its failure reads as a missing file rather than a missing card.
+export function brokenLinkItemType(
+  field: Field<LinkableDefConstructor>,
+): BrokenLinkItemType {
+  return isFileDef(field.card) ? 'file' : 'card';
+}
+
+// The label the placeholder shows next to the link-off icon. The two reference
+// shapes name themselves in different segments: a card instance url is
+// `<Type>/<id>`, whose readable name is the type; a file url is a path, whose
+// readable name is the file name. Reading a file url as a card reference names
+// the directory that happens to sit second-to-last — `images` for a missing
+// `images/photo.jpg` — which points a reader at nothing.
+export function brokenLinkDisplayName(
+  field: Field<LinkableDefConstructor>,
+  reference: string,
+): string {
+  return isFileDef(field.card)
+    ? fileNameFromUrl(reference)
+    : cardTypeName(reference);
 }
 
 function fieldComponent(

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -106,6 +106,7 @@ import {
   isDirectIndexedFieldKey,
   cardTypeName,
   fileNameFromUrl,
+  referenceNamesFile,
   isDeclaredScreenshotFormat,
   isValidScreenshotName,
   DECLARED_SCREENSHOT_FORMATS,
@@ -4223,8 +4224,17 @@ function lazilyLoadLink(
         (isCardError(error) && error.status === 404) ||
         (typeof error?.message === 'string' &&
           /not found/i.test(error.message));
+      // The realm file the broken reference stands for: a card instance is
+      // served out of `<id>.json`, while a reference that names a file is
+      // already the file. The field's own type settles it when the field is
+      // declared to hold a file; otherwise the reference's shape does, judged
+      // by a registered extension rather than by a dot, so a card id that
+      // carries one keeps the `.json` its row is keyed on. This string is both
+      // what the reader is told is missing and the dep invalidation watches, so
+      // a `.json` appended to a file path names a row that can never appear and
+      // the mended link never reaches this consumer.
       let referenceForMissingFile =
-        isFileLink || reference.endsWith('.json')
+        isFileLink || referenceNamesFile(reference)
           ? reference
           : `${reference}.json`;
       let payloadError: Pick<SerializedError, 'status' | 'message'> &

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -14,6 +14,8 @@ import {
   type Field,
   type CardContext,
   type LinkableDefConstructor,
+  brokenLinkDisplayName,
+  brokenLinkItemType,
   CreateCardFn,
   isFileDef,
 } from './card-api';
@@ -28,7 +30,6 @@ import {
   Loader,
   type ResolvedCodeRef,
   isCardInstance,
-  cardTypeName,
 } from '@cardstack/runtime-common';
 import {
   BrokenLinkTemplate,
@@ -113,7 +114,11 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
               @errorDoc={{@brokenLink.errorDoc}}
               @state={{@brokenLink.kind}}
               @format='embedded'
-              @displayName={{cardTypeName @brokenLink.reference}}
+              @itemType={{brokenLinkItemType @field}}
+              @displayName={{brokenLinkDisplayName
+                @field
+                @brokenLink.reference
+              }}
               @viewCard={{crud.viewCard}}
             />
           </CardCrudFunctionsConsumer>

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -14,7 +14,9 @@ import {
   CreateCardFn,
   CardCrudFunctions,
   isFileDef,
+  brokenLinkDisplayName,
   brokenLinkFormat,
+  brokenLinkItemType,
 } from './card-api';
 import {
   getRelationshipMembershipState,
@@ -50,7 +52,6 @@ import {
   uuidv4,
   CardCrudFunctionsContextName,
   CardErrorJSONAPI,
-  cardTypeName,
 } from '@cardstack/runtime-common';
 import {
   IconMinusCircle,
@@ -312,7 +313,11 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
                     @errorDoc={{entry.broken.errorDoc}}
                     @state={{entry.broken.kind}}
                     @format='fitted'
-                    @displayName={{cardTypeName entry.broken.reference}}
+                    @itemType={{brokenLinkItemType @field}}
+                    @displayName={{brokenLinkDisplayName
+                      @field
+                      entry.broken.reference
+                    }}
                     @viewCard={{crud.viewCard}}
                     data-test-plural-view-item={{entry.index}}
                   />
@@ -473,7 +478,11 @@ class LinksToManyCompactEditor extends GlimmerComponent<LinksToManyCompactEditor
                     @errorDoc={{broken.errorDoc}}
                     @state={{broken.kind}}
                     @format='atom'
-                    @displayName={{cardTypeName broken.reference}}
+                    @itemType={{brokenLinkItemType @field}}
+                    @displayName={{brokenLinkDisplayName
+                      @field
+                      broken.reference
+                    }}
                     @viewCard={{crud.viewCard}}
                     data-test-plural-view-item={{i}}
                   />
@@ -732,7 +741,11 @@ export function getLinksToManyComponent({
                               effectiveFormat
                               effectiveFormat
                             }}
-                            @displayName={{cardTypeName broken.reference}}
+                            @itemType={{brokenLinkItemType field}}
+                            @displayName={{brokenLinkDisplayName
+                              field
+                              broken.reference
+                            }}
                             @viewCard={{crud.viewCard}}
                             data-test-plural-view-item={{i}}
                           />

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -3074,19 +3074,8 @@ export default class StoreService extends Service implements StoreInterface {
     });
     let result = await extractor.extract();
     if (result.status === 'error' || !result.resource) {
-      // Carry the extract's own status through. A file the realm does not hold
-      // fails with the fetch's 404, and that status is what tells the link
-      // producer it is looking at a missing file rather than a file that blew
-      // up while being read — the difference between the "Link Not Found"
-      // placeholder a reader can act on and a generic error. Anything without
-      // a usable status is a genuine extract failure, so 500 stands.
-      let failure = result.error?.error;
-      let msg = failure?.message ?? 'File extract failed';
-      let status =
-        typeof failure?.status === 'number' && failure.status >= 400
-          ? failure.status
-          : 500;
-      return new CardError(msg, { status });
+      let msg = result.error?.error?.message ?? 'File extract failed';
+      return new CardError(msg, { status: 500 });
     }
     return { data: result.resource };
   }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -3074,8 +3074,19 @@ export default class StoreService extends Service implements StoreInterface {
     });
     let result = await extractor.extract();
     if (result.status === 'error' || !result.resource) {
-      let msg = result.error?.error?.message ?? 'File extract failed';
-      return new CardError(msg, { status: 500 });
+      // Carry the extract's own status through. A file the realm does not hold
+      // fails with the fetch's 404, and that status is what tells the link
+      // producer it is looking at a missing file rather than a file that blew
+      // up while being read — the difference between the "Link Not Found"
+      // placeholder a reader can act on and a generic error. Anything without
+      // a usable status is a genuine extract failure, so 500 stands.
+      let failure = result.error?.error;
+      let msg = failure?.message ?? 'File extract failed';
+      let status =
+        typeof failure?.status === 'number' && failure.status >= 400
+          ? failure.status
+          : 500;
+      return new CardError(msg, { status });
     }
     return { data: result.resource };
   }

--- a/packages/host/app/utils/render-error.ts
+++ b/packages/host/app/utils/render-error.ts
@@ -1,4 +1,5 @@
 import {
+  hasExtension,
   loadCardDef,
   type Loader,
   type LooseSingleCardDocument,
@@ -128,16 +129,21 @@ function applyAuthMessageOverrides(renderError: RenderError): RenderError {
   return renderError;
 }
 
+// Recover the reference a `missing file <ref>` message names, as the realm
+// file that reference stands for. A card instance id carries no extension —
+// `<realm>/Widget/w-1` is served out of the file `<realm>/Widget/w-1.json` —
+// so the `.json` form is the file to report and the dep to invalidate on.
+// A reference that already names a file (an uploaded image, a module, a
+// markdown doc) is that file: suffixing it would name a path the realm has
+// never held, which is worse than useless in an error a human reads and in a
+// dep the indexer watches.
 function extractMissingRefFromMessage(message: string): string | undefined {
   let match = /^missing file (.+?)(?: not found)?$/i.exec(message.trim());
-  if (match?.[1]) {
-    let ref = match[1].trim();
-    if (!ref.endsWith('.json')) {
-      ref = `${ref}.json`;
-    }
-    return ref;
+  if (!match?.[1]) {
+    return undefined;
   }
-  return undefined;
+  let ref = match[1].trim();
+  return hasExtension(ref) ? ref : `${ref}.json`;
 }
 
 function normalizeId(id: string, context?: RenderErrorContext): string {

--- a/packages/host/app/utils/render-error.ts
+++ b/packages/host/app/utils/render-error.ts
@@ -1,10 +1,10 @@
 import {
-  hasExtension,
   loadCardDef,
   type Loader,
   type LooseSingleCardDocument,
   isCardError,
   type RenderError,
+  referenceNamesFile,
   rri,
   trimExecutableExtension,
 } from '@cardstack/runtime-common';
@@ -129,21 +129,20 @@ function applyAuthMessageOverrides(renderError: RenderError): RenderError {
   return renderError;
 }
 
-// Recover the reference a `missing file <ref>` message names, as the realm
-// file that reference stands for. A card instance id carries no extension —
-// `<realm>/Widget/w-1` is served out of the file `<realm>/Widget/w-1.json` —
-// so the `.json` form is the file to report and the dep to invalidate on.
-// A reference that already names a file (an uploaded image, a module, a
-// markdown doc) is that file: suffixing it would name a path the realm has
-// never held, which is worse than useless in an error a human reads and in a
-// dep the indexer watches.
+// Recover the reference a `missing file <ref>` message names, as the realm file
+// that reference stands for. That file is the one reported to a reader and the
+// dep invalidation watches, so the two reference shapes resolve differently: a
+// card instance is served out of `<id>.json`, while a reference that names a
+// file is already the file. `referenceNamesFile` draws the line at a registered
+// extension rather than at a dot, so a card id that carries one keeps the
+// `.json` its row is keyed on.
 function extractMissingRefFromMessage(message: string): string | undefined {
   let match = /^missing file (.+?)(?: not found)?$/i.exec(message.trim());
   if (!match?.[1]) {
     return undefined;
   }
   let ref = match[1].trim();
-  return hasExtension(ref) ? ref : `${ref}.json`;
+  return referenceNamesFile(ref) ? ref : `${ref}.json`;
 }
 
 function normalizeId(id: string, context?: RenderErrorContext): string {

--- a/packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts
+++ b/packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts
@@ -27,6 +27,7 @@ import {
   field,
   FileDef,
   getDataBucket,
+  getRelationshipMembershipState,
   linksTo,
   setupBaseRealm,
   StringField,
@@ -523,6 +524,54 @@ module(
           MISSING_IMAGE_URL,
           'the reference is the file path the realm is missing',
         );
+    });
+
+    test('a broken link to a file path reports that path, not a .json beside it', async function (assert) {
+      await setupRealm();
+      // A `linksTo` declared to hold a card, holding a reference that names a
+      // file. The realm holds no such file, so reading the link 404s and the
+      // producer plants the sentinel from a real failure rather than a
+      // hand-written one.
+      let person = await createPerson({
+        pet: { links: { self: MISSING_IMAGE_URL } },
+      });
+
+      await renderCard(loader, person, 'isolated');
+      await waitFor('[data-test-broken-link-template]');
+
+      let slot = getRelationshipMembershipState(person, 'pet').membership?.[0];
+      assert.strictEqual(slot?.kind, 'not-found', 'the link reports not-found');
+      assert.strictEqual(
+        slot?.kind === 'not-found' ? slot.errorDoc.message : undefined,
+        `missing file ${MISSING_IMAGE_URL}`,
+        'the failure names the file path itself, with no .json appended',
+      );
+      assert.deepEqual(
+        slot?.kind === 'not-found' ? slot.errorDoc.deps : undefined,
+        [MISSING_IMAGE_URL],
+        'the dep invalidation watches is the file path, which a row can be keyed on',
+      );
+    });
+
+    test('a broken link to a dotted card id reports its .json file', async function (assert) {
+      await setupRealm();
+      // `.6` is not a registered file extension, so the dot belongs to the id.
+      // The realm serves such an instance out of `<id>.json`, which is the file
+      // to report and the dep to watch.
+      let dottedId = `${testRealmURL}ModelConfiguration/claude-sonnet-4.6`;
+      let person = await createPerson({
+        pet: { links: { self: dottedId } },
+      });
+
+      await renderCard(loader, person, 'isolated');
+      await waitFor('[data-test-broken-link-template]');
+
+      let slot = getRelationshipMembershipState(person, 'pet').membership?.[0];
+      assert.strictEqual(
+        slot?.kind === 'not-found' ? slot.errorDoc.message : undefined,
+        `missing file ${dottedId}.json`,
+        'a dotted card id keeps the .json its row is keyed on',
+      );
     });
 
     test('a broken card link is labelled by its card type', async function (assert) {

--- a/packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts
+++ b/packages/host/tests/integration/components/linksto-broken-link-placeholder-test.gts
@@ -25,6 +25,7 @@ import {
   Component,
   contains,
   field,
+  FileDef,
   getDataBucket,
   linksTo,
   setupBaseRealm,
@@ -37,6 +38,10 @@ import { setupRenderingTest } from '../../helpers/setup';
 import type { CardDef as CardDefType } from '@cardstack/base/card-api';
 
 const GHOST_URL = `${testRealmURL}Pet/ghost`;
+// A file reference is a path, so the realm never holds a `.json` alongside it —
+// the placeholder has to read it as the file it names rather than as the
+// `<Type>/<id>` shape a card reference has.
+const MISSING_IMAGE_URL = `${testRealmURL}Widget/images/photo.jpg`;
 
 // The cards are declared inside a helper rather than at module scope because the
 // base-realm helpers (CardDef, field, …) are only populated once
@@ -71,6 +76,15 @@ function makeCards() {
       </template>
     };
   }
+  // A `linksTo(FileDef)` field: the slot holds a file, so its broken state has
+  // to read as a missing file rather than a missing card.
+  class Widget extends CardDef {
+    static displayName = 'Widget';
+    @field photo = linksTo(FileDef);
+    static isolated = class extends Component<typeof Widget> {
+      <template><@fields.photo @format='embedded' /></template>
+    };
+  }
   class Person extends CardDef {
     static displayName = 'Person';
     @field firstName = contains(StringField);
@@ -93,7 +107,7 @@ function makeCards() {
       <template><@fields.pet /></template>
     };
   }
-  return { Person, Pet };
+  return { Person, Pet, Widget };
 }
 
 // Drive a real lazy-load failure: the realm never holds `Pet/ghost`, so reading
@@ -106,6 +120,19 @@ async function createPerson(
     attributes: { firstName: 'Hassan' },
     relationships,
     meta: { adoptsFrom: { module: testRRI('test-cards'), name: 'Person' } },
+  };
+  return (await store.__dangerousCreateFromSerialized(
+    resource,
+    { data: resource },
+    new URL(testRealmURL),
+  )) as CardDefType;
+}
+
+async function createWidget(): Promise<CardDefType> {
+  let store = getService('store');
+  let resource: LooseCardResource = {
+    attributes: {},
+    meta: { adoptsFrom: { module: testRRI('test-cards'), name: 'Widget' } },
   };
   return (await store.__dangerousCreateFromSerialized(
     resource,
@@ -143,11 +170,11 @@ module(
     // Realm holds Person/Pet plus one real Pet (`Pet/mango`); `Pet/ghost` is
     // never present, so links to it resolve to a 404.
     async function setupRealm() {
-      let { Person, Pet } = makeCards();
+      let { Person, Pet, Widget } = makeCards();
       await setupIntegrationTestRealm({
         mockMatrixUtils,
         contents: {
-          'test-cards.gts': { Person, Pet },
+          'test-cards.gts': { Person, Pet, Widget },
           'Pet/mango.json': {
             data: {
               attributes: { firstName: 'Mango' },
@@ -459,6 +486,61 @@ module(
       assert
         .dom('[data-test-add-new="pet"]')
         .doesNotExist('a read-only broken link cannot be replaced');
+    });
+
+    test('a broken file link is labelled by its file name and reads as a missing file', async function (assert) {
+      await setupRealm();
+      let widget = await createWidget();
+      getDataBucket(widget).set('photo', {
+        type: 'link-not-found',
+        reference: MISSING_IMAGE_URL,
+        errorDoc: {
+          status: 404,
+          title: 'Link Not Found',
+          message: `missing file ${MISSING_IMAGE_URL}`,
+          additionalErrors: null,
+        } satisfies SerializedError,
+      });
+
+      await renderCard(loader, widget, 'isolated');
+      await waitFor('[data-test-broken-link-template]');
+
+      assert
+        .dom('[data-test-broken-link-headline]')
+        .hasText(
+          'Linked file not found',
+          'the placeholder names the kind of thing the slot holds',
+        );
+      assert
+        .dom('[data-test-broken-link-type]')
+        .hasText(
+          'photo.jpg',
+          'the label is the file name, not the directory a card reference would read as its type',
+        );
+      assert
+        .dom('[data-test-broken-link-url]')
+        .hasText(
+          MISSING_IMAGE_URL,
+          'the reference is the file path the realm is missing',
+        );
+    });
+
+    test('a broken card link is labelled by its card type', async function (assert) {
+      await setupRealm();
+      let person = await createPerson({
+        pet: { links: { self: GHOST_URL } },
+      });
+
+      await renderCard(loader, person, 'isolated');
+      await waitFor('[data-test-broken-link-template]');
+
+      let embedded = `[data-test-slot='embedded']`;
+      assert
+        .dom(`${embedded} [data-test-broken-link-headline]`)
+        .hasText('Linked card not found');
+      assert
+        .dom(`${embedded} [data-test-broken-link-type]`)
+        .hasText('Pet', 'a card reference is labelled by its type segment');
     });
   },
 );

--- a/packages/host/tests/integration/components/linksto-many-broken-link-placeholder-test.gts
+++ b/packages/host/tests/integration/components/linksto-many-broken-link-placeholder-test.gts
@@ -24,6 +24,7 @@ import {
   Component,
   contains,
   field,
+  FileDef,
   getDataBucket,
   linksToMany,
   setupBaseRealm,
@@ -75,7 +76,16 @@ function makeCards() {
       </template>
     };
   }
-  return { Person, Pet };
+  // A `linksToMany(FileDef)` field: each slot holds a file, so a broken slot
+  // has to read as a missing file rather than a missing card.
+  class Gallery extends CardDef {
+    static displayName = 'Gallery';
+    @field photos = linksToMany(FileDef);
+    static isolated = class extends Component<typeof Gallery> {
+      <template><@fields.photos @format='fitted' /></template>
+    };
+  }
+  return { Person, Pet, Gallery };
 }
 
 // Build a Person attached to the realm-backed store without indexing it, so
@@ -126,11 +136,11 @@ module(
     // Realm holds Person/Pet plus two real Pets (`Pet/mango`, `Pet/vangogh`);
     // `Pet/ghost` is never present, so links to it resolve to a 404.
     async function setupRealm() {
-      let { Person, Pet } = makeCards();
+      let { Person, Pet, Gallery } = makeCards();
       await setupIntegrationTestRealm({
         mockMatrixUtils,
         contents: {
-          'test-cards.gts': { Person, Pet },
+          'test-cards.gts': { Person, Pet, Gallery },
           'Pet/mango.json': {
             data: {
               attributes: { firstName: 'Mango' },
@@ -477,6 +487,51 @@ module(
       assert
         .dom('[data-test-broken-link-template]')
         .exists({ count: 1 }, 'the broken placeholder is still in place');
+    });
+
+    test('a broken file element is labelled by its file name and reads as a missing file', async function (assert) {
+      await setupRealm();
+      let store = getService('store');
+      let resource: LooseCardResource = {
+        attributes: {},
+        meta: {
+          adoptsFrom: { module: testRRI('test-cards'), name: 'Gallery' },
+        },
+      };
+      let gallery = (await store.__dangerousCreateFromSerialized(
+        resource,
+        { data: resource },
+        new URL(testRealmURL),
+      )) as CardDefType;
+      let missingImage = `${testRealmURL}Gallery/images/photo.jpg`;
+      getDataBucket(gallery).set('photos', [
+        {
+          type: 'link-not-found',
+          reference: missingImage,
+          errorDoc: {
+            status: 404,
+            title: 'Link Not Found',
+            message: `missing file ${missingImage}`,
+            additionalErrors: null,
+          } satisfies SerializedError,
+        },
+      ]);
+
+      await renderCard(loader, gallery, 'isolated');
+      await waitFor('[data-test-broken-link-template]');
+
+      assert
+        .dom('[data-test-broken-link-headline]')
+        .hasText(
+          'Linked file not found',
+          'the placeholder names the kind of thing the slot holds',
+        );
+      assert
+        .dom('[data-test-broken-link-type]')
+        .hasText(
+          'photo.jpg',
+          'the label is the file name, not the directory a card reference would read as its type',
+        );
     });
   },
 );

--- a/packages/host/tests/unit/render-error-test.ts
+++ b/packages/host/tests/unit/render-error-test.ts
@@ -84,4 +84,53 @@ module('Unit | render-error', function () {
       'the message names the file the realm is missing, not a .json path it has never held',
     );
   });
+
+  test('a card id containing a dot still resolves to its .json file', function (assert) {
+    let renderError: RenderError = {
+      type: 'instance-error',
+      error: {
+        status: 404,
+        title: 'Not Found',
+        message:
+          'missing file http://test-realm/test/ModelConfiguration/claude-sonnet-4.6',
+        additionalErrors: null,
+      },
+    };
+
+    let normalized = normalizeRenderError(renderError);
+
+    // `.6` is not a registered file extension, so the dot belongs to the id
+    // rather than naming a file. Reading it as an extension would point the
+    // error — and the dep invalidation watches — at a path no row is keyed on.
+    assert.strictEqual(
+      normalized.error.id,
+      'http://test-realm/test/ModelConfiguration/claude-sonnet-4.6.json',
+      'a dotted card id resolves to the file its row is keyed on',
+    );
+    assert.strictEqual(
+      normalized.error.message,
+      'missing file http://test-realm/test/ModelConfiguration/claude-sonnet-4.6.json',
+      'the message names that file',
+    );
+  });
+
+  test('a module reference keeps its executable extension', function (assert) {
+    let renderError: RenderError = {
+      type: 'instance-error',
+      error: {
+        status: 404,
+        title: 'Not Found',
+        message: 'missing file http://test-realm/test/post.gts',
+        additionalErrors: null,
+      },
+    };
+
+    let normalized = normalizeRenderError(renderError);
+
+    assert.strictEqual(
+      normalized.error.id,
+      'http://test-realm/test/post.gts',
+      'a module is served under its own extension, so it names its own file',
+    );
+  });
 });

--- a/packages/host/tests/unit/render-error-test.ts
+++ b/packages/host/tests/unit/render-error-test.ts
@@ -29,4 +29,59 @@ module('Unit | render-error', function () {
       'input object is not mutated',
     );
   });
+
+  test('a missing card instance is reported as the .json file backing it', function (assert) {
+    let renderError: RenderError = {
+      type: 'instance-error',
+      error: {
+        status: 404,
+        title: 'Not Found',
+        message: 'missing file http://test-realm/test/Widget/w-1',
+        additionalErrors: null,
+      },
+    };
+
+    let normalized = normalizeRenderError(renderError);
+
+    assert.strictEqual(
+      normalized.error.id,
+      'http://test-realm/test/Widget/w-1.json',
+      'an extensionless instance id resolves to the file the realm serves it from',
+    );
+    assert.strictEqual(
+      normalized.error.message,
+      'missing file http://test-realm/test/Widget/w-1.json',
+      'the message names that file',
+    );
+    assert.strictEqual(
+      normalized.error.title,
+      'Link Not Found',
+      'the error is titled as a missing link',
+    );
+  });
+
+  test('a missing file keeps its own path', function (assert) {
+    let renderError: RenderError = {
+      type: 'instance-error',
+      error: {
+        status: 404,
+        title: 'Not Found',
+        message: 'missing file http://test-realm/test/images/photo.jpg',
+        additionalErrors: null,
+      },
+    };
+
+    let normalized = normalizeRenderError(renderError);
+
+    assert.strictEqual(
+      normalized.error.id,
+      'http://test-realm/test/images/photo.jpg',
+      'a reference that already names a file is reported as that file',
+    );
+    assert.strictEqual(
+      normalized.error.message,
+      'missing file http://test-realm/test/images/photo.jpg',
+      'the message names the file the realm is missing, not a .json path it has never held',
+    );
+  });
 });

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -138,6 +138,18 @@ export function segmentNamesFile(name: string): boolean {
   return extensionOfName(name) in FILEDEF_CODE_REF_BY_EXTENSION;
 }
 
+// Whether a reference names a file rather than a card instance. String form of
+// `urlNamesFile`, for a reference that may not parse as a URL (a registered
+// prefix id such as `@cardstack/skills/some-skill`). Judged the same way, by a
+// registered extension on the last path segment: a dot alone proves nothing,
+// because a card id can carry one, and reading such a dot as an extension is
+// what turns `<realm>/ModelConfiguration/claude-sonnet-4.6` into a reference to
+// a file that does not exist.
+export function referenceNamesFile(reference: string): boolean {
+  let path = reference.split(/[?#]/)[0];
+  return segmentNamesFile(path.slice(path.lastIndexOf('/') + 1));
+}
+
 export function resolveFileDefCodeRef(
   fileURL: URL,
   virtualNetwork: VirtualNetwork,


### PR DESCRIPTION
A broken link whose target names a file is reported as that file — in the message a reader is shown, in the dep invalidation watches, and in the placeholder's label.

## Which realm file a broken reference stands for

A card instance is served out of its id plus `.json` — `Product/chai` out of `Product/chai.json` — so the `.json` form is the file to report and the dep to watch. A reference that already names a file is that file, and suffixing it names a path the realm can never hold.

The dividing line is a **registered FileDef extension**, not a dot. Card ids legitimately carry dots — `ModelConfiguration/claude-sonnet-4.6`, `hello.test` — and reading such a dot as an extension strands the dep at a URL no index row is keyed on. `dependency-tracker.ts` and `index-runner/dependency-normalization.ts` already document this rule; `referenceNamesFile` joins `urlNamesFile` / `segmentNamesFile` as the string form of that test, for references that may not parse as a URL (a registered prefix id).

Two places choose that form and now share the rule:

- **`lazilyLoadLink`** (`packages/base/card-api.gts`) — a `linksTo` declared to hold a card, holding a reference that names a file, suffixed `.json` onto the file path. That string is both `errorDoc.message` and the sole entry in `deps`, so the reader is told about a file that cannot exist and the mended link has no dep that could invalidate this consumer. The field's own type still settles it first when the field is declared to hold a file; the reference's shape settles the rest.
- **`extractMissingRefFromMessage`** (`packages/host/app/utils/render-error.ts`) — recovers the reference out of a `missing file …` message, which `applyMissingLinkOverrides` writes back into `error.id` and the message. No current producer is known to reach it (see below); the classifier is corrected rather than left wrong, since a dotted card id reaching it would lose the `.json` its row is keyed on.

## The placeholder labels a file the way it labels a card

A card reference has the shape `Type/id`, so its readable name is the second-to-last path segment; a file reference is a path, so its readable name is the file name. Reading a file url through the card rule names the containing directory — `images` for a missing `images/photo.jpg`, under the headline "Linked card not found".

The five `linksTo` / `linksToMany` broken-link render sites now derive both the label and the placeholder's `itemType` from the field, so a broken file link reads "Linked file not found" over the file's own name. This is the rule the BFM `:file[...]` chooser already applies to its broken refs.

## What this does and does not fix

The report that prompted this — a missing image surfacing as `missing file …/photo.jpg.json` — is no longer reproducible on `main`, for a reason worth stating so nobody re-hunts it. `lazilyLoadLink` used to dispatch a `boxel-render-error` for a failed link, demoting the whole consumer card; that carried `missing file …/photo.jpg` into `normalizeRenderError`, which appended `.json` because the error had no `id`. `fb3b1ae85` ("Capture broken links via getRelationship scan, retire boxel-render-error") retired that dispatch in favour of the `link-not-found` sentinel and its placeholder, which removed the route into that normalization and with it the symptom.

So this is not the fix for that report. It fixes the defect underneath it, which is still live: `lazilyLoadLink` costs a card-typed link holding a file reference its invalidation dep, the placeholder mislabels a missing file as a missing card, and the dot-vs-extension classification would otherwise be inherited by any future caller of the message path.

## Deferred

`processCardError` (`packages/host/app/services/store.ts`) has a 404 branch written for card instances and applied to every 404, so a file 404 reaching it reads as `Card Not Found` / `The card {url} does not exist` — the same card/file confusion this change fixes elsewhere. That is reachable today, on a different path from the ones here: `getFileMetaInstance` throws a 404 `CardError` into it, and since `CardError.fromSerializableError` never sets `responseText`, the `JSON.parse(error.responseText)` probe throws and control lands in that branch.

It is out of scope here because nothing this change touches routes into it — a broken `linksTo(FileDef)` resolves through `GcCardStore.loadFileMetaDocument`, which carries the fetch's own status and never reaches `processCardError`. Tracked separately.

## Test plan

Nine tests across three files.

- `Unit | render-error` (4) — a file reference and a module reference keep their own paths; an extensionless instance reference and a dotted card id (`ModelConfiguration/claude-sonnet-4.6`) both resolve to their `.json` file.
- `Integration | linksTo broken-link placeholder (singular)` (4) — a real 404 on a `linksTo` pointing at a file path reports that path with no `.json` and records it as its only dep; a real 404 on a dotted card id keeps the `.json`; a broken `linksTo(FileDef)` renders "Linked file not found" labelled by the file name; a broken card link still reads as a card labelled by its type.
- `Integration | linksToMany broken-link placeholder (per element)` (1) — a broken `linksToMany(FileDef)` element gets the same file labelling.

The two singular-format tests that drive a real 404 exercise `lazilyLoadLink` itself rather than hand-planting a sentinel, so they pin the message and the dep the producer actually writes.

`pnpm lint:types` (host), prettier, eslint and `ember-template-lint` pass on the changed files.

## CI

Green except `Matrix Client Tests (3, 3)`, which fails at the same step on `main` — see the standing-down comment on this PR for the base-branch runs. `percy/-cardstack-host` has one visual change awaiting human approval; a visual change is expected, since the broken-link placeholder's headline and label change for file-backed links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012haqwCNMn5ZFuf3GNwUar2