### PR TITLE
Extend the theme contract with kit tokens and add sample UI to the theme dashboards

### DIFF
--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -19,7 +19,6 @@ import {
   BasicFitted,
   CopyButton,
   Swatch,
-  Button,
   FieldContainer,
   GridContainer,
 } from '@cardstack/boxel-ui/components';
@@ -48,6 +47,8 @@ import {
   ThemeDashboardHeader,
   NavSection,
   PreviewPills,
+  FontsPreview,
+  ThemeSpecimens,
   CardContainerCss,
   ThemeImporter,
   ResetButton,
@@ -223,47 +224,13 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
                     </GridContainer>
                   {{/unless}}
                   <@fields.typography class='brand-typography-preview' />
+                {{else if (eq section.id 'fonts')}}
+                  <FontsPreview
+                    @fontStack={{@model.fontStacksFor this.isDarkMode}}
+                    @cssImports={{@model.cssImports}}
+                  />
                 {{else if (eq section.id 'ui-components')}}
-                  <GridContainer class='cta-grid'>
-                    <FieldContainer @label='Primary CTA' @vertical={{true}}>
-                      <div class='preview-container cta-preview-container'>
-                        <Button @kind='primary' @size='extra-small'>Sample CTA</Button>
-                      </div>
-                    </FieldContainer>
-                    <FieldContainer @label='Secondary CTA' @vertical={{true}}>
-                      <div class='preview-container cta-preview-container'>
-                        <Button @kind='secondary' @size='extra-small'>Sample CTA</Button>
-                      </div>
-                    </FieldContainer>
-                    <FieldContainer @label='Disabled CTA' @vertical={{true}}>
-                      <div class='preview-container cta-preview-container'>
-                        <Button @disabled={{true}} @size='extra-small'>Sample
-                          CTA</Button>
-                      </div>
-                    </FieldContainer>
-                  </GridContainer>
-                  <FieldContainer
-                    @label='Corner Radius for holding shapes'
-                    @vertical={{true}}
-                  >
-                    <GridContainer class='ui-grid'>
-                      <div class='preview-container ui-preview-container'>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing
-                          elit, sed do eiusmod tempor incididunt ut labore et
-                          dolore magna aliqua. Ut enim ad minim veniam, quis
-                          nostrud exercitation ullamco laboris nisi ut aliquip
-                          ex ea commodo consequat. Duis aute irure dolor in
-                          reprehenderit in voluptate velit esse cillum dolore eu
-                          fugiat nulla pariatur. Excepteur sint occaecat
-                          cupidatat non proident, sunt in culpa qui officia
-                          deserunt mollit anim id est laborum.
-                        </p>
-                      </div>
-                      <div
-                        class='preview-container ui-preview-container photo-container'
-                      />
-                    </GridContainer>
-                  </FieldContainer>
+                  <ThemeSpecimens />
                 {{else if (eq section.id 'visual-dna')}}
                   <div class='dsr-section-content'>
                     {{#if this.editMode}}
@@ -344,7 +311,10 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
                   </div>
                 {{else if (eq section.id 'card-container-css')}}
                   {{#if @model.cssVariables}}
-                    <CardContainerCss @cssVariables={{@model.cssVariables}} />
+                    <CardContainerCss
+                      @cssVariables={{@model.cssVariables}}
+                      @isDarkMode={{this.isDarkMode}}
+                    />
                     <hr class='brand-guide-vars-divider' />
                     <h3 class='brand-guide-vars-heading'>Brand Guide-Specific
                       Variables</h3>
@@ -641,46 +611,13 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
       :deep(h3) {
         font-size: var(--boxel-font-size-md);
       }
-      .cta-grid {
-        margin-bottom: var(--boxel-sp-xl);
-        grid-template-columns: repeat(3, 1fr);
-      }
-      .preview-container {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        max-width: 100%;
-        background-color: var(--muted);
-        color: var(--dsr-foreground);
-        border-radius: var(--boxel-border-radius);
-        overflow: hidden;
-      }
-      .cta-preview-container {
-        min-height: 7.5rem;
-      }
-      .ui-grid {
-        grid-template-columns: repeat(2, 1fr);
-      }
-      .ui-preview-container {
-        height: 11.25rem;
-        align-items: flex-start;
-        padding: var(--boxel-sp-xxl);
-        overflow: auto;
-      }
-      .photo-container {
-        background-image: url('https://app-assets-cardstack.s3.us-east-1.amazonaws.com/%40cardstack/boxel/images/placeholders/photo-placeholder.png');
-        background-position: center;
-        background-repeat: no-repeat;
-        background-size: cover;
-      }
 
       /* typography section */
       .typography-grid {
         grid-template-columns: 1fr 1fr;
       }
       @container (width <= 768px) {
-        .typography-grid,
-        .cta-grid {
+        .typography-grid {
           grid-template-columns: 1fr;
         }
       }
@@ -1011,6 +948,11 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
       fieldName: 'typography',
     },
     {
+      id: 'fonts',
+      navTitle: 'Fonts',
+      title: 'Fonts',
+    },
+    {
       id: 'mark-usage',
       navTitle: 'Mark Usage',
       title: 'Mark Usage',
@@ -1043,7 +985,8 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
         this.sections.filter(
           (section) =>
             section.id !== 'card-container-css' &&
-            section.id !== 'ui-components',
+            section.id !== 'ui-components' &&
+            section.id !== 'fonts',
         ),
         this.hasThemeCss,
       );
@@ -1061,6 +1004,10 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
 
       if (section.id === 'card-container-css') {
         return Boolean(this.args.model.cssVariables);
+      }
+
+      if (section.id === 'fonts') {
+        return this.hasFontsContent;
       }
 
       if (section.id === 'custom-css') {
@@ -1095,6 +1042,14 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
 
       return Boolean(content);
     });
+  }
+
+  private get hasFontsContent() {
+    let model = this.args.model;
+    return Boolean(
+      model.fontStacksFor?.(this.isDarkMode).some((font) => font.stack) ||
+      model.cssImports?.length,
+    );
   }
 
   private get hasBrandPaletteContent() {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3426,26 +3426,65 @@ export class CSSField extends TextAreaField {
             --border,
             color-mix(in oklab, var(--field-fg) 20%, var(--field-bg))
           );
+          --field-fade: 1.5rem;
           position: relative;
+          background-color: var(--field-bg);
+          border: 1px solid var(--field-border);
+          border-radius: var(--radius, var(--boxel-border-radius));
+          overflow: hidden;
         }
         .css-field-copy-button {
           position: absolute;
           top: var(--boxel-sp-xs);
           right: var(--boxel-sp-xs);
+          z-index: 1;
         }
         .css-field {
           margin-block: 0;
           padding: var(--boxel-sp);
-          background-color: var(--field-bg);
-          border: 1px solid var(--field-border);
-          border-radius: var(--radius, var(--boxel-border-radius));
           color: var(--field-fg);
           font-family: var(
             --font-mono,
             var(--boxel-monospace-font-family, monospace)
           );
           font-size: var(--boxel-font-size-xs);
-          overflow-x: auto;
+          max-height: var(--css-field-max-height, none);
+          overflow: auto;
+          /* iOS-style edge fades: text dissolves into the background at an
+             edge only while more content lies beyond it. Each mask layer is
+             taller than the box by the fade height, so shifting it up by that
+             amount parks its fade offscreen; the scroll timeline slides them
+             into view. Base positions show no fade, which is also what
+             browsers without scroll-driven animations render. */
+          mask-image:
+            linear-gradient(to bottom, transparent, black var(--field-fade)),
+            linear-gradient(to top, transparent, black var(--field-fade));
+          mask-size: 100% calc(100% + var(--field-fade));
+          mask-repeat: no-repeat;
+          mask-composite: intersect;
+          mask-position:
+            0 calc(-1 * var(--field-fade)),
+            0 0;
+          animation: css-field-edge-fade linear both;
+          animation-timeline: scroll(self);
+        }
+        @keyframes css-field-edge-fade {
+          0% {
+            mask-position:
+              0 calc(-1 * var(--field-fade)),
+              0 calc(-1 * var(--field-fade));
+          }
+          8%,
+          92% {
+            mask-position:
+              0 0,
+              0 calc(-1 * var(--field-fade));
+          }
+          100% {
+            mask-position:
+              0 0,
+              0 0;
+          }
         }
         .css-field::placeholder {
           opacity: 0.5;

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -1385,16 +1385,24 @@ export class ThemeRecipe extends GlimmerComponent<{
   <template>
     {{#if this.entries.length}}
       <div class='theme-recipe' ...attributes>
-        <div class='theme-recipe-header'>
-          <h4>Key tokens{{if @isDarkMode ' (dark)'}}</h4>
-          <CopyButton @textToCopy={{this.text}} />
-        </div>
+        <h4>Key tokens{{if @isDarkMode ' (dark)'}}</h4>
         <p class='theme-recipe-description'>
           The variables components read most and that other defaults are derived
           from. Pulled from the generated CSS so you can read or copy them
           without scanning the full list.
         </p>
-        <pre class='theme-recipe-pre' data-test-theme-recipe>{{this.text}}</pre>
+        {{! same surface as CSSField's code block, with the copy button pinned
+            to the block rather than the heading }}
+        <div class='theme-recipe-block'>
+          <CopyButton
+            class='theme-recipe-copy-button'
+            @textToCopy={{this.text}}
+          />
+          <pre
+            class='theme-recipe-pre'
+            data-test-theme-recipe
+          >{{this.text}}</pre>
+        </div>
       </div>
     {{/if}}
     <style scoped>
@@ -1402,27 +1410,35 @@ export class ThemeRecipe extends GlimmerComponent<{
         .theme-recipe {
           margin-bottom: var(--boxel-sp-xl);
         }
-        .theme-recipe-header {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          gap: var(--boxel-sp-xs);
-        }
-        .theme-recipe-header h4 {
+        .theme-recipe h4 {
           margin: 0;
         }
         .theme-recipe-description {
-          margin: var(--boxel-sp-4xs) 0 0;
+          margin: var(--boxel-sp-4xs) 0 var(--boxel-sp-xs);
           color: var(--muted-foreground);
           font-size: var(--boxel-font-size-sm);
         }
+        .theme-recipe-block {
+          position: relative;
+          background-color: var(--card);
+          color: var(--card-foreground);
+          border: 1px solid var(--border);
+          border-radius: var(--radius, var(--boxel-border-radius));
+          overflow: hidden;
+        }
+        .theme-recipe-copy-button {
+          position: absolute;
+          top: var(--boxel-sp-xs);
+          right: var(--boxel-sp-xs);
+          z-index: 1;
+        }
         .theme-recipe-pre {
-          margin: var(--boxel-sp-xs) 0 0;
-          padding: var(--boxel-sp-sm) var(--boxel-sp);
-          background-color: var(--muted);
-          color: var(--muted-foreground);
-          border-radius: var(--boxel-border-radius-sm);
-          font-family: var(--font-mono, var(--boxel-monospace-font-family));
+          margin: 0;
+          padding: var(--boxel-sp);
+          font-family: var(
+            --font-mono,
+            var(--boxel-monospace-font-family, monospace)
+          );
           font-size: var(--boxel-font-size-xs);
           overflow-x: auto;
         }
@@ -1435,7 +1451,7 @@ const SPECIMEN_TABS = [
   { id: 'surfaces', label: 'Surfaces & Ink' },
   { id: 'controls', label: 'Controls' },
   { id: 'dashboard', label: 'Dashboard' },
-  { id: 'reading', label: 'Reading' },
+  { id: 'reading', label: 'Editorial' },
 ] as const;
 
 type SpecimenTabId = (typeof SPECIMEN_TABS)[number]['id'];
@@ -1522,7 +1538,7 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
   <template>
     <div class='specimens' ...attributes>
-      <div class='specimen-tabs' role='tablist' aria-label='Theme specimens'>
+      <div class='specimen-tabs' role='tablist' aria-label='Component samples'>
         {{#each this.tabs as |tab|}}
           <button
             type='button'
@@ -1771,11 +1787,11 @@ export class ThemeSpecimens extends GlimmerComponent<{
         </div>
       </section>
 
-      {{! Reading }}
+      {{! Editorial }}
       <section
         class='specimen-panel'
         role='tabpanel'
-        aria-label='Reading'
+        aria-label='Editorial'
         hidden={{this.isHidden 'reading'}}
         {{this.linkPanel 'reading'}}
         data-test-specimen-panel='reading'
@@ -2087,10 +2103,6 @@ export class ThemeSpecimens extends GlimmerComponent<{
           gap: var(--boxel-sp);
           align-items: start;
         }
-        .sp-sample-card {
-          background-color: var(--card);
-          color: var(--card-foreground);
-        }
 
         /* dashboard */
         .sp-stats {
@@ -2202,6 +2214,12 @@ export class ThemeSpecimens extends GlimmerComponent<{
           color: var(--subtle-foreground);
           font-size: var(--boxel-caption-font-size);
         }
+      }
+      /* outside the layer: CardContainer paints --background with an unlayered
+         rule, so a layered override would lose to it */
+      .sp-sample-card {
+        background-color: var(--card);
+        color: var(--card-foreground);
       }
     </style>
   </template>
@@ -2344,7 +2362,7 @@ export class ThemeVisualizer extends GlimmerComponent<{
           </div>
         {{/if}}
         <div>
-          <h3 class='structured-theme-visualizer-subtitle'>Specimens</h3>
+          <h3 class='structured-theme-visualizer-subtitle'>Components</h3>
           <ThemeSpecimens />
         </div>
       </div>

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -364,7 +364,7 @@ export class CardContainerCss extends GlimmerComponent<{
       '--boxel-subheading',
       '--boxel-section-heading',
       '--boxel-caption',
-      '--boxel-label',
+      '--boxel-ui-label',
       '--boxel-eyebrow',
     ]);
   }
@@ -1205,9 +1205,6 @@ export class ThemeDashboardHeader extends GlimmerComponent<{
         .theme-dashboard-header-title {
           margin-bottom: var(--boxel-sp-sm);
           color: var(--foreground);
-        }
-        .theme-dashboard-header-tagline {
-          max-width: 48rem;
         }
         .theme-dashboard-version-edit-field {
           margin-top: var(--boxel-sp);

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -364,6 +364,8 @@ export class CardContainerCss extends GlimmerComponent<{
       '--boxel-subheading',
       '--boxel-section-heading',
       '--boxel-caption',
+      '--boxel-label',
+      '--boxel-eyebrow',
     ]);
   }
 
@@ -480,6 +482,8 @@ export class CardContainerCss extends GlimmerComponent<{
             <dt><code>--boxel-subheading-*</code></dt><dd>h3</dd>
             <dt><code>--boxel-body-*</code></dt><dd>p</dd>
             <dt><code>--boxel-caption-*</code></dt><dd>small</dd>
+            <dt><code>--boxel-label-*</code></dt><dd>UI labels, control text</dd>
+            <dt><code>--boxel-eyebrow-*</code></dt><dd>kicker above a title</dd>
           </dl>
         </div>
       </div>

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -1465,6 +1465,13 @@ const CHART_BARS = [62, 84, 45, 91, 70].map((height, index) => ({
   style: sanitizeHtmlSafe(`height: ${height}%`),
 }));
 
+// Ids in this markup end up in cached prerendered HTML, and several copies can
+// share one document, so a process-local counter like guidFor() is not unique
+// enough. A random token per instance is.
+function instanceId(): string {
+  return `specimens-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 // Realistic scenes built from boxel-ui, so a theme is judged on a page rather
 // than on isolated swatches. Every panel stays in the DOM (inactive ones are
 // hidden) so tests and prerender see the full set.
@@ -1472,6 +1479,8 @@ export class ThemeSpecimens extends GlimmerComponent<{
   Element: HTMLElement;
 }> {
   @tracked private activeTab: SpecimenTabId = 'surfaces';
+  private uid = instanceId();
+  private panelId = (id: string) => `${this.uid}-${id}`;
   @tracked private switchOn = true;
   @tracked private selected: string | null = SELECT_OPTIONS[1];
   private selectOptions = SELECT_OPTIONS;
@@ -1507,6 +1516,7 @@ export class ThemeSpecimens extends GlimmerComponent<{
             }}
             role='tab'
             aria-selected={{if (this.isActive tab.id) 'true' 'false'}}
+            aria-controls={{this.panelId tab.id}}
             {{on 'click' (fn this.selectTab tab.id)}}
             data-test-specimen-tab={{tab.id}}
           >
@@ -1517,8 +1527,10 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Surfaces & Ink }}
       <section
+        id={{this.panelId 'surfaces'}}
         class='specimen-panel'
         role='tabpanel'
+        aria-label='Surfaces & Ink'
         hidden={{this.isHidden 'surfaces'}}
         data-test-specimen-panel='surfaces'
       >
@@ -1625,8 +1637,10 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Controls }}
       <section
+        id={{this.panelId 'controls'}}
         class='specimen-panel'
         role='tabpanel'
+        aria-label='Controls'
         hidden={{this.isHidden 'controls'}}
         data-test-specimen-panel='controls'
       >
@@ -1705,8 +1719,10 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Dashboard }}
       <section
+        id={{this.panelId 'dashboard'}}
         class='specimen-panel'
         role='tabpanel'
+        aria-label='Dashboard'
         hidden={{this.isHidden 'dashboard'}}
         data-test-specimen-panel='dashboard'
       >
@@ -1741,8 +1757,10 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Reading }}
       <section
+        id={{this.panelId 'reading'}}
         class='specimen-panel'
         role='tabpanel'
+        aria-label='Reading'
         hidden={{this.isHidden 'reading'}}
         data-test-specimen-panel='reading'
       >

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -482,7 +482,7 @@ export class CardContainerCss extends GlimmerComponent<{
             <dt><code>--boxel-subheading-*</code></dt><dd>h3</dd>
             <dt><code>--boxel-body-*</code></dt><dd>p</dd>
             <dt><code>--boxel-caption-*</code></dt><dd>small</dd>
-            <dt><code>--boxel-label-*</code></dt><dd>UI labels, control text</dd>
+            <dt><code>--boxel-ui-label-*</code></dt><dd>UI labels, control text</dd>
             <dt><code>--boxel-eyebrow-*</code></dt><dd>kicker above a title</dd>
           </dl>
         </div>

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -1323,10 +1323,16 @@ export class PreviewPills extends GlimmerComponent<{
 
 // The tokens that decide a theme's look, excerpted from the generated CSS so a
 // reader does not have to scan the full variable dump for them
+// Chosen by counting: these are the contract tokens boxel-ui components read
+// most, plus the ones other theme.css defaults are mixed from (--foreground
+// alone feeds thirteen), plus the knobs the spacing and radius scales derive
+// from. Re-count before adding to it.
 const RECIPE_TOKENS = [
   '--background',
   '--foreground',
   '--card',
+  '--muted',
+  '--muted-foreground',
   '--primary',
   '--primary-foreground',
   '--secondary',
@@ -1337,9 +1343,7 @@ const RECIPE_TOKENS = [
   '--radius',
   '--spacing',
   '--font-sans',
-  '--font-serif',
   '--font-mono',
-  '--shadow',
 ];
 
 export class ThemeRecipe extends GlimmerComponent<{
@@ -1385,6 +1389,11 @@ export class ThemeRecipe extends GlimmerComponent<{
           <h4>Key tokens{{if @isDarkMode ' (dark)'}}</h4>
           <CopyButton @textToCopy={{this.text}} />
         </div>
+        <p class='theme-recipe-description'>
+          The variables components read most and that other defaults are derived
+          from. Pulled from the generated CSS so you can read or copy them
+          without scanning the full list.
+        </p>
         <pre class='theme-recipe-pre' data-test-theme-recipe>{{this.text}}</pre>
       </div>
     {{/if}}
@@ -1401,6 +1410,11 @@ export class ThemeRecipe extends GlimmerComponent<{
         }
         .theme-recipe-header h4 {
           margin: 0;
+        }
+        .theme-recipe-description {
+          margin: var(--boxel-sp-4xs) 0 0;
+          color: var(--muted-foreground);
+          font-size: var(--boxel-font-size-sm);
         }
         .theme-recipe-pre {
           margin: var(--boxel-sp-xs) 0 0;
@@ -1481,8 +1495,6 @@ export class ThemeSpecimens extends GlimmerComponent<{
     this.selected = option;
   }
 
-  private panelId = (id: string) => `${guidFor(this)}-${id}`;
-
   <template>
     <div class='specimens' ...attributes>
       <div class='specimen-tabs' role='tablist' aria-label='Theme specimens'>
@@ -1495,7 +1507,6 @@ export class ThemeSpecimens extends GlimmerComponent<{
             }}
             role='tab'
             aria-selected={{if (this.isActive tab.id) 'true' 'false'}}
-            aria-controls={{this.panelId tab.id}}
             {{on 'click' (fn this.selectTab tab.id)}}
             data-test-specimen-tab={{tab.id}}
           >
@@ -1506,7 +1517,6 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Surfaces & Ink }}
       <section
-        id={{this.panelId 'surfaces'}}
         class='specimen-panel'
         role='tabpanel'
         hidden={{this.isHidden 'surfaces'}}
@@ -1523,16 +1533,17 @@ export class ThemeSpecimens extends GlimmerComponent<{
               <TokenPill @name='--card' />
             </header>
             <div class='sp-inset'>
-              <label class='sp-field-label' for={{this.panelId 'field'}}>
-                Field at rest in an inset well
-                <TokenPill @name='--inset' />
-                <TokenPill @name='--field' />
-                <TokenPill @name='--subtle-foreground' />
+              {{! wrapping label: no id, so cached prerendered copies of this
+                  dashboard can share a document without colliding }}
+              <label class='sp-field-label'>
+                <span class='sp-field-label-text'>
+                  Field at rest in an inset well
+                  <TokenPill @name='--inset' />
+                  <TokenPill @name='--field' />
+                  <TokenPill @name='--subtle-foreground' />
+                </span>
+                <BoxelInput @placeholder='Placeholder in subtle ink' />
               </label>
-              <BoxelInput
-                @id={{this.panelId 'field'}}
-                @placeholder='Placeholder in subtle ink'
-              />
             </div>
             <div class='sp-table-scroll'>
               <table class='sp-table'>
@@ -1614,7 +1625,6 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Controls }}
       <section
-        id={{this.panelId 'controls'}}
         class='specimen-panel'
         role='tabpanel'
         hidden={{this.isHidden 'controls'}}
@@ -1695,7 +1705,6 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Dashboard }}
       <section
-        id={{this.panelId 'dashboard'}}
         class='specimen-panel'
         role='tabpanel'
         hidden={{this.isHidden 'dashboard'}}
@@ -1732,7 +1741,6 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Reading }}
       <section
-        id={{this.panelId 'reading'}}
         class='specimen-panel'
         role='tabpanel'
         hidden={{this.isHidden 'reading'}}
@@ -1868,10 +1876,15 @@ export class ThemeSpecimens extends GlimmerComponent<{
         }
         .sp-field-label {
           display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-xs);
+          font-size: var(--boxel-font-size-sm);
+        }
+        .sp-field-label-text {
+          display: flex;
           flex-wrap: wrap;
           align-items: center;
           gap: var(--boxel-sp-4xs);
-          font-size: var(--boxel-font-size-sm);
         }
         .sp-table-scroll {
           overflow-x: auto;

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -1571,6 +1571,7 @@ export class ThemeDashboard extends GlimmerComponent<{
         data-theme-dashboard
         data-boxel-theme-scope={{if @themeCss this.themeScopeId}}
         ...attributes
+        data-test-theme-dashboard
       >
         {{#if @themeCss}}
           {{! template-lint-disable require-scoped-style }}

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -1056,12 +1056,16 @@ export class NavBar extends GlimmerComponent<{
           max-height: 50vh;
           overflow-y: auto;
         }
+        /* the bar spans the card; its items keep to the content measure */
         .nav-container {
           position: relative;
           flex-grow: 1;
           display: flex;
           gap: var(--boxel-sp-xs);
           overflow: hidden;
+          width: 100%;
+          max-width: var(--dsr-content-max-width);
+          margin: 0 auto;
           padding-inline: var(--boxel-sp-xl);
         }
 
@@ -1127,40 +1131,42 @@ export class ThemeDashboardHeader extends GlimmerComponent<{
       class='theme-dashboard-header {{if @mode @mode "isolated"}}'
       ...attributes
     >
-      {{#if (and (eq @mode 'edit') (bool @model) (bool @fields))}}
-        <CardInfoTemplates.edit
-          @fields={{@fields}}
-          @model={{this.cardInfoModel}}
-          @hideThemeChooser={{true}}
-        />
-        <FieldContainer
-          class='theme-dashboard-version-edit-field'
-          @icon={{VersionIcon}}
-          @label='Version No'
-          @tag='label'
-        >
-          <@fields.version />
-        </FieldContainer>
-      {{else}}
-        {{#if (has-block 'meta')}}
-          {{yield to='meta'}}
+      <div class='theme-dashboard-header-content'>
+        {{#if (and (eq @mode 'edit') (bool @model) (bool @fields))}}
+          <CardInfoTemplates.edit
+            @fields={{@fields}}
+            @model={{this.cardInfoModel}}
+            @hideThemeChooser={{true}}
+          />
+          <FieldContainer
+            class='theme-dashboard-version-edit-field'
+            @icon={{VersionIcon}}
+            @label='Version No'
+            @tag='label'
+          >
+            <@fields.version />
+          </FieldContainer>
         {{else}}
-          <div class='theme-dashboard-header-meta'>
-            <span class='theme-dashboard-header-meta-label'>
-              {{if @metaLabel @metaLabel 'Style Guide'}}
-            </span>
-            <span class='theme-dashboard-header-meta-version'>
-              Version
-              {{if @version @version '1.0'}}
-            </span>
-          </div>
+          {{#if (has-block 'meta')}}
+            {{yield to='meta'}}
+          {{else}}
+            <div class='theme-dashboard-header-meta'>
+              <span class='theme-dashboard-header-meta-label'>
+                {{if @metaLabel @metaLabel 'Style Guide'}}
+              </span>
+              <span class='theme-dashboard-header-meta-version'>
+                Version
+                {{if @version @version '1.0'}}
+              </span>
+            </div>
+          {{/if}}
+          <h1 class='theme-dashboard-header-title'>{{@title}}</h1>
+          {{#if @description}}
+            <p class='theme-dashboard-header-tagline'>{{@description}}</p>
+          {{/if}}
         {{/if}}
-        <h1 class='theme-dashboard-header-title'>{{@title}}</h1>
-        {{#if @description}}
-          <p class='theme-dashboard-header-tagline'>{{@description}}</p>
-        {{/if}}
-      {{/if}}
-      {{yield}}
+        {{yield}}
+      </div>
     </header>
     <style scoped>
       @layer baseComponent {
@@ -1175,6 +1181,16 @@ export class ThemeDashboardHeader extends GlimmerComponent<{
         }
         .edit {
           padding: var(--boxel-sp-xl);
+        }
+        /* the band spans the card; its content keeps to the dashboard's measure */
+        .theme-dashboard-header-content {
+          /* the band carries the horizontal padding that .dsr-content and the
+             nav include in their measure, so subtract it to keep text edges
+             aligned */
+          max-width: calc(
+            var(--dsr-content-max-width, 56rem) - 2 * var(--boxel-sp-xl)
+          );
+          margin: 0 auto;
         }
         .theme-dashboard-header-meta {
           display: flex;
@@ -1602,6 +1618,9 @@ export class ThemeDashboard extends GlimmerComponent<{
           height: 100%;
         }
         .detailed-style-reference {
+          /* one measure for the header, content, and footer columns; the
+             theme card opens in the wide stack format, so this is sized for it */
+          --dsr-content-max-width: 72rem;
           display: flex;
           flex-direction: column;
           height: 100%;
@@ -1627,7 +1646,7 @@ export class ThemeDashboard extends GlimmerComponent<{
           display: flex;
           flex-direction: column;
           width: 100%;
-          max-width: 56rem;
+          max-width: var(--dsr-content-max-width);
           margin: 0 auto;
           padding: var(--boxel-sp-3xl) var(--boxel-sp-xl);
           counter-reset: section;
@@ -1641,7 +1660,7 @@ export class ThemeDashboard extends GlimmerComponent<{
           color: var(--muted-foreground);
         }
         .footer-content {
-          max-width: 56rem;
+          max-width: var(--dsr-content-max-width);
           margin: 0 auto;
           text-align: center;
         }

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -1,6 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import GlimmerComponent from '@glimmer/component';
-import { fn } from '@ember/helper';
+import { concat, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -23,7 +23,10 @@ import {
   BoxelInput,
   Menu as BoxelMenu,
   Pill,
+  ProgressBar,
   Switch,
+  CopyButton,
+  BoxelSelect,
 } from '@cardstack/boxel-ui/components';
 import {
   and,
@@ -31,6 +34,7 @@ import {
   cn,
   eq,
   MenuItem,
+  sanitizeHtmlSafe,
   themeScope,
   themeScopedCss,
 } from '@cardstack/boxel-ui/helpers';
@@ -38,6 +42,7 @@ import {
 import {
   DEFAULT_THEME_SCALE,
   FontPreviews,
+  TokenPill,
 } from '../structured-theme-variables';
 import CardInfoTemplates from '../default-templates/card-info';
 
@@ -245,6 +250,7 @@ export class ThemeImporter extends GlimmerComponent<{
 export class CardContainerCss extends GlimmerComponent<{
   Args: {
     cssVariables: string;
+    isDarkMode?: boolean;
   };
   Element: HTMLElement;
 }> {
@@ -417,6 +423,10 @@ export class CardContainerCss extends GlimmerComponent<{
         <code>--boxel-*</code>
         internals with Boxel defaults as fallbacks.
       </p>
+      <ThemeRecipe
+        @cssVariables={{@cssVariables}}
+        @isDarkMode={{@isDarkMode}}
+      />
       <div class='computed-vars-section'>
         <div class='computed-vars-group'>
           <h4>Spacing</h4>
@@ -1311,6 +1321,934 @@ export class PreviewPills extends GlimmerComponent<{
   </template>
 }
 
+// The tokens that decide a theme's look, excerpted from the generated CSS so a
+// reader does not have to scan the full variable dump for them
+const RECIPE_TOKENS = [
+  '--background',
+  '--foreground',
+  '--card',
+  '--primary',
+  '--primary-foreground',
+  '--secondary',
+  '--accent',
+  '--destructive',
+  '--border',
+  '--ring',
+  '--radius',
+  '--spacing',
+  '--font-sans',
+  '--font-serif',
+  '--font-mono',
+  '--shadow',
+];
+
+export class ThemeRecipe extends GlimmerComponent<{
+  Args: { cssVariables?: string | null; isDarkMode?: boolean };
+  Element: HTMLElement;
+}> {
+  private get entries(): { name: string; value: string }[] {
+    let css = this.args.cssVariables;
+    if (!css) {
+      return [];
+    }
+    let declared = new Map<string, string>();
+    let collect = (selector: RegExp) => {
+      let block = css!.match(selector);
+      if (!block) {
+        return;
+      }
+      for (let match of block[1].matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+        declared.set(match[1], match[2].trim());
+      }
+    };
+    // the dark block layers over :root, so read it second in dark mode
+    collect(/:root\s*{([^}]*)}/);
+    if (this.args.isDarkMode) {
+      collect(/\.dark\s*{([^}]*)}/);
+    }
+    return RECIPE_TOKENS.flatMap((name) => {
+      let value = declared.get(name);
+      return value ? [{ name, value }] : [];
+    });
+  }
+
+  private get text(): string {
+    return `:root {\n${this.entries
+      .map(({ name, value }) => `  ${name}: ${value};`)
+      .join('\n')}\n}`;
+  }
+
+  <template>
+    {{#if this.entries.length}}
+      <div class='theme-recipe' ...attributes>
+        <div class='theme-recipe-header'>
+          <h4>Key tokens{{if @isDarkMode ' (dark)'}}</h4>
+          <CopyButton @textToCopy={{this.text}} />
+        </div>
+        <pre class='theme-recipe-pre' data-test-theme-recipe>{{this.text}}</pre>
+      </div>
+    {{/if}}
+    <style scoped>
+      @layer baseComponent {
+        .theme-recipe {
+          margin-bottom: var(--boxel-sp-xl);
+        }
+        .theme-recipe-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: var(--boxel-sp-xs);
+        }
+        .theme-recipe-header h4 {
+          margin: 0;
+        }
+        .theme-recipe-pre {
+          margin: var(--boxel-sp-xs) 0 0;
+          padding: var(--boxel-sp-sm) var(--boxel-sp);
+          background-color: var(--muted);
+          color: var(--muted-foreground);
+          border-radius: var(--boxel-border-radius-sm);
+          font-family: var(--font-mono, var(--boxel-monospace-font-family));
+          font-size: var(--boxel-font-size-xs);
+          overflow-x: auto;
+        }
+      }
+    </style>
+  </template>
+}
+
+const SPECIMEN_TABS = [
+  { id: 'surfaces', label: 'Surfaces & Ink' },
+  { id: 'controls', label: 'Controls' },
+  { id: 'dashboard', label: 'Dashboard' },
+  { id: 'reading', label: 'Reading' },
+] as const;
+
+type SpecimenTabId = (typeof SPECIMEN_TABS)[number]['id'];
+
+const SPECIMEN_ROWS = [
+  { name: 'Website redesign', status: 'success', label: 'On track' },
+  { name: 'Quarterly report', status: 'warning', label: 'At risk' },
+  { name: 'Onboarding guide', status: 'info', label: 'In review' },
+  { name: 'Vendor contract', status: 'attention', label: 'Needs sign-off' },
+];
+
+const INKS = [
+  'primary',
+  'secondary',
+  'accent',
+  'destructive',
+  'success',
+  'warning',
+  'info',
+  'attention',
+];
+
+const SELECT_OPTIONS = ['Draft', 'In review', 'Published', 'Archived'];
+
+const CHART_BARS = [62, 84, 45, 91, 70].map((height, index) => ({
+  className: `sp-bar sp-bar--${index + 1}`,
+  style: sanitizeHtmlSafe(`height: ${height}%`),
+}));
+
+// Realistic scenes built from boxel-ui, so a theme is judged on a page rather
+// than on isolated swatches. Every panel stays in the DOM (inactive ones are
+// hidden) so tests and prerender see the full set.
+export class ThemeSpecimens extends GlimmerComponent<{
+  Element: HTMLElement;
+}> {
+  @tracked private activeTab: SpecimenTabId = 'surfaces';
+  @tracked private switchOn = true;
+  @tracked private selected: string | null = SELECT_OPTIONS[1];
+  private selectOptions = SELECT_OPTIONS;
+  private tabs = SPECIMEN_TABS;
+  private rows = SPECIMEN_ROWS;
+  private inks = INKS;
+  private bars = CHART_BARS;
+
+  private isActive = (id: SpecimenTabId) => this.activeTab === id;
+  private isHidden = (id: SpecimenTabId) => this.activeTab !== id;
+
+  @action private selectTab(id: SpecimenTabId) {
+    this.activeTab = id;
+  }
+
+  @action private toggleSwitch(isEnabled: boolean) {
+    this.switchOn = isEnabled;
+  }
+
+  @action private select(option: string | null) {
+    this.selected = option;
+  }
+
+  private panelId = (id: string) => `${guidFor(this)}-${id}`;
+
+  <template>
+    <div class='specimens' ...attributes>
+      <div class='specimen-tabs' role='tablist' aria-label='Theme specimens'>
+        {{#each this.tabs as |tab|}}
+          <button
+            type='button'
+            class={{cn
+              'specimen-tab'
+              specimen-tab--active=(this.isActive tab.id)
+            }}
+            role='tab'
+            aria-selected={{if (this.isActive tab.id) 'true' 'false'}}
+            aria-controls={{this.panelId tab.id}}
+            {{on 'click' (fn this.selectTab tab.id)}}
+            data-test-specimen-tab={{tab.id}}
+          >
+            {{tab.label}}
+          </button>
+        {{/each}}
+      </div>
+
+      {{! Surfaces & Ink }}
+      <section
+        id={{this.panelId 'surfaces'}}
+        class='specimen-panel'
+        role='tabpanel'
+        hidden={{this.isHidden 'surfaces'}}
+        data-test-specimen-panel='surfaces'
+      >
+        <div class='sp-canvas'>
+          <div class='sp-canvas-label'>
+            <span>Canvas</span>
+            <TokenPill @name='--canvas' />
+          </div>
+          <div class='sp-card'>
+            <header class='sp-card-header'>
+              <h4>Card on canvas</h4>
+              <TokenPill @name='--card' />
+            </header>
+            <div class='sp-inset'>
+              <label class='sp-field-label' for={{this.panelId 'field'}}>
+                Field at rest in an inset well
+                <TokenPill @name='--inset' />
+                <TokenPill @name='--field' />
+                <TokenPill @name='--subtle-foreground' />
+              </label>
+              <BoxelInput
+                @id={{this.panelId 'field'}}
+                @placeholder='Placeholder in subtle ink'
+              />
+            </div>
+            <div class='sp-table-scroll'>
+              <table class='sp-table'>
+                <thead>
+                  <tr>
+                    <th scope='col'>Project</th>
+                    <th scope='col'>Status</th>
+                    <th scope='col'>Row</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{#each this.rows as |row index|}}
+                    <tr
+                      class={{cn
+                        sp-row--hover=(eq index 1)
+                        sp-row--selected=(eq index 2)
+                      }}
+                      aria-selected={{if (eq index 2) 'true'}}
+                    >
+                      <td>{{row.name}}</td>
+                      <td>
+                        <span
+                          class={{cn
+                            'sp-status'
+                            (concat 'sp-status--' row.status)
+                          }}
+                        >{{row.label}}</span>
+                      </td>
+                      <td class='sp-row-note'>
+                        {{#if (eq index 0)}}
+                          <TokenPill @name='--card' />
+                        {{else if (eq index 1)}}
+                          <TokenPill @name='--hover' />
+                        {{else if (eq index 2)}}
+                          <TokenPill @name='--selected' />
+                        {{else}}
+                          <TokenPill @name='--stripe' />
+                        {{/if}}
+                      </td>
+                    </tr>
+                  {{/each}}
+                </tbody>
+              </table>
+            </div>
+            <div class='sp-tooltip-row'>
+              <span class='sp-tooltip' role='tooltip'>Tooltip</span>
+              <TokenPill @name='--tooltip' />
+            </div>
+          </div>
+        </div>
+        <div class='sp-ink-grid'>
+          <div>
+            <h4 class='sp-group-title'>Hue as ink</h4>
+            <ul class='sp-inks'>
+              {{#each this.inks as |ink|}}
+                <li class={{concat 'sp-ink sp-ink--' ink}}>
+                  <a href='#' class='sp-ink-link'>{{ink}} ink</a>
+                  <TokenPill @name={{concat '--' ink '-ink'}} />
+                </li>
+              {{/each}}
+            </ul>
+          </div>
+          <div>
+            <h4 class='sp-group-title'>Status on its own fill</h4>
+            <div class='sp-status-row'>
+              <span class='sp-status sp-status--success'>Success</span>
+              <span class='sp-status sp-status--warning'>Warning</span>
+              <span class='sp-status sp-status--info'>Info</span>
+              <span class='sp-status sp-status--attention'>Attention</span>
+              <span class='sp-status sp-status--destructive'>Destructive</span>
+            </div>
+            <p class='sp-subtle'>
+              Tertiary text in subtle ink
+              <TokenPill @name='--subtle-foreground' />
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {{! Controls }}
+      <section
+        id={{this.panelId 'controls'}}
+        class='specimen-panel'
+        role='tabpanel'
+        hidden={{this.isHidden 'controls'}}
+        data-test-specimen-panel='controls'
+      >
+        <div class='sp-controls-row'>
+          <Button
+            @size='small'
+            @rectangular={{true}}
+            data-test-action-sample='default'
+          >
+            Default Action
+          </Button>
+          <Button
+            @kind='primary'
+            @size='small'
+            @rectangular={{true}}
+            data-test-action-sample='primary'
+          >
+            Primary Action
+          </Button>
+          <Button
+            @kind='secondary'
+            @size='small'
+            @rectangular={{true}}
+            data-test-action-sample='secondary'
+          >
+            Secondary Action
+          </Button>
+          <Button @kind='muted' @size='small' @rectangular={{true}}>
+            Muted Action
+          </Button>
+          <Button @kind='destructive' @size='small' @rectangular={{true}}>
+            Destructive
+          </Button>
+          <Button @size='small' @rectangular={{true}} @disabled={{true}}>
+            Disabled
+          </Button>
+        </div>
+        <div class='sp-controls-grid'>
+          <FieldContainer @label='Text input' @vertical={{true}}>
+            <BoxelInput @placeholder='Type to search' />
+          </FieldContainer>
+          <FieldContainer @label='Select' @vertical={{true}}>
+            <BoxelSelect
+              @options={{this.selectOptions}}
+              @selected={{this.selected}}
+              @onChange={{this.select}}
+              @placeholder='Choose a status'
+              @renderInPlace={{true}}
+              aria-label='Sample select'
+              as |option|
+            >
+              {{option}}
+            </BoxelSelect>
+          </FieldContainer>
+          <FieldContainer @label='Switch' @vertical={{true}}>
+            <Switch
+              @isEnabled={{this.switchOn}}
+              @onChange={{this.toggleSwitch}}
+              @label='Sample switch'
+            />
+          </FieldContainer>
+          <FieldContainer @label='Progress' @vertical={{true}}>
+            <ProgressBar @value={{64}} @max={{100}} @label='64%' />
+          </FieldContainer>
+        </div>
+        <CardContainer @displayBoundaries={{true}} class='sp-sample-card'>
+          <BoxelContainer @display='grid'>
+            <h4>Sample Card</h4>
+            <p>
+              Card component showcasing background, borders, and shadows from
+              the theme system.
+            </p>
+          </BoxelContainer>
+        </CardContainer>
+      </section>
+
+      {{! Dashboard }}
+      <section
+        id={{this.panelId 'dashboard'}}
+        class='specimen-panel'
+        role='tabpanel'
+        hidden={{this.isHidden 'dashboard'}}
+        data-test-specimen-panel='dashboard'
+      >
+        <div class='sp-stats'>
+          <div class='sp-stat'>
+            <span class='sp-stat-label'>Tasks completed</span>
+            <span class='sp-stat-value'>1,284</span>
+            <span class='sp-delta sp-delta--up'>▲ 8.2%</span>
+          </div>
+          <div class='sp-stat'>
+            <span class='sp-stat-label'>Avg. response</span>
+            <span class='sp-stat-value'>42m</span>
+            <span class='sp-delta sp-delta--down'>▼ 3.1%</span>
+          </div>
+          <div class='sp-stat'>
+            <span class='sp-stat-label'>Open items</span>
+            <span class='sp-stat-value'>17</span>
+            <span class='sp-delta'>no change</span>
+          </div>
+        </div>
+        <div class='sp-chart' role='img' aria-label='Sample bar chart'>
+          {{#each this.bars as |bar|}}
+            <div class={{bar.className}} style={{bar.style}}></div>
+          {{/each}}
+        </div>
+        <div class='sp-banner' role='status'>
+          <strong>Two projects need sign-off.</strong>
+          Warning hue used as ink on a neutral surface.
+          <TokenPill @name='--warning-ink' />
+        </div>
+      </section>
+
+      {{! Reading }}
+      <section
+        id={{this.panelId 'reading'}}
+        class='specimen-panel'
+        role='tabpanel'
+        hidden={{this.isHidden 'reading'}}
+        data-test-specimen-panel='reading'
+      >
+        <article class='sp-article'>
+          <span class='sp-eyebrow'>Field notes</span>
+          <h2 class='sp-article-title'>The last vat still taking colour</h2>
+          <p class='sp-lead'>
+            Body copy at reading measure, with a
+            <a
+              href='#'
+              class='sp-ink-link sp-ink--primary sp-ink-link-body'
+            >link in primary ink</a>
+            and a run of ordinary prose long enough to show line height.
+          </p>
+          <p>
+            Every surface here is the theme's own: the page, the rule under the
+            quote, the caption's quieter ink. Nothing is hard-coded.
+          </p>
+          <blockquote class='sp-quote'>
+            A theme is judged on a page, not on a swatch.
+          </blockquote>
+          <p class='sp-caption'>Caption text in muted ink.</p>
+        </article>
+      </section>
+    </div>
+    <style scoped>
+      @layer baseComponent {
+        .specimens {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-lg);
+          container-type: inline-size;
+        }
+        .specimen-tabs {
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--boxel-sp-4xs);
+          border-bottom: 1px solid var(--border);
+        }
+        .specimen-tab {
+          padding: var(--boxel-sp-xs) var(--boxel-sp);
+          border: 0;
+          border-bottom: 2px solid transparent;
+          margin-bottom: -1px;
+          background: none;
+          color: var(--muted-foreground);
+          font: inherit;
+          font-size: var(--boxel-font-size-sm);
+          font-weight: 500;
+          cursor: pointer;
+        }
+        .specimen-tab:hover {
+          background-color: var(--hover);
+          color: var(--foreground);
+        }
+        .specimen-tab:focus-visible {
+          outline: 2px solid var(--ring);
+          outline-offset: -2px;
+        }
+        .specimen-tab--active {
+          color: var(--foreground);
+          border-bottom-color: var(--primary);
+        }
+        .specimen-panel {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-lg);
+        }
+        /* author display beats the UA [hidden] rule, so restate it */
+        .specimen-panel[hidden] {
+          display: none;
+        }
+        .specimen-panel h4 {
+          margin: 0;
+        }
+        .sp-group-title {
+          margin-bottom: var(--boxel-sp-xs);
+          color: var(--muted-foreground);
+          font-size: var(--boxel-font-size-sm);
+        }
+
+        /* surfaces */
+        .sp-canvas {
+          min-width: 0;
+          padding: var(--boxel-sp);
+          background-color: var(--canvas);
+          color: var(--foreground);
+          border-radius: var(--radius);
+        }
+        .sp-canvas-label {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: var(--boxel-sp-xs);
+          margin-bottom: var(--boxel-sp-xs);
+          color: var(--muted-foreground);
+          font-size: var(--boxel-font-size-xs);
+        }
+        .sp-card {
+          min-width: 0;
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp);
+          padding: var(--boxel-sp);
+          background-color: var(--card);
+          color: var(--card-foreground);
+          border: 1px solid var(--border);
+          border-radius: var(--radius);
+          box-shadow: var(--shadow-sm);
+        }
+        .sp-card-header {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          justify-content: space-between;
+          gap: var(--boxel-sp-xs);
+        }
+        .sp-inset {
+          /* BoxelInput paints from --background and --muted-foreground, so remap
+             those inside the well to show the field and subtle-ink tokens on
+             the real component */
+          --background: var(--field);
+          --muted-foreground: var(--subtle-foreground);
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-xs);
+          padding: var(--boxel-sp);
+          background-color: var(--inset);
+          border-radius: calc(var(--radius) - 0.25rem);
+          box-shadow: var(--shadow-inset);
+        }
+        .sp-field-label {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: var(--boxel-sp-4xs);
+          font-size: var(--boxel-font-size-sm);
+        }
+        .sp-table-scroll {
+          overflow-x: auto;
+        }
+        .sp-table {
+          width: 100%;
+          border-collapse: collapse;
+          font-size: var(--boxel-font-size-sm);
+        }
+        .sp-table td {
+          white-space: nowrap;
+        }
+        .sp-table th {
+          padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+          border-bottom: 1px solid var(--border-strong);
+          color: var(--muted-foreground);
+          text-align: left;
+          font-family: var(--boxel-ui-label-font-family);
+          font-size: var(--boxel-ui-label-font-size);
+          font-weight: var(--boxel-ui-label-font-weight);
+          letter-spacing: var(--boxel-ui-label-letter-spacing);
+        }
+        .sp-table td {
+          padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+          border-bottom: 1px solid var(--border);
+        }
+        .sp-table tbody tr:nth-child(even) {
+          background-color: var(--stripe);
+        }
+        .sp-table tbody tr.sp-row--hover,
+        .sp-table tbody tr:hover {
+          background-color: var(--hover);
+        }
+        .sp-table tbody tr.sp-row--selected {
+          background-color: var(--selected);
+        }
+        .sp-row-note {
+          text-align: right;
+        }
+        .sp-tooltip-row {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: var(--boxel-sp-xs);
+        }
+        .sp-tooltip {
+          padding: var(--boxel-sp-4xs) var(--boxel-sp-xs);
+          background-color: var(--tooltip);
+          color: var(--tooltip-foreground);
+          border-radius: var(--boxel-border-radius-sm);
+          font-size: var(--boxel-font-size-xs);
+        }
+        .sp-ink-grid {
+          display: grid;
+          grid-template-columns: repeat(
+            auto-fit,
+            minmax(min(14rem, 100%), 1fr)
+          );
+          gap: var(--boxel-sp-lg);
+        }
+        .sp-inks {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: grid;
+          grid-template-columns: repeat(
+            auto-fill,
+            minmax(min(14rem, 100%), 1fr)
+          );
+          gap: var(--boxel-sp-xs);
+        }
+        .sp-ink {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          justify-content: space-between;
+          gap: var(--boxel-sp-4xs) var(--boxel-sp-xs);
+        }
+        .sp-ink-link {
+          color: inherit;
+          font-size: var(--boxel-font-size-sm);
+          font-weight: 600;
+          text-decoration: underline;
+          text-decoration-thickness: 1px;
+          text-underline-offset: 0.15em;
+          text-transform: capitalize;
+        }
+        .sp-ink-link-body {
+          font-size: inherit;
+        }
+        .sp-ink--primary {
+          color: var(--primary-ink);
+        }
+        .sp-ink--secondary {
+          color: var(--secondary-ink);
+        }
+        .sp-ink--accent {
+          color: var(--accent-ink);
+        }
+        .sp-ink--destructive {
+          color: var(--destructive-ink);
+        }
+        .sp-ink--success {
+          color: var(--success-ink);
+        }
+        .sp-ink--warning {
+          color: var(--warning-ink);
+        }
+        .sp-ink--info {
+          color: var(--info-ink);
+        }
+        .sp-ink--attention {
+          color: var(--attention-ink);
+        }
+        .sp-status-row {
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--boxel-sp-xs);
+        }
+        .sp-status {
+          display: inline-block;
+          padding: 0 var(--boxel-sp-xs);
+          border-radius: var(--boxel-border-radius-xl);
+          font-size: var(--boxel-font-size-xs);
+          font-weight: 600;
+          line-height: 1.6;
+        }
+        .sp-status--success {
+          background-color: var(--success);
+          color: var(--success-foreground);
+        }
+        .sp-status--warning {
+          background-color: var(--warning);
+          color: var(--warning-foreground);
+        }
+        .sp-status--info {
+          background-color: var(--info);
+          color: var(--info-foreground);
+        }
+        .sp-status--attention {
+          background-color: var(--attention);
+          color: var(--attention-foreground);
+        }
+        .sp-status--destructive {
+          background-color: var(--destructive);
+          color: var(--destructive-foreground);
+        }
+        .sp-subtle {
+          margin: var(--boxel-sp) 0 0;
+          color: var(--subtle-foreground);
+          font-size: var(--boxel-font-size-sm);
+        }
+
+        /* controls */
+        .sp-controls-row {
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--boxel-sp-xs);
+        }
+        .sp-controls-grid {
+          display: grid;
+          grid-template-columns: repeat(
+            auto-fit,
+            minmax(min(12rem, 100%), 1fr)
+          );
+          gap: var(--boxel-sp);
+          align-items: start;
+        }
+        .sp-sample-card {
+          background-color: var(--card);
+          color: var(--card-foreground);
+        }
+
+        /* dashboard */
+        .sp-stats {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(min(9rem, 100%), 1fr));
+          gap: var(--boxel-sp);
+        }
+        .sp-stat {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-4xs);
+          padding: var(--boxel-sp);
+          background-color: var(--card);
+          color: var(--card-foreground);
+          border: 1px solid var(--border);
+          border-radius: var(--radius);
+          box-shadow: var(--shadow-xs);
+        }
+        .sp-stat-label {
+          color: var(--muted-foreground);
+          font-family: var(--boxel-ui-label-font-family);
+          font-size: var(--boxel-ui-label-font-size);
+          font-weight: var(--boxel-ui-label-font-weight);
+          letter-spacing: var(--boxel-ui-label-letter-spacing);
+        }
+        .sp-stat-value {
+          font-size: var(--boxel-heading-font-size);
+          font-weight: 600;
+          font-variant-numeric: tabular-nums;
+        }
+        .sp-delta {
+          color: var(--subtle-foreground);
+          font-size: var(--boxel-font-size-xs);
+        }
+        .sp-delta--up {
+          color: var(--success-ink);
+        }
+        .sp-delta--down {
+          color: var(--destructive-ink);
+        }
+        .sp-chart {
+          display: flex;
+          align-items: flex-end;
+          gap: var(--boxel-sp-xs);
+          height: 6rem;
+          padding: var(--boxel-sp-xs) var(--boxel-sp-sm) 0;
+          border-bottom: 1px solid var(--border-strong);
+        }
+        .sp-bar {
+          flex: 1;
+          border-radius: var(--boxel-border-radius-xs)
+            var(--boxel-border-radius-xs) 0 0;
+        }
+        .sp-bar--1 {
+          background-color: var(--chart-1);
+        }
+        .sp-bar--2 {
+          background-color: var(--chart-2);
+        }
+        .sp-bar--3 {
+          background-color: var(--chart-3);
+        }
+        .sp-bar--4 {
+          background-color: var(--chart-4);
+        }
+        .sp-bar--5 {
+          background-color: var(--chart-5);
+        }
+        .sp-banner {
+          padding: var(--boxel-sp-xs) var(--boxel-sp);
+          border-left: 3px solid var(--warning);
+          background-color: var(--card);
+          color: var(--warning-ink);
+          font-size: var(--boxel-font-size-sm);
+        }
+
+        /* reading */
+        .sp-article {
+          max-width: 40rem;
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+        }
+        .sp-article p {
+          margin: 0;
+        }
+        .sp-eyebrow {
+          color: var(--muted-foreground);
+          font-family: var(--boxel-eyebrow-font-family);
+          font-size: var(--boxel-eyebrow-font-size);
+          font-weight: var(--boxel-eyebrow-font-weight);
+          letter-spacing: var(--boxel-eyebrow-letter-spacing);
+          text-transform: uppercase;
+        }
+        .sp-article-title {
+          margin: 0;
+        }
+        .sp-lead {
+          font-size: var(--boxel-subheading-font-size);
+        }
+        .sp-quote {
+          margin: var(--boxel-sp-xs) 0;
+          padding-left: var(--boxel-sp);
+          border-left: 3px solid var(--border-strong);
+          color: var(--muted-foreground);
+          font-style: italic;
+        }
+        .sp-caption {
+          color: var(--subtle-foreground);
+          font-size: var(--boxel-caption-font-size);
+        }
+      }
+    </style>
+  </template>
+}
+
+// Font previews beside the CSS import list, used by the visualizer and by the
+// Brand Guide's Fonts section
+export class FontsPreview extends GlimmerComponent<{
+  Args: {
+    fontStack?: { label: string; stack?: string }[];
+    cssImports?: string[] | null;
+  };
+  Element: HTMLElement;
+}> {
+  <template>
+    <div class='fonts-grid' ...attributes>
+      <FontPreviews @fontStack={{@fontStack}} />
+      {{#if @cssImports.length}}
+        <FieldContainer
+          class='css-imports-preview'
+          @label='CSS Imports'
+          @vertical={{true}}
+        >
+          <ul class='font-import-links'>
+            {{#each @cssImports as |importUrl|}}
+              <li>
+                <a
+                  class='font-import-link'
+                  href={{importUrl}}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  <ExternalLinkIcon
+                    class='font-import-link-icon'
+                    width='14'
+                    height='14'
+                    aria-hidden='true'
+                  />
+                  {{importUrl}}
+                </a>
+              </li>
+            {{/each}}
+          </ul>
+        </FieldContainer>
+      {{else}}
+        <p class='font-import-empty'><em>No web fonts referenced.</em></p>
+      {{/if}}
+    </div>
+    <style scoped>
+      /* previews beside the import list when both fit, stacked otherwise */
+      .fonts-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr));
+        gap: var(--boxel-sp-xl);
+        align-items: start;
+      }
+      .font-import-links {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-2xs);
+      }
+      .font-import-link {
+        display: flex;
+        align-items: baseline;
+        gap: var(--boxel-sp-2xs);
+        padding: var(--boxel-sp-2xs) var(--boxel-sp-xs);
+        background-color: var(--muted);
+        color: var(--muted-foreground);
+        border: 1px solid var(--border);
+        border-radius: var(--boxel-border-radius-sm);
+        font-family: var(--font-mono);
+        font-size: var(--boxel-font-size-xs);
+        text-decoration: none;
+        overflow-wrap: anywhere;
+      }
+      .font-import-link:hover,
+      .font-import-link:focus-visible {
+        text-decoration: underline;
+      }
+      .font-import-link-icon {
+        flex-shrink: 0;
+        align-self: center;
+      }
+      .font-import-empty {
+        margin: 0;
+        color: var(--muted-foreground);
+      }
+    </style>
+  </template>
+}
+
 export class ThemeVisualizer extends GlimmerComponent<{
   Args: {
     fontStack?: { label: string; stack?: string }[];
@@ -1346,37 +2284,10 @@ export class ThemeVisualizer extends GlimmerComponent<{
         {{else if this.showFontsSection}}
           <div data-test-font-imports-section>
             <h3 class='structured-theme-visualizer-subtitle'>Fonts</h3>
-            <FontPreviews @fontStack={{@fontStack}} />
-            {{#if @cssImports.length}}
-              <FieldContainer
-                class='css-imports-preview'
-                @label='CSS Imports'
-                @vertical={{true}}
-              >
-                <ul class='font-import-links'>
-                  {{#each @cssImports as |importUrl|}}
-                    <li>
-                      <a
-                        class='font-import-link'
-                        href={{importUrl}}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                      >
-                        <ExternalLinkIcon
-                          class='font-import-link-icon'
-                          width='14'
-                          height='14'
-                          aria-hidden='true'
-                        />
-                        {{importUrl}}
-                      </a>
-                    </li>
-                  {{/each}}
-                </ul>
-              </FieldContainer>
-            {{else if this.hasNoImports}}
-              <p class='font-import-empty'><em>No web fonts referenced.</em></p>
-            {{/if}}
+            <FontsPreview
+              @fontStack={{@fontStack}}
+              @cssImports={{@cssImports}}
+            />
           </div>
         {{/if}}
         {{#if (has-block 'typography')}}
@@ -1385,48 +2296,10 @@ export class ThemeVisualizer extends GlimmerComponent<{
             {{yield to='typography'}}
           </div>
         {{/if}}
-        {{#unless @editMode}}
-          <div>
-            <h3 class='structured-theme-visualizer-subtitle'>Components</h3>
-            <div class='structured-theme-component-samples'>
-              <Button
-                @size='small'
-                @rectangular={{true}}
-                data-test-action-sample='default'
-              >
-                Default Action
-              </Button>
-              <Button
-                @kind='primary'
-                @size='small'
-                @rectangular={{true}}
-                data-test-action-sample='primary'
-              >
-                Primary Action
-              </Button>
-              <Button
-                @kind='secondary'
-                @size='small'
-                @rectangular={{true}}
-                data-test-action-sample='secondary'
-              >
-                Secondary Action
-              </Button>
-              <CardContainer
-                @displayBoundaries={{true}}
-                class='structured-theme-component-sample-card'
-              >
-                <BoxelContainer @display='grid'>
-                  <h3>Sample Card</h3>
-                  <p>
-                    Card component showcasing background, borders, and shadows
-                    from the theme system.
-                  </p>
-                </BoxelContainer>
-              </CardContainer>
-            </div>
-          </div>
-        {{/unless}}
+        <div>
+          <h3 class='structured-theme-visualizer-subtitle'>Specimens</h3>
+          <ThemeSpecimens />
+        </div>
       </div>
     </section>
 
@@ -1473,56 +2346,9 @@ export class ThemeVisualizer extends GlimmerComponent<{
           border-bottom: var(--boxel-border);
           margin-bottom: var(--boxel-sp-xl);
         }
-        .structured-theme-component-samples {
-          display: flex;
-          flex-wrap: wrap;
-          gap: var(--boxel-sp);
-          align-items: flex-start;
-        }
         .visualizer-preview-pills {
           margin-bottom: var(--boxel-sp);
         }
-      }
-      .structured-theme-component-sample-card {
-        background-color: var(--card);
-        color: var(--card-foreground);
-      }
-      .css-imports-preview {
-        margin-top: var(--boxel-sp-xl);
-      }
-      .font-import-links {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        display: flex;
-        flex-direction: column;
-        gap: var(--boxel-sp-2xs);
-      }
-      .font-import-link {
-        display: flex;
-        align-items: baseline;
-        gap: var(--boxel-sp-2xs);
-        padding: var(--boxel-sp-2xs) var(--boxel-sp-xs);
-        background-color: var(--muted);
-        color: var(--muted-foreground);
-        border: 1px solid var(--border);
-        border-radius: var(--boxel-border-radius-sm);
-        font-family: var(--font-mono);
-        font-size: var(--boxel-font-size-xs);
-        text-decoration: none;
-        overflow-wrap: anywhere;
-      }
-      .font-import-link:hover,
-      .font-import-link:focus-visible {
-        text-decoration: underline;
-      }
-      .font-import-link-icon {
-        flex-shrink: 0;
-        align-self: center;
-      }
-      .font-import-empty {
-        margin: var(--boxel-sp) 0 0;
-        color: var(--muted-foreground);
       }
     </style>
   </template>
@@ -1618,7 +2444,7 @@ export class ThemeDashboard extends GlimmerComponent<{
         .detailed-style-reference {
           /* one measure for the header, content, and footer columns; the
              theme card opens in the wide stack format, so this is sized for it */
-          --dsr-content-max-width: 72rem;
+          --dsr-content-max-width: 90rem;
           /* long generated CSS scrolls inside its block instead of stretching the page */
           --css-field-max-height: 40vh;
           display: flex;

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -1618,6 +1618,8 @@ export class ThemeDashboard extends GlimmerComponent<{
           /* one measure for the header, content, and footer columns; the
              theme card opens in the wide stack format, so this is sized for it */
           --dsr-content-max-width: 72rem;
+          /* long generated CSS scrolls inside its block instead of stretching the page */
+          --css-field-max-height: 40vh;
           display: flex;
           flex-direction: column;
           height: 100%;

--- a/packages/base/default-templates/theme-dashboard.gts
+++ b/packages/base/default-templates/theme-dashboard.gts
@@ -1465,11 +1465,14 @@ const CHART_BARS = [62, 84, 45, 91, 70].map((height, index) => ({
   style: sanitizeHtmlSafe(`height: ${height}%`),
 }));
 
-// Ids in this markup end up in cached prerendered HTML, and several copies can
-// share one document, so a process-local counter like guidFor() is not unique
-// enough. A random token per instance is.
-function instanceId(): string {
-  return `specimens-${Math.random().toString(36).slice(2, 10)}`;
+// Prerendered HTML is cached, must be deterministic for unchanged content, and
+// can be inserted into a document more than once, so it carries no ids: the
+// panels are named by aria-label alone and the fragment is inert anyway. Live
+// renders link tabs to panels with a random per-instance token, unique even
+// across the copies of one card open in different stacks. The host's render
+// page marks its output container with `data-prerender`.
+function isPrerendering(el: Element): boolean {
+  return Boolean(el.closest('[data-prerender]'));
 }
 
 // Realistic scenes built from boxel-ui, so a theme is judged on a page rather
@@ -1479,8 +1482,21 @@ export class ThemeSpecimens extends GlimmerComponent<{
   Element: HTMLElement;
 }> {
   @tracked private activeTab: SpecimenTabId = 'surfaces';
-  private uid = instanceId();
-  private panelId = (id: string) => `${this.uid}-${id}`;
+  private uid = `specimens-${Math.random().toString(36).slice(2, 10)}`;
+
+  // ids are stamped after insert rather than rendered, so the template output
+  // stays id-free where it will be serialized
+  private linkPanel = modifier((el: HTMLElement, [key]: [SpecimenTabId]) => {
+    if (!isPrerendering(el)) {
+      el.id = `${this.uid}-${key}`;
+    }
+  });
+
+  private linkTab = modifier((el: HTMLElement, [key]: [SpecimenTabId]) => {
+    if (!isPrerendering(el)) {
+      el.setAttribute('aria-controls', `${this.uid}-${key}`);
+    }
+  });
   @tracked private switchOn = true;
   @tracked private selected: string | null = SELECT_OPTIONS[1];
   private selectOptions = SELECT_OPTIONS;
@@ -1516,7 +1532,7 @@ export class ThemeSpecimens extends GlimmerComponent<{
             }}
             role='tab'
             aria-selected={{if (this.isActive tab.id) 'true' 'false'}}
-            aria-controls={{this.panelId tab.id}}
+            {{this.linkTab tab.id}}
             {{on 'click' (fn this.selectTab tab.id)}}
             data-test-specimen-tab={{tab.id}}
           >
@@ -1527,11 +1543,11 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Surfaces & Ink }}
       <section
-        id={{this.panelId 'surfaces'}}
         class='specimen-panel'
         role='tabpanel'
         aria-label='Surfaces & Ink'
         hidden={{this.isHidden 'surfaces'}}
+        {{this.linkPanel 'surfaces'}}
         data-test-specimen-panel='surfaces'
       >
         <div class='sp-canvas'>
@@ -1637,11 +1653,11 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Controls }}
       <section
-        id={{this.panelId 'controls'}}
         class='specimen-panel'
         role='tabpanel'
         aria-label='Controls'
         hidden={{this.isHidden 'controls'}}
+        {{this.linkPanel 'controls'}}
         data-test-specimen-panel='controls'
       >
         <div class='sp-controls-row'>
@@ -1719,11 +1735,11 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Dashboard }}
       <section
-        id={{this.panelId 'dashboard'}}
         class='specimen-panel'
         role='tabpanel'
         aria-label='Dashboard'
         hidden={{this.isHidden 'dashboard'}}
+        {{this.linkPanel 'dashboard'}}
         data-test-specimen-panel='dashboard'
       >
         <div class='sp-stats'>
@@ -1757,11 +1773,11 @@ export class ThemeSpecimens extends GlimmerComponent<{
 
       {{! Reading }}
       <section
-        id={{this.panelId 'reading'}}
         class='specimen-panel'
         role='tabpanel'
         aria-label='Reading'
         hidden={{this.isHidden 'reading'}}
+        {{this.linkPanel 'reading'}}
         data-test-specimen-panel='reading'
       >
         <article class='sp-article'>

--- a/packages/base/detailed-style-reference.gts
+++ b/packages/base/detailed-style-reference.gts
@@ -320,7 +320,10 @@ class Isolated extends Component<typeof DetailedStyleReference> {
                   </div>
                 {{else if (eq section.id 'card-container-css')}}
                   {{#if @model.cssVariables}}
-                    <CardContainerCss @cssVariables={{@model.cssVariables}} />
+                    <CardContainerCss
+                      @cssVariables={{@model.cssVariables}}
+                      @isDarkMode={{this.isDarkMode}}
+                    />
                   {{/if}}
                 {{else if (eq section.id 'import-css')}}
                   {{! the cardInfo editor in the header owns the name and

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -680,11 +680,22 @@ class InheritedSwatch extends GlimmerComponent<{
           <code>{{this.expression}}</code>
         </:content>
       </Tooltip>
-      <Swatch
-        class='inherited-swatch-preview'
-        @color={{this.resolved}}
-        @label={{@name}}
-      />
+      <div class='inherited-swatch-row'>
+        <Swatch
+          class='inherited-swatch-preview'
+          @color={{this.resolved}}
+          @label={{@name}}
+        />
+        {{#if this.resolved}}
+          <CopyButton
+            @width='16px'
+            @height='16px'
+            @ariaLabel='Copy {{this.resolved}}'
+            @tooltipText='Copy {{this.resolved}}'
+            @textToCopy={{this.resolved}}
+          />
+        {{/if}}
+      </div>
     </div>
     <style scoped>
       @layer {
@@ -700,7 +711,14 @@ class InheritedSwatch extends GlimmerComponent<{
           width: 100%;
           min-width: 0;
         }
-        /* same swatch layout as ThemeSwatch */
+        /* same swatch + copy button layout as ThemeSwatch */
+        .inherited-swatch-row {
+          display: grid;
+          grid-template-columns: minmax(50%, 1fr) 1.875rem;
+          align-items: end;
+          width: 100%;
+          min-width: 0;
+        }
         .inherited-swatch-preview {
           --swatch-width: 2.75rem;
           --swatch-height: 2.75rem;
@@ -708,7 +726,6 @@ class InheritedSwatch extends GlimmerComponent<{
           flex-direction: row-reverse;
           justify-content: flex-end;
           align-items: center;
-          align-self: stretch;
           min-width: 0;
         }
         :deep(.boxel-swatch-preview) {

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -139,6 +139,14 @@ export class ThemeTypographyField extends FieldDef {
   @field caption = contains(TypographyField, {
     description: 'Caption/annotation and small text typography settings.',
   });
+  @field label = contains(TypographyField, {
+    description:
+      'UI label typography: control text, table headers, badges, and other chrome.',
+  });
+  @field eyebrow = contains(TypographyField, {
+    description:
+      'Eyebrow typography: the small, tracked-out kicker above a title.',
+  });
   get cssVariableFields(): CssVariableFieldEntry[] | undefined {
     return calculateTypographyVariables(this, 'theme');
   }
@@ -202,6 +210,16 @@ export class ThemeTypographyField extends FieldDef {
         <section class='theme-typography-edit-section'>
           <h4 class='theme-typography-edit-heading'>Caption</h4>
           <@fields.caption />
+        </section>
+
+        <section class='theme-typography-edit-section'>
+          <h4 class='theme-typography-edit-heading'>Label</h4>
+          <@fields.label />
+        </section>
+
+        <section class='theme-typography-edit-section'>
+          <h4 class='theme-typography-edit-heading'>Eyebrow</h4>
+          <@fields.eyebrow />
         </section>
 
       </div>
@@ -268,6 +286,20 @@ export class ThemeTypographyField extends FieldDef {
             Small text
           {{/if}}
         </small>
+        <span class='theme-typography-label'>
+          {{#if @model.label.sampleText}}
+            {{@model.label.sampleText}}
+          {{else}}
+            UI label
+          {{/if}}
+        </span>
+        <span class='theme-typography-eyebrow'>
+          {{#if @model.eyebrow.sampleText}}
+            {{@model.eyebrow.sampleText}}
+          {{else}}
+            Eyebrow
+          {{/if}}
+        </span>
       </section>
       <style scoped>
         .theme-typography {
@@ -285,6 +317,21 @@ export class ThemeTypographyField extends FieldDef {
         p {
           margin: 0;
           word-break: break-word;
+        }
+        .theme-typography-label {
+          font-family: var(--boxel-label-font-family);
+          font-size: var(--boxel-label-font-size);
+          font-weight: var(--boxel-label-font-weight);
+          line-height: var(--boxel-label-line-height);
+          letter-spacing: var(--boxel-label-letter-spacing);
+        }
+        .theme-typography-eyebrow {
+          font-family: var(--boxel-eyebrow-font-family);
+          font-size: var(--boxel-eyebrow-font-size);
+          font-weight: var(--boxel-eyebrow-font-weight);
+          line-height: var(--boxel-eyebrow-line-height);
+          letter-spacing: var(--boxel-eyebrow-letter-spacing);
+          text-transform: uppercase;
         }
       </style>
     </template>
@@ -498,6 +545,45 @@ export default class ThemeVarField extends FieldDef {
   @field popoverForeground = contains(ColorField, {
     description: describeColor('Text color for popover content.'),
   });
+  // neutral surfaces beyond shadcn's; --foreground must read on all of them
+  @field canvas = contains(ColorField, {
+    description: describeColor(
+      'Workspace ground behind the page background. Do not use as foreground color.',
+    ),
+  });
+  @field inset = contains(ColorField, {
+    description: describeColor(
+      'Background of a well sunk into a card. Do not use as foreground color.',
+    ),
+  });
+  @field field = contains(ColorField, {
+    description: describeColor(
+      'Background of an editable input at rest; its border is --input. Do not use as foreground color.',
+    ),
+  });
+  @field hover = contains(ColorField, {
+    description: describeColor(
+      'Pointer-hover surface, usually translucent so it composes over any background.',
+    ),
+  });
+  @field stripe = contains(ColorField, {
+    description: describeColor(
+      'Alternate (zebra) row background. Sits between --card and --hover.',
+    ),
+  });
+  @field selected = contains(ColorField, {
+    description: describeColor(
+      'Selected row/item background. Falls back to a tint of --primary over --card when unset.',
+    ),
+  });
+  @field tooltip = contains(ColorField, {
+    description: describeColor(
+      'Tooltip background; the one inverted surface. Do not use as foreground color.',
+    ),
+  });
+  @field tooltipForeground = contains(ColorField, {
+    description: describeColor('Text color on tooltip surfaces.'),
+  });
   @field primary = contains(ColorField, {
     description: describeColor(
       'Primary brand/action cta background-color. Do not use as foreground color.',
@@ -524,6 +610,11 @@ export default class ThemeVarField extends FieldDef {
   @field mutedForeground = contains(ColorField, {
     description: describeColor('Muted foreground color.'),
   });
+  @field subtleForeground = contains(ColorField, {
+    description: describeColor(
+      'Third ink step, fainter than --muted-foreground: timestamps, tertiary counts, placeholder-adjacent text.',
+    ),
+  });
   @field accent = contains(ColorField, {
     description: describeColor('Accent background-color.'),
   });
@@ -543,16 +634,92 @@ export default class ThemeVarField extends FieldDef {
       'Success/positive feedback color. Not standard shadcn: falls back to the fixed Boxel status palette green (--boxel-success) when unset.',
     ),
   });
+  @field successForeground = contains(ColorField, {
+    description: describeColor('Text/icon color on success surfaces.'),
+  });
   @field warning = contains(ColorField, {
     description: describeColor(
       'Warning/caution feedback color. Not standard shadcn: falls back to the fixed Boxel status palette yellow (--boxel-warning) when unset.',
     ),
   });
+  @field warningForeground = contains(ColorField, {
+    description: describeColor('Text/icon color on warning surfaces.'),
+  });
+  @field info = contains(ColorField, {
+    description: describeColor(
+      'Informational feedback color. Not standard shadcn. Do not use as foreground color.',
+    ),
+  });
+  @field infoForeground = contains(ColorField, {
+    description: describeColor('Text/icon color on info surfaces.'),
+  });
+  @field attention = contains(ColorField, {
+    description: describeColor(
+      'Needs-your-attention feedback color, distinct from warning and destructive. Not standard shadcn. Do not use as foreground color.',
+    ),
+  });
+  @field attentionForeground = contains(ColorField, {
+    description: describeColor('Text/icon color on attention surfaces.'),
+  });
+  @field overlay = contains(ColorField, {
+    description: describeColor('Translucent scrim behind modals and drawers.'),
+  });
+
+  // hue-as-ink variables: each hue used as text/icon color on a neutral
+  // surface, as opposed to the -foreground color used on the hue's own fill
+  @field primaryInk = contains(ColorField, {
+    description: describeColor(
+      'Primary hue as text/icon color on neutral surfaces (links, labels). Falls back to a mix of --primary and --foreground when unset.',
+    ),
+  });
+  @field secondaryInk = contains(ColorField, {
+    description: describeColor(
+      'Secondary hue as text/icon color on neutral surfaces. Falls back to a mix of --secondary and --foreground when unset.',
+    ),
+  });
+  @field accentInk = contains(ColorField, {
+    description: describeColor(
+      'Accent hue as text/icon color on neutral surfaces. Falls back to a mix of --accent and --foreground when unset.',
+    ),
+  });
+  @field destructiveInk = contains(ColorField, {
+    description: describeColor(
+      'Destructive hue as text/icon color on neutral surfaces. Falls back to a mix of --destructive and --foreground when unset.',
+    ),
+  });
+  @field successInk = contains(ColorField, {
+    description: describeColor(
+      'Success hue as text/icon color on neutral surfaces. Falls back to a mix of --success and --foreground when unset.',
+    ),
+  });
+  @field warningInk = contains(ColorField, {
+    description: describeColor(
+      'Warning hue as text/icon color on neutral surfaces. Falls back to a mix of --warning and --foreground when unset.',
+    ),
+  });
+  @field infoInk = contains(ColorField, {
+    description: describeColor(
+      'Info hue as text/icon color on neutral surfaces. Falls back to a mix of --info and --foreground when unset.',
+    ),
+  });
+  @field attentionInk = contains(ColorField, {
+    description: describeColor(
+      'Attention hue as text/icon color on neutral surfaces. Falls back to a mix of --attention and --foreground when unset.',
+    ),
+  });
+
   @field border = contains(ColorField, {
     description: describeColor('Specifies border-color.'),
   });
+  @field borderStrong = contains(ColorField, {
+    description: describeColor(
+      'One visible step darker than --border, for dividers that must hold their own.',
+    ),
+  });
   @field input = contains(ColorField, {
-    description: describeColor('Background/border color for inputs.'),
+    description: describeColor(
+      'Border color for inputs; the input background is --field.',
+    ),
   });
   @field ring = contains(ColorField, {
     description: describeColor('Focus ring color.'),
@@ -573,6 +740,12 @@ export default class ThemeVarField extends FieldDef {
   });
   @field chart5 = contains(ColorField, {
     description: describeColor('Quinary chart/graph color.'),
+  });
+  @field chart6 = contains(ColorField, {
+    description: describeColor('Sixth chart/graph color.'),
+  });
+  @field chart7 = contains(ColorField, {
+    description: describeColor('Seventh chart/graph color.'),
   });
 
   // sidebar color variables
@@ -637,6 +810,10 @@ export default class ThemeVarField extends FieldDef {
   @field trackingNormal = contains(CSSValueField, {
     description: 'Specifies letter-spacing base value.',
   });
+  @field controlHeight = contains(CSSValueField, {
+    description:
+      'Height of form controls (inputs, selects, buttons). Defaults to 2.5rem.',
+  });
   // box-shadow primitives, stored so tweakcn themes round-trip losslessly.
   // The composed shadow scale below does not derive from them; editing these
   // has no effect on rendered shadows.
@@ -686,6 +863,9 @@ export default class ThemeVarField extends FieldDef {
   @field shadow2xl = contains(CSSValueField, {
     description: 'Largest shadow depth.',
   });
+  @field shadowInset = contains(CSSValueField, {
+    description: 'Inset shadow for sunken wells and inputs.',
+  });
 
   get cssVariableFields(): CssVariableFieldEntry[] | undefined {
     let fields = getFields(this);
@@ -730,17 +910,54 @@ export default class ThemeVarField extends FieldDef {
     'popoverForeground',
     'muted',
     'mutedForeground',
+    'subtleForeground',
+  ];
+  private surfaceColors = [
+    'canvas',
+    'inset',
+    'field',
+    'hover',
+    'stripe',
+    'selected',
+    'tooltip',
+    'tooltipForeground',
   ];
   private formColors = [
     'border',
+    'borderStrong',
     'input',
     'ring',
     'destructive',
     'destructiveForeground',
     'success',
+    'successForeground',
     'warning',
+    'warningForeground',
+    'info',
+    'infoForeground',
+    'attention',
+    'attentionForeground',
+    'overlay',
   ];
-  private chartColors = ['chart1', 'chart2', 'chart3', 'chart4', 'chart5'];
+  private inkColors = [
+    'primaryInk',
+    'secondaryInk',
+    'accentInk',
+    'destructiveInk',
+    'successInk',
+    'warningInk',
+    'infoInk',
+    'attentionInk',
+  ];
+  private chartColors = [
+    'chart1',
+    'chart2',
+    'chart3',
+    'chart4',
+    'chart5',
+    'chart6',
+    'chart7',
+  ];
   private sidebarColors = [
     'sidebar',
     'sidebarForeground',
@@ -761,6 +978,7 @@ export default class ThemeVarField extends FieldDef {
     'shadowLg',
     'shadowXl',
     'shadow2xl',
+    'shadowInset',
   ];
   get fieldGroups() {
     return [
@@ -777,8 +995,16 @@ export default class ThemeVarField extends FieldDef {
         fields: getFieldGroup(this.uiComponentColors, this),
       },
       {
+        title: 'Surface Colors',
+        fields: getFieldGroup(this.surfaceColors, this),
+      },
+      {
         title: 'Form & Feedback Colors',
         fields: getFieldGroup(this.formColors, this),
+      },
+      {
+        title: 'Ink Colors',
+        fields: getFieldGroup(this.inkColors, this),
       },
       {
         title: 'Chart Colors',
@@ -849,6 +1075,7 @@ export default class ThemeVarField extends FieldDef {
         { label: 'lg', value: m.shadowLg },
         { label: 'xl', value: m.shadowXl },
         { label: '2xl', value: m.shadow2xl },
+        { label: 'Inset', value: m.shadowInset },
       ].filter((s) => s.value);
     }
 
@@ -1002,6 +1229,83 @@ export default class ThemeVarField extends FieldDef {
               <@fields.mutedForeground />
             </FieldContainer>
           </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Subtle Foreground'
+              @vertical={{true}}
+              data-test-field='subtleForeground'
+            >
+              <@fields.subtleForeground />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Surfaces</h4>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Canvas'
+              @vertical={{true}}
+              data-test-field='canvas'
+            >
+              <@fields.canvas />
+            </FieldContainer>
+            <FieldContainer
+              @label='Inset'
+              @vertical={{true}}
+              data-test-field='inset'
+            >
+              <@fields.inset />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Field'
+              @vertical={{true}}
+              data-test-field='field'
+            >
+              <@fields.field />
+            </FieldContainer>
+            <FieldContainer
+              @label='Hover'
+              @vertical={{true}}
+              data-test-field='hover'
+            >
+              <@fields.hover />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Stripe'
+              @vertical={{true}}
+              data-test-field='stripe'
+            >
+              <@fields.stripe />
+            </FieldContainer>
+            <FieldContainer
+              @label='Selected'
+              @vertical={{true}}
+              data-test-field='selected'
+            >
+              <@fields.selected />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Tooltip'
+              @vertical={{true}}
+              data-test-field='tooltip'
+            >
+              <@fields.tooltip />
+            </FieldContainer>
+            <FieldContainer
+              @label='Tooltip Foreground'
+              @vertical={{true}}
+              data-test-field='tooltipForeground'
+            >
+              <@fields.tooltipForeground />
+            </FieldContainer>
+          </div>
         </section>
 
         <section class='theme-var-edit-section'>
@@ -1015,14 +1319,21 @@ export default class ThemeVarField extends FieldDef {
               <@fields.border />
             </FieldContainer>
             <FieldContainer
+              @label='Border Strong'
+              @vertical={{true}}
+              data-test-field='borderStrong'
+            >
+              <@fields.borderStrong />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
               @label='Input'
               @vertical={{true}}
               data-test-field='input'
             >
               <@fields.input />
             </FieldContainer>
-          </div>
-          <div class='theme-var-edit-row theme-var-edit-row--2col'>
             <FieldContainer
               @label='Ring'
               @vertical={{true}}
@@ -1056,11 +1367,140 @@ export default class ThemeVarField extends FieldDef {
               <@fields.success />
             </FieldContainer>
             <FieldContainer
+              @label='Success Foreground'
+              @vertical={{true}}
+              data-test-field='successForeground'
+            >
+              <@fields.successForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
               @label='Warning'
               @vertical={{true}}
               data-test-field='warning'
             >
               <@fields.warning />
+            </FieldContainer>
+            <FieldContainer
+              @label='Warning Foreground'
+              @vertical={{true}}
+              data-test-field='warningForeground'
+            >
+              <@fields.warningForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Info'
+              @vertical={{true}}
+              data-test-field='info'
+            >
+              <@fields.info />
+            </FieldContainer>
+            <FieldContainer
+              @label='Info Foreground'
+              @vertical={{true}}
+              data-test-field='infoForeground'
+            >
+              <@fields.infoForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Attention'
+              @vertical={{true}}
+              data-test-field='attention'
+            >
+              <@fields.attention />
+            </FieldContainer>
+            <FieldContainer
+              @label='Attention Foreground'
+              @vertical={{true}}
+              data-test-field='attentionForeground'
+            >
+              <@fields.attentionForeground />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Overlay'
+              @vertical={{true}}
+              data-test-field='overlay'
+            >
+              <@fields.overlay />
+            </FieldContainer>
+          </div>
+        </section>
+
+        <section class='theme-var-edit-section'>
+          <h4 class='theme-var-edit-heading'>Ink Colors</h4>
+          <p class='theme-var-edit-hint'>
+            Each hue used as text or icon color on a neutral surface. Leave
+            blank to derive from the hue and the foreground color.
+          </p>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Primary Ink'
+              @vertical={{true}}
+              data-test-field='primaryInk'
+            >
+              <@fields.primaryInk />
+            </FieldContainer>
+            <FieldContainer
+              @label='Secondary Ink'
+              @vertical={{true}}
+              data-test-field='secondaryInk'
+            >
+              <@fields.secondaryInk />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Accent Ink'
+              @vertical={{true}}
+              data-test-field='accentInk'
+            >
+              <@fields.accentInk />
+            </FieldContainer>
+            <FieldContainer
+              @label='Destructive Ink'
+              @vertical={{true}}
+              data-test-field='destructiveInk'
+            >
+              <@fields.destructiveInk />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Success Ink'
+              @vertical={{true}}
+              data-test-field='successInk'
+            >
+              <@fields.successInk />
+            </FieldContainer>
+            <FieldContainer
+              @label='Warning Ink'
+              @vertical={{true}}
+              data-test-field='warningInk'
+            >
+              <@fields.warningInk />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Info Ink'
+              @vertical={{true}}
+              data-test-field='infoInk'
+            >
+              <@fields.infoInk />
+            </FieldContainer>
+            <FieldContainer
+              @label='Attention Ink'
+              @vertical={{true}}
+              data-test-field='attentionInk'
+            >
+              <@fields.attentionInk />
             </FieldContainer>
           </div>
         </section>
@@ -1106,6 +1546,22 @@ export default class ThemeVarField extends FieldDef {
               data-test-field='chart5'
             >
               <@fields.chart5 />
+            </FieldContainer>
+            <FieldContainer
+              @label='Chart 6'
+              @vertical={{true}}
+              data-test-field='chart6'
+            >
+              <@fields.chart6 />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Chart 7'
+              @vertical={{true}}
+              data-test-field='chart7'
+            >
+              <@fields.chart7 />
             </FieldContainer>
           </div>
         </section>
@@ -1237,6 +1693,13 @@ export default class ThemeVarField extends FieldDef {
             >
               <@fields.trackingNormal />
             </FieldContainer>
+            <FieldContainer
+              @label='Control Height'
+              @vertical={{true}}
+              data-test-field='controlHeight'
+            >
+              <@fields.controlHeight />
+            </FieldContainer>
           </div>
         </section>
 
@@ -1317,6 +1780,15 @@ export default class ThemeVarField extends FieldDef {
               data-test-field='shadow2xl'
             >
               <@fields.shadow2xl />
+            </FieldContainer>
+          </div>
+          <div class='theme-var-edit-row theme-var-edit-row--2col'>
+            <FieldContainer
+              @label='Inset'
+              @vertical={{true}}
+              data-test-field='shadowInset'
+            >
+              <@fields.shadowInset />
             </FieldContainer>
           </div>
           <h5 class='theme-var-edit-subheading'>Imported shadow primitives</h5>

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -5,6 +5,7 @@ import { modifier } from 'ember-modifier';
 import {
   CopyButton,
   FieldContainer,
+  Pill,
   Swatch,
   Tooltip,
 } from '@cardstack/boxel-ui/components';
@@ -293,55 +294,72 @@ export class ThemeTypographyField extends FieldDef {
   static embedded = class Embedded extends Component<typeof this> {
     <template>
       <section class='theme-typography'>
-        <span class='theme-typography-eyebrow'>
-          {{#if @model.eyebrow.sampleText}}
-            {{@model.eyebrow.sampleText}}
-          {{else}}
-            Eyebrow
-          {{/if}}
-        </span>
-        <h1>
-          {{#if @model.heading.sampleText}}
-            {{@model.heading.sampleText}}
-          {{else}}
-            Sample Heading (H1)
-          {{/if}}
-        </h1>
-        <h2>
-          {{#if @model.sectionHeading.sampleText}}
-            {{@model.sectionHeading.sampleText}}
-          {{else}}
-            Sample Section Heading (H2)
-          {{/if}}
-        </h2>
-        <h3>
-          {{#if @model.subheading.sampleText}}
-            {{@model.subheading.sampleText}}
-          {{else}}
-            Sample Subheading (H3)
-          {{/if}}
-        </h3>
-        <p>
-          {{#if @model.body.sampleText}}
-            {{@model.body.sampleText}}
-          {{else}}
-            Sample body text.
-          {{/if}}
-        </p>
-        <small>
-          {{#if @model.caption.sampleText}}
-            {{@model.caption.sampleText}}
-          {{else}}
-            Small text
-          {{/if}}
-        </small>
-        <span class='theme-typography-label'>
-          {{#if @model.label.sampleText}}
-            {{@model.label.sampleText}}
-          {{else}}
-            UI label
-          {{/if}}
-        </span>
+        <MeasuredType @role='Eyebrow' @token='--boxel-eyebrow-*'>
+          <span class='theme-typography-eyebrow'>
+            {{#if @model.eyebrow.sampleText}}
+              {{@model.eyebrow.sampleText}}
+            {{else}}
+              Eyebrow
+            {{/if}}
+          </span>
+        </MeasuredType>
+        <MeasuredType @role='Heading' @token='--boxel-heading-*'>
+          <h1>
+            {{#if @model.heading.sampleText}}
+              {{@model.heading.sampleText}}
+            {{else}}
+              Sample Heading (H1)
+            {{/if}}
+          </h1>
+        </MeasuredType>
+        <MeasuredType
+          @role='Section heading'
+          @token='--boxel-section-heading-*'
+        >
+          <h2>
+            {{#if @model.sectionHeading.sampleText}}
+              {{@model.sectionHeading.sampleText}}
+            {{else}}
+              Sample Section Heading (H2)
+            {{/if}}
+          </h2>
+        </MeasuredType>
+        <MeasuredType @role='Subheading' @token='--boxel-subheading-*'>
+          <h3>
+            {{#if @model.subheading.sampleText}}
+              {{@model.subheading.sampleText}}
+            {{else}}
+              Sample Subheading (H3)
+            {{/if}}
+          </h3>
+        </MeasuredType>
+        <MeasuredType @role='Body' @token='--boxel-body-*'>
+          <p>
+            {{#if @model.body.sampleText}}
+              {{@model.body.sampleText}}
+            {{else}}
+              Sample body text.
+            {{/if}}
+          </p>
+        </MeasuredType>
+        <MeasuredType @role='Caption' @token='--boxel-caption-*'>
+          <small>
+            {{#if @model.caption.sampleText}}
+              {{@model.caption.sampleText}}
+            {{else}}
+              Small text
+            {{/if}}
+          </small>
+        </MeasuredType>
+        <MeasuredType @role='UI label' @token='--boxel-ui-label-*'>
+          <span class='theme-typography-label'>
+            {{#if @model.label.sampleText}}
+              {{@model.label.sampleText}}
+            {{else}}
+              UI label
+            {{/if}}
+          </span>
+        </MeasuredType>
       </section>
       <style scoped>
         .theme-typography {
@@ -378,6 +396,135 @@ export class ThemeTypographyField extends FieldDef {
       </style>
     </template>
   };
+}
+
+// The variable name behind a sample, so a reader can find what to edit: a
+// muted Pill rendered as <code>, in the mono face
+export class TokenPill extends GlimmerComponent<{
+  Args: { name: string };
+  Element: HTMLElement;
+}> {
+  <template>
+    <Pill @tag='code' @variant='muted' class='token-pill' ...attributes>
+      {{@name}}
+    </Pill>
+    <style scoped>
+      .token-pill {
+        font-family: var(--font-mono, var(--boxel-monospace-font-family));
+        font-weight: 400;
+        letter-spacing: normal;
+        white-space: nowrap;
+      }
+    </style>
+  </template>
+}
+
+// One rung of the type ladder: the specimen, its token, and the size and
+// weight the browser actually resolved for it
+class MeasuredType extends GlimmerComponent<{
+  Args: { role: string; token: string };
+  Blocks: { default: [] };
+  Element: HTMLElement;
+}> {
+  @tracked private measured?: string;
+
+  private measure = modifier((el: HTMLElement) => {
+    let read = () =>
+      schedule('afterRender', () => {
+        if (!el.isConnected) {
+          return;
+        }
+        // the yielded specimen carries the role's styles, not the wrapper
+        let style = getComputedStyle(el.firstElementChild ?? el);
+        let size = parseFloat(style.fontSize);
+        let line = parseFloat(style.lineHeight);
+        let ratio =
+          size && line
+            ? ` / ${(line / size).toFixed(2).replace(/0$/, '')}`
+            : '';
+        let next = `${Math.round(size * 100) / 100}px${ratio} · ${style.fontWeight}`;
+        // the observer below also sees this component's own output, so only
+        // dirty the tracked value when the measurement actually moved
+        if (next !== this.measured) {
+          this.measured = next;
+        }
+      });
+    read();
+    // theme edits and the light/dark toggle land inside the dashboard: its
+    // <style> tag is rewritten and its wrapper's data-theme flips. Neither
+    // changes this component's args, so watch that subtree and re-measure.
+    let scope =
+      el.closest<HTMLElement>('[data-theme-dashboard]')?.parentElement ??
+      document.head;
+    let observer = new MutationObserver(read);
+    observer.observe(scope, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    return () => observer.disconnect();
+  });
+
+  <template>
+    <div class='measured-type' ...attributes>
+      <div class='measured-type-specimen' {{this.measure}}>
+        {{yield}}
+      </div>
+      <dl class='measured-type-meta'>
+        <dt class='measured-type-role'>{{@role}}</dt>
+        <dd class='measured-type-value' data-test-measured-type={{@role}}>
+          {{this.measured}}
+        </dd>
+        <dd><TokenPill @name={{@token}} /></dd>
+      </dl>
+    </div>
+    <style scoped>
+      .measured-type {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: var(--boxel-sp);
+        align-items: baseline;
+        padding-bottom: var(--boxel-sp-xs);
+        border-bottom: 1px solid var(--border);
+      }
+      .measured-type-specimen {
+        min-width: 0;
+      }
+      .measured-type-meta {
+        margin: 0;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: var(--boxel-sp-4xs) var(--boxel-sp-xs);
+        color: var(--muted-foreground);
+        font-size: var(--boxel-font-size-xs);
+        text-align: right;
+      }
+      .measured-type-meta dd {
+        margin: 0;
+      }
+      .measured-type-role {
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .measured-type-value {
+        font-family: var(--font-mono, var(--boxel-monospace-font-family));
+        font-variant-numeric: tabular-nums;
+      }
+      @container (width < 480px) {
+        .measured-type {
+          grid-template-columns: 1fr;
+        }
+        .measured-type-meta {
+          justify-content: flex-start;
+          text-align: left;
+        }
+      }
+    </style>
+  </template>
 }
 
 export class FontPreviews extends GlimmerComponent<{

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -1,7 +1,12 @@
+import { schedule } from '@ember/runloop';
+import { tracked } from '@glimmer/tracking';
+import { modifier } from 'ember-modifier';
+
 import {
   CopyButton,
   FieldContainer,
   Swatch,
+  Tooltip,
 } from '@cardstack/boxel-ui/components';
 import {
   buildCssVariableName,
@@ -58,11 +63,48 @@ function describeColor(base: string) {
   return `${base} ${COLOR_VALUE_INPUT_HELP}`;
 }
 
-function getFieldGroup(fieldNames: string[], model?: Record<string, any>) {
+// `property` is what an unset variable is probed through to resolve its
+// inherited default (see resolveThemeVariable)
+function getFieldGroup(
+  fieldNames: string[],
+  model?: Record<string, any>,
+  property = 'background-color',
+) {
   return fieldNames?.map((fieldName: string) => ({
     name: buildCssVariableName(fieldName),
     value: model?.[fieldName],
+    property,
   }));
+}
+
+// what a probe computes to when the variable is undeclared or not valid for
+// the probed property
+const UNRESOLVED_PROBE_VALUES = new Set([
+  '',
+  'none',
+  'auto',
+  'rgba(0, 0, 0, 0)',
+]);
+
+// Resolves a contract token the theme leaves unset. The swatch grid renders
+// inside the dashboard's theme scope, where theme.css declares every token, so
+// reading it there yields the default the card actually renders with, in the
+// color mode the preview is showing. `expression` is the declared value with
+// var() substituted (a color-mix formula stays a formula); `resolved` applies
+// it to `property` on a probe so formulas collapse to a literal.
+function resolveThemeVariable(el: HTMLElement, name: string, property: string) {
+  let expression = getComputedStyle(el).getPropertyValue(name).trim();
+  let probe = document.createElement('span');
+  probe.style.cssText =
+    'position:absolute;visibility:hidden;pointer-events:none';
+  probe.style.setProperty(property, `var(${name})`);
+  el.appendChild(probe);
+  let resolved = getComputedStyle(probe).getPropertyValue(property).trim();
+  probe.remove();
+  if (UNRESOLVED_PROBE_VALUES.has(resolved)) {
+    resolved = expression;
+  }
+  return { expression, resolved };
 }
 
 export function calculateTypographyVariables(
@@ -251,6 +293,13 @@ export class ThemeTypographyField extends FieldDef {
   static embedded = class Embedded extends Component<typeof this> {
     <template>
       <section class='theme-typography'>
+        <span class='theme-typography-eyebrow'>
+          {{#if @model.eyebrow.sampleText}}
+            {{@model.eyebrow.sampleText}}
+          {{else}}
+            Eyebrow
+          {{/if}}
+        </span>
         <h1>
           {{#if @model.heading.sampleText}}
             {{@model.heading.sampleText}}
@@ -291,13 +340,6 @@ export class ThemeTypographyField extends FieldDef {
             {{@model.label.sampleText}}
           {{else}}
             UI label
-          {{/if}}
-        </span>
-        <span class='theme-typography-eyebrow'>
-          {{#if @model.eyebrow.sampleText}}
-            {{@model.eyebrow.sampleText}}
-          {{else}}
-            Eyebrow
           {{/if}}
         </span>
       </section>
@@ -421,10 +463,128 @@ class Embedded extends Component<typeof ThemeVarField> {
   </template>
 }
 
+// A field the theme leaves blank, shown with the value it inherits from the
+// Boxel defaults so the preview reads as the card will render
+class InheritedSwatch extends GlimmerComponent<{
+  Args: {
+    name: string;
+    property: string;
+  };
+  Element: HTMLElement;
+}> {
+  @tracked private resolved?: string;
+  @tracked private expression?: string;
+
+  // The grid re-renders when the preview's color mode flips, so this re-runs
+  // per mode. Tracked state is written after render: the values are consumed
+  // by this template before the modifier installs.
+  private resolve = modifier(
+    (el: HTMLElement, [name, property]: [string, string]) => {
+      schedule('afterRender', () => {
+        if (!el.isConnected) {
+          return;
+        }
+        let { expression, resolved } = resolveThemeVariable(el, name, property);
+        this.expression = expression;
+        this.resolved = resolved;
+      });
+    },
+  );
+
+  <template>
+    {{! class names here must not repeat ThemeSwatch's: its scoped rules reach
+        this element through ...attributes }}
+    <div
+      class='inherited-swatch'
+      {{this.resolve @name @property}}
+      data-test-var-value={{@name}}
+      data-test-var-inherited={{this.resolved}}
+      ...attributes
+    >
+      <Tooltip class='inherited-swatch-tag' @placement='top'>
+        <:trigger>
+          <span class='inherited-tag'>inherited</span>
+        </:trigger>
+        <:content>
+          Not set on this theme. Resolves from the Boxel defaults as
+          <code>{{this.expression}}</code>
+        </:content>
+      </Tooltip>
+      <Swatch
+        class='inherited-swatch-preview'
+        @color={{this.resolved}}
+        @label={{@name}}
+      />
+    </div>
+    <style scoped>
+      @layer {
+        /* tag at the top of the cell and swatch at the bottom, so across a row
+           the tags line up with each other and the swatches with the set
+           swatches in neighbouring cells, which also bottom-align */
+        .inherited-swatch {
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          align-items: flex-start;
+          gap: var(--boxel-sp-4xs);
+          width: 100%;
+          min-width: 0;
+        }
+        /* same swatch layout as ThemeSwatch */
+        .inherited-swatch-preview {
+          --swatch-width: 2.75rem;
+          --swatch-height: 2.75rem;
+          display: flex;
+          flex-direction: row-reverse;
+          justify-content: flex-end;
+          align-items: center;
+          align-self: stretch;
+          min-width: 0;
+        }
+        :deep(.boxel-swatch-preview) {
+          box-shadow: var(--swatch-background);
+          flex-shrink: 0;
+          aspect-ratio: 1;
+          border-style: dashed;
+        }
+        :deep(.boxel-swatch-label) {
+          min-width: 0;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        :deep(.boxel-swatch-name) {
+          font-weight: 600;
+          font-size: var(--boxel-font-size-xs);
+          font-family: var(--font-mono, var(--boxel-monospace-font-family));
+          text-wrap: wrap;
+          overflow-wrap: anywhere;
+        }
+        :deep(.boxel-swatch-value) {
+          font-size: var(--boxel-font-size-xs);
+          text-transform: lowercase;
+        }
+        .inherited-tag {
+          padding: var(--boxel-sp-5xs) var(--boxel-sp-3xs);
+          border: 1px solid var(--border, var(--boxel-border-color));
+          border-radius: var(--boxel-border-radius-xs);
+          color: var(--muted-foreground, var(--boxel-450));
+          font-size: var(--boxel-font-size-2xs);
+          font-weight: 600;
+          letter-spacing: var(--boxel-lsp-xs);
+          text-transform: uppercase;
+          white-space: nowrap;
+        }
+      }
+    </style>
+  </template>
+}
+
 class ThemeSwatch extends GlimmerComponent<{
   Args: {
     value: string;
-    label?: string;
+    label: string;
+    property?: string;
   };
   Element: HTMLElement;
 }> {
@@ -445,10 +605,11 @@ class ThemeSwatch extends GlimmerComponent<{
         />
       </div>
     {{else if @label.length}}
-      <div data-test-var-value={{@label}}>
-        <div class='empty-field-name'>{{@label}}</div>
-        <code class='empty-value'>/* not set */</code>
-      </div>
+      <InheritedSwatch
+        @name={{@label}}
+        @property={{if @property @property 'background-color'}}
+        ...attributes
+      />
     {{/if}}
     <style scoped>
       @layer {
@@ -476,7 +637,6 @@ class ThemeSwatch extends GlimmerComponent<{
           overflow: hidden;
           text-overflow: ellipsis;
         }
-        .empty-field-name,
         :deep(.boxel-swatch-name) {
           font-weight: 600;
           font-size: var(--boxel-font-size-xs);
@@ -488,11 +648,6 @@ class ThemeSwatch extends GlimmerComponent<{
           font-size: var(--boxel-font-size-xs);
           text-transform: lowercase;
         }
-        .empty-value {
-          padding: var(--boxel-sp-4xs);
-          font-style: italic;
-          font-size: var(--boxel-font-size-xs);
-        }
       }
     </style>
   </template>
@@ -500,14 +655,18 @@ class ThemeSwatch extends GlimmerComponent<{
 
 class FieldGrid extends GlimmerComponent<{
   Args: {
-    fields: { name: string; value: string }[];
+    fields: { name: string; value: string; property?: string }[];
   };
   Element: HTMLElement;
 }> {
   <template>
     <div class='field-grid' ...attributes>
       {{#each @fields as |field|}}
-        <ThemeSwatch @value={{field.value}} @label={{field.name}} />
+        <ThemeSwatch
+          @value={{field.value}}
+          @label={{field.name}}
+          @property={{field.property}}
+        />
       {{/each}}
     </div>
     <style scoped>
@@ -515,7 +674,7 @@ class FieldGrid extends GlimmerComponent<{
         display: grid;
         /* min() lets the column shrink instead of overflowing a narrow card */
         grid-template-columns: repeat(auto-fill, minmax(min(11rem, 100%), 1fr));
-        gap: var(--boxel-sp-xs) var(--boxel-sp-2xs);
+        gap: var(--boxel-sp-sm) var(--boxel-sp-2xs);
       }
     </style>
   </template>
@@ -1016,7 +1175,7 @@ export default class ThemeVarField extends FieldDef {
       },
       {
         title: 'Box Shadow',
-        fields: getFieldGroup(this.boxShadows, this),
+        fields: getFieldGroup(this.boxShadows, this, 'box-shadow'),
       },
     ];
   }

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -361,11 +361,11 @@ export class ThemeTypographyField extends FieldDef {
           word-break: break-word;
         }
         .theme-typography-label {
-          font-family: var(--boxel-label-font-family);
-          font-size: var(--boxel-label-font-size);
-          font-weight: var(--boxel-label-font-weight);
-          line-height: var(--boxel-label-line-height);
-          letter-spacing: var(--boxel-label-letter-spacing);
+          font-family: var(--boxel-ui-label-font-family);
+          font-size: var(--boxel-ui-label-font-size);
+          font-weight: var(--boxel-ui-label-font-weight);
+          line-height: var(--boxel-ui-label-line-height);
+          letter-spacing: var(--boxel-ui-label-letter-spacing);
         }
         .theme-typography-eyebrow {
           font-family: var(--boxel-eyebrow-font-family);
@@ -475,19 +475,34 @@ class InheritedSwatch extends GlimmerComponent<{
   @tracked private resolved?: string;
   @tracked private expression?: string;
 
-  // The grid re-renders when the preview's color mode flips, so this re-runs
-  // per mode. Tracked state is written after render: the values are consumed
-  // by this template before the modifier installs.
+  // Tracked state is written after render: the values are consumed by this
+  // template before the modifier installs. The preview's light/dark toggle
+  // flips `data-theme` on an ancestor without necessarily tearing this tree
+  // down (Style Reference renders the palette unconditionally), so watch that
+  // attribute and re-resolve rather than relying on a re-render.
   private resolve = modifier(
     (el: HTMLElement, [name, property]: [string, string]) => {
-      schedule('afterRender', () => {
-        if (!el.isConnected) {
-          return;
-        }
-        let { expression, resolved } = resolveThemeVariable(el, name, property);
-        this.expression = expression;
-        this.resolved = resolved;
-      });
+      let read = () =>
+        schedule('afterRender', () => {
+          if (!el.isConnected) {
+            return;
+          }
+          let { expression, resolved } = resolveThemeVariable(
+            el,
+            name,
+            property,
+          );
+          this.expression = expression;
+          this.resolved = resolved;
+        });
+      read();
+      let scheme = el.closest('[data-theme]');
+      let observer: MutationObserver | undefined;
+      if (scheme) {
+        observer = new MutationObserver(read);
+        observer.observe(scheme, { attributeFilter: ['data-theme'] });
+      }
+      return () => observer?.disconnect();
     },
   );
 
@@ -877,7 +892,7 @@ export default class ThemeVarField extends FieldDef {
   });
   @field input = contains(ColorField, {
     description: describeColor(
-      'Border color for inputs; the input background is --field.',
+      'Border color for inputs, and the track fill of unfilled controls such as a switch. Input backgrounds come from --field.',
     ),
   });
   @field ring = contains(ColorField, {
@@ -1943,7 +1958,7 @@ export default class ThemeVarField extends FieldDef {
           </div>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
             <FieldContainer
-              @label='Inset'
+              @label='Shadow inset'
               @vertical={{true}}
               data-test-field='shadowInset'
             >

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -445,6 +445,9 @@ class Embedded extends Component<typeof ThemeVarField> {
   <template>
     {{#each @model.fieldGroups as |group|}}
       <h4 class='field-group-title'>{{group.title}}</h4>
+      {{#if group.description}}
+        <p class='field-group-description'>{{group.description}}</p>
+      {{/if}}
       <FieldGrid class='field-group-grid' @fields={{group.fields}} />
     {{/each}}
     <style scoped>
@@ -454,6 +457,11 @@ class Embedded extends Component<typeof ThemeVarField> {
           color: var(--muted-foreground);
           font-weight: 500;
           font-size: var(--boxel-font-size);
+        }
+        .field-group-description {
+          margin: calc(-1 * var(--boxel-sp-xs)) 0 var(--boxel-sp);
+          color: var(--muted-foreground);
+          font-size: var(--boxel-font-size-sm);
         }
         .field-group-grid {
           margin-bottom: var(--boxel-sp-2xl);
@@ -1170,6 +1178,8 @@ export default class ThemeVarField extends FieldDef {
       },
       {
         title: 'Surface Colors',
+        description:
+          'Neutral backgrounds beyond the card: the workspace ground, sunken wells, hover and selected states, zebra rows, and tooltips.',
         fields: getFieldGroup(this.surfaceColors, this),
       },
       {
@@ -1178,6 +1188,8 @@ export default class ThemeVarField extends FieldDef {
       },
       {
         title: 'Ink Colors',
+        description:
+          "Each hue used as text or icon color on a neutral surface, as opposed to the -foreground color used on the hue's own fill.",
         fields: getFieldGroup(this.inkColors, this),
       },
       {
@@ -1416,6 +1428,10 @@ export default class ThemeVarField extends FieldDef {
 
         <section class='theme-var-edit-section'>
           <h4 class='theme-var-edit-heading'>Surfaces</h4>
+          <p class='theme-var-edit-hint'>
+            Neutral backgrounds beyond the card: the workspace ground, sunken
+            wells, hover and selected states, zebra rows, and tooltips.
+          </p>
           <div class='theme-var-edit-row theme-var-edit-row--2col'>
             <FieldContainer
               @label='Canvas'

--- a/packages/base/structured-theme.gts
+++ b/packages/base/structured-theme.gts
@@ -333,6 +333,7 @@ class Edit extends Isolated {
 
 export default class StructuredTheme extends Theme {
   static displayName = 'Theme';
+  static prefersWideFormat = true;
 
   @field typography = contains(ThemeTypographyField, {
     description:

--- a/packages/base/structured-theme.gts
+++ b/packages/base/structured-theme.gts
@@ -280,7 +280,10 @@ class Isolated extends Component<typeof StructuredTheme> {
               >
                 {{#if (eq section.id 'card-container-css')}}
                   {{#if @model.cssVariables}}
-                    <CardContainerCss @cssVariables={{@model.cssVariables}} />
+                    <CardContainerCss
+                      @cssVariables={{@model.cssVariables}}
+                      @isDarkMode={{this.isDarkMode}}
+                    />
                   {{else}}
                     <p><em>No theme variables added</em></p>
                   {{/if}}

--- a/packages/base/style-reference.gts
+++ b/packages/base/style-reference.gts
@@ -117,10 +117,12 @@ class Isolated extends Component<typeof StyleReference> {
           />
         {{else}}
           <header class='style-header'>
-            <h1><@fields.cardTitle /></h1>
-            <p class='style-header-description'>
-              <@fields.cardDescription />
-            </p>
+            <div class='style-header-content'>
+              <h1><@fields.cardTitle /></h1>
+              <p class='style-header-description'>
+                <@fields.cardDescription />
+              </p>
+            </div>
           </header>
         {{/if}}
       </:header>
@@ -284,8 +286,12 @@ class Isolated extends Component<typeof StyleReference> {
       section {
         scroll-margin-top: var(--boxel-sp-2xl);
       }
-      .style-reference {
-        max-width: 50rem;
+      /* the header band spans the card; its text keeps to the dashboard's
+         content measure, minus the band's own padding */
+      .style-header-content {
+        max-width: calc(
+          var(--dsr-content-max-width, 56rem) - 2 * var(--boxel-sp-2xl)
+        );
         margin: 0 auto;
       }
       .style-header {

--- a/packages/base/style-reference.gts
+++ b/packages/base/style-reference.gts
@@ -138,7 +138,7 @@ class Isolated extends Component<typeof StyleReference> {
             @editMode={{this.editMode}}
           >
             <:colorPalette>
-              <@fields.rootVariables />
+              <@fields.rootVariables data-test-root-vars />
             </:colorPalette>
             <:typography>
               <@fields.typography />
@@ -286,11 +286,13 @@ class Isolated extends Component<typeof StyleReference> {
       section {
         scroll-margin-top: var(--boxel-sp-2xl);
       }
-      /* the header band spans the card; its text keeps to the dashboard's
-         content measure, minus the band's own padding */
+      /* the header band spans the card; its text keeps to the body's measure,
+         which is the dashboard's content measure less .dsr-content's padding
+         and the section grid's own padding-inline */
       .style-header-content {
         max-width: calc(
-          var(--dsr-content-max-width, 56rem) - 2 * var(--boxel-sp-2xl)
+          var(--dsr-content-max-width, 56rem) - 2 * var(--boxel-sp-xl) - 2 *
+            var(--boxel-sp-2xl)
         );
         margin: 0 auto;
       }

--- a/packages/base/style-reference.gts
+++ b/packages/base/style-reference.gts
@@ -256,7 +256,10 @@ class Isolated extends Component<typeof StyleReference> {
               {{#if @model.cssVariables}}
                 <section id='card-container-css'>
                   <h2>Computed Styles</h2>
-                  <CardContainerCss @cssVariables={{@model.cssVariables}} />
+                  <CardContainerCss
+                    @cssVariables={{@model.cssVariables}}
+                    @isDarkMode={{this.isDarkMode}}
+                  />
                 </section>
               {{/if}}
 

--- a/packages/base/typography.gts
+++ b/packages/base/typography.gts
@@ -28,7 +28,8 @@ class TypographyEmbedded extends Component<typeof TypographyField> {
   </template>
 
   private get styles() {
-    let { fontFamily, fontSize, fontWeight, lineHeight } = this.args.model;
+    let { fontFamily, fontSize, fontWeight, lineHeight, letterSpacing } =
+      this.args.model;
     let styles = [];
     if (fontFamily) {
       styles.push(`font-family: ${fontFamily}`);
@@ -42,6 +43,9 @@ class TypographyEmbedded extends Component<typeof TypographyField> {
     if (lineHeight) {
       styles.push(`line-height: ${lineHeight}`);
     }
+    if (letterSpacing) {
+      styles.push(`letter-spacing: ${letterSpacing}`);
+    }
     return sanitizeHtmlSafe(styles.join('; '));
   }
 }
@@ -53,6 +57,7 @@ export default class TypographyField extends FieldDef {
   @field fontSize = contains(CSSValueField);
   @field fontWeight = contains(CSSValueField);
   @field lineHeight = contains(CSSValueField);
+  @field letterSpacing = contains(CSSValueField);
   @field sampleText = contains(StringField);
 
   get fieldEntries(): CssVariableEntry[] | undefined {
@@ -118,12 +123,14 @@ export default class TypographyField extends FieldDef {
 
   static edit = class Edit extends Component<typeof TypographyField> {
     private get styles() {
-      let { fontFamily, fontSize, fontWeight, lineHeight } = this.args.model;
+      let { fontFamily, fontSize, fontWeight, lineHeight, letterSpacing } =
+        this.args.model;
       let styles = [];
       if (fontFamily) styles.push(`font-family: ${fontFamily}`);
       if (fontSize) styles.push(`font-size: ${fontSize}`);
       if (fontWeight) styles.push(`font-weight: ${fontWeight}`);
       if (lineHeight) styles.push(`line-height: ${lineHeight}`);
+      if (letterSpacing) styles.push(`letter-spacing: ${letterSpacing}`);
       return sanitizeHtmlSafe(styles.join('; '));
     }
 
@@ -150,6 +157,11 @@ export default class TypographyField extends FieldDef {
           </FieldContainer>
           <FieldContainer @label='Line Height' @vertical={{true}}>
             <@fields.lineHeight />
+          </FieldContainer>
+        </div>
+        <div class='typography-edit-row typography-edit-row--2col'>
+          <FieldContainer @label='Letter Spacing' @vertical={{true}}>
+            <@fields.letterSpacing />
           </FieldContainer>
         </div>
         <FieldContainer @label='Sample Text' @vertical={{true}}>
@@ -202,6 +214,7 @@ export default class TypographyField extends FieldDef {
         { key: 'fontSize', label: 'Font size' },
         { key: 'fontWeight', label: 'Font weight' },
         { key: 'lineHeight', label: 'Line height' },
+        { key: 'letterSpacing', label: 'Letter spacing' },
       ];
       for (let { key, label } of labels) {
         let value = model[key] as string | undefined;

--- a/packages/boxel-ui/src/components/card-container/index.gts
+++ b/packages/boxel-ui/src/components/card-container/index.gts
@@ -264,7 +264,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       );
       --boxel-eyebrow-font-weight: var(--theme-eyebrow-font-weight, 600);
 
-      /* letter-spacing per slot; body and label follow the theme's base tracking */
+      /* letter-spacing per slot; body, caption, and label follow the theme's base tracking */
       --boxel-heading-letter-spacing: var(
         --theme-heading-letter-spacing,
         normal
@@ -300,6 +300,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       font-size: var(--boxel-body-font-size);
       font-weight: var(--boxel-body-font-weight);
       line-height: var(--boxel-body-line-height);
+      letter-spacing: var(--boxel-body-letter-spacing);
     }
 
     /* Element reset + typography roles, contained to card content: bare
@@ -319,18 +320,21 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
         font-size: var(--boxel-heading-font-size);
         font-weight: var(--boxel-heading-font-weight);
         line-height: var(--boxel-heading-line-height);
+        letter-spacing: var(--boxel-heading-letter-spacing);
       }
       :global(.boxel-card-container h2) {
         font-family: var(--boxel-section-heading-font-family);
         font-size: var(--boxel-section-heading-font-size);
         font-weight: var(--boxel-section-heading-font-weight);
         line-height: var(--boxel-section-heading-line-height);
+        letter-spacing: var(--boxel-section-heading-letter-spacing);
       }
       :global(.boxel-card-container h3) {
         font-family: var(--boxel-subheading-font-family);
         font-size: var(--boxel-subheading-font-size);
         font-weight: var(--boxel-subheading-font-weight);
         line-height: var(--boxel-subheading-line-height);
+        letter-spacing: var(--boxel-subheading-letter-spacing);
       }
       :global(.boxel-card-container :is(h4, h5, h6)) {
         font-size: inherit;
@@ -338,6 +342,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       :global(.boxel-card-container small) {
         font-size: var(--boxel-caption-font-size);
         line-height: var(--boxel-caption-line-height);
+        letter-spacing: var(--boxel-caption-letter-spacing);
       }
     }
   </style>

--- a/packages/boxel-ui/src/components/card-container/index.gts
+++ b/packages/boxel-ui/src/components/card-container/index.gts
@@ -234,6 +234,68 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       );
       --boxel-caption-font-weight: var(--theme-caption-font-weight, 500);
 
+      /* ui label: control text, table headers, badges */
+      --boxel-label-font-family: var(
+        --theme-label-font-family,
+        var(--boxel-body-font-family)
+      );
+      --boxel-label-font-size: var(
+        --theme-label-font-size,
+        var(--boxel-font-size-xs)
+      );
+      --boxel-label-line-height: var(
+        --theme-label-line-height,
+        var(--boxel-line-height-xs)
+      );
+      --boxel-label-font-weight: var(--theme-label-font-weight, 500);
+
+      /* eyebrow: the tracked-out kicker above a title */
+      --boxel-eyebrow-font-family: var(
+        --theme-eyebrow-font-family,
+        var(--boxel-label-font-family)
+      );
+      --boxel-eyebrow-font-size: var(
+        --theme-eyebrow-font-size,
+        var(--boxel-font-size-2xs)
+      );
+      --boxel-eyebrow-line-height: var(
+        --theme-eyebrow-line-height,
+        var(--boxel-line-height-xs)
+      );
+      --boxel-eyebrow-font-weight: var(--theme-eyebrow-font-weight, 600);
+
+      /* letter-spacing per slot; body and label follow the theme's base tracking */
+      --boxel-heading-letter-spacing: var(
+        --theme-heading-letter-spacing,
+        normal
+      );
+      --boxel-section-heading-letter-spacing: var(
+        --theme-section-heading-letter-spacing,
+        var(--theme-heading-letter-spacing, normal)
+      );
+      --boxel-subheading-letter-spacing: var(
+        --theme-subheading-letter-spacing,
+        var(--theme-heading-letter-spacing, normal)
+      );
+      --boxel-body-letter-spacing: var(
+        --theme-body-letter-spacing,
+        var(--tracking-normal, normal)
+      );
+      --boxel-caption-letter-spacing: var(
+        --theme-caption-letter-spacing,
+        var(--boxel-body-letter-spacing)
+      );
+      --boxel-label-letter-spacing: var(
+        --theme-label-letter-spacing,
+        var(--boxel-body-letter-spacing)
+      );
+      --boxel-eyebrow-letter-spacing: var(
+        --theme-eyebrow-letter-spacing,
+        0.08em
+      );
+
+      --boxel-form-control-height: var(--control-height, 2.5rem);
+
       font-family: var(--boxel-body-font-family);
       font-size: var(--boxel-body-font-size);
       font-weight: var(--boxel-body-font-weight);

--- a/packages/boxel-ui/src/components/card-container/index.gts
+++ b/packages/boxel-ui/src/components/card-container/index.gts
@@ -234,25 +234,27 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       );
       --boxel-caption-font-weight: var(--theme-caption-font-weight, 500);
 
-      /* ui label: control text, table headers, badges */
-      --boxel-label-font-family: var(
+      /* ui label: control text, table headers, badges. Kept off the
+         `--boxel-label-*` family, which is Label's own contract and has to
+         keep falling back to the body slot. */
+      --boxel-ui-label-font-family: var(
         --theme-label-font-family,
         var(--boxel-body-font-family)
       );
-      --boxel-label-font-size: var(
+      --boxel-ui-label-font-size: var(
         --theme-label-font-size,
         var(--boxel-font-size-xs)
       );
-      --boxel-label-line-height: var(
+      --boxel-ui-label-line-height: var(
         --theme-label-line-height,
         var(--boxel-line-height-xs)
       );
-      --boxel-label-font-weight: var(--theme-label-font-weight, 500);
+      --boxel-ui-label-font-weight: var(--theme-label-font-weight, 500);
 
       /* eyebrow: the tracked-out kicker above a title */
       --boxel-eyebrow-font-family: var(
         --theme-eyebrow-font-family,
-        var(--boxel-label-font-family)
+        var(--boxel-ui-label-font-family)
       );
       --boxel-eyebrow-font-size: var(
         --theme-eyebrow-font-size,
@@ -285,7 +287,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
         --theme-caption-letter-spacing,
         var(--boxel-body-letter-spacing)
       );
-      --boxel-label-letter-spacing: var(
+      --boxel-ui-label-letter-spacing: var(
         --theme-label-letter-spacing,
         var(--boxel-body-letter-spacing)
       );

--- a/packages/boxel-ui/src/components/label/index.gts
+++ b/packages/boxel-ui/src/components/label/index.gts
@@ -37,7 +37,7 @@ const Label: TemplateOnlyComponent<Signature> = <template>
         font-size: var(--boxel-label-font-size, var(--boxel-body-font-size));
         font-weight: var(--boxel-label-font-weight, 500);
         line-height: var(--boxel-label-line-height, 1.1);
-        font-family: inherit;
+        font-family: var(--boxel-label-font-family, inherit);
         letter-spacing: var(--boxel-label-letter-spacing, var(--boxel-lsp-sm));
       }
       .boxel-label--small {

--- a/packages/boxel-ui/src/components/label/index.gts
+++ b/packages/boxel-ui/src/components/label/index.gts
@@ -37,7 +37,7 @@ const Label: TemplateOnlyComponent<Signature> = <template>
         font-size: var(--boxel-label-font-size, var(--boxel-body-font-size));
         font-weight: var(--boxel-label-font-weight, 500);
         line-height: var(--boxel-label-line-height, 1.1);
-        font-family: var(--boxel-label-font-family, inherit);
+        font-family: inherit;
         letter-spacing: var(--boxel-label-letter-spacing, var(--boxel-lsp-sm));
       }
       .boxel-label--small {

--- a/packages/boxel-ui/src/components/select/index.gts
+++ b/packages/boxel-ui/src/components/select/index.gts
@@ -147,6 +147,7 @@ export default class BoxelSelect<ItemT = any> extends Component<
       '--boxel-dropdown-selected-highlighted-color',
       '--boxel-dropdown-selected-hover-color',
       '--boxel-dropdown-hover-color',
+      '--boxel-dropdown-hover-text-color',
       '--boxel-form-control-border-radius',
     ];
 
@@ -389,30 +390,38 @@ export default class BoxelSelect<ItemT = any> extends Component<
         .boxel-select__dropdown.ember-power-select-dropdown {
           --dropdown-background-color: var(
             --boxel-dropdown-background-color,
-            var(--background, var(--boxel-light))
+            var(--background)
           );
           --dropdown-border-color: var(
             --boxel-dropdown-border-color,
-            var(--border, var(--boxel-border-color))
+            var(--border)
           );
           --dropdown-text-color: var(
             --boxel-dropdown-text-color,
-            var(--foreground, var(--boxel-dark))
+            var(--foreground)
           );
           --dropdown-highlight-color: var(
             --boxel-dropdown-highlight-color,
-            var(--theme-highlight, var(--boxel-highlight))
+            var(--theme-highlight, var(--primary))
           );
           --dropdown-highlight-hover-color: var(
             --boxel-dropdown-highlight-hover-color,
             var(
-              --boxel-dropdown-hover-color,
-              var(--theme-highlight-hover, var(--boxel-highlight-hover))
+              --theme-highlight-hover,
+              color-mix(
+                in oklab,
+                var(--dropdown-highlight-color) 88%,
+                var(--dropdown-selected-text-color)
+              )
             )
           );
           --dropdown-hover-color: var(
             --boxel-dropdown-hover-color,
-            var(--theme-hover, var(--boxel-light-100))
+            var(--theme-hover, var(--muted))
+          );
+          --dropdown-hover-text-color: var(
+            --boxel-dropdown-hover-text-color,
+            var(--foreground)
           );
           --dropdown-focus-border-color: var(
             --boxel-dropdown-focus-border-color,
@@ -420,7 +429,7 @@ export default class BoxelSelect<ItemT = any> extends Component<
           );
           --dropdown-selected-text-color: var(
             --boxel-dropdown-selected-text-color,
-            var(--foreground, var(--boxel-dark))
+            var(--primary-foreground)
           );
           --dropdown-selected-highlighted-color: var(
             --boxel-dropdown-selected-highlighted-color,
@@ -496,7 +505,7 @@ export default class BoxelSelect<ItemT = any> extends Component<
 
         .boxel-select__dropdown .ember-power-select-option:hover {
           background-color: var(--dropdown-hover-color);
-          color: var(--dropdown-selected-text-color);
+          color: var(--dropdown-hover-text-color);
         }
 
         .boxel-select__dropdown .ember-power-select-option:focus {
@@ -693,13 +702,13 @@ export class BoxelSelectOptions extends PowerSelectOptions {
 
       .boxel-select-option-item:not([aria-disabled='true']):hover {
         background-color: var(--dropdown-hover-color);
-        color: var(--dropdown-selected-text-color);
+        color: var(--dropdown-hover-text-color);
         cursor: pointer;
       }
 
       .boxel-select-option-item.is-highlighted {
         background-color: var(--dropdown-hover-color);
-        color: var(--dropdown-selected-text-color);
+        color: var(--dropdown-hover-text-color);
       }
 
       .boxel-select-option-item.is-selected {
@@ -715,6 +724,7 @@ export class BoxelSelectOptions extends PowerSelectOptions {
          apply — hovering an option also highlights it. */
       .boxel-select-option-item.is-selected:hover {
         background-color: var(--dropdown-selected-hover-color);
+        color: var(--dropdown-selected-text-color);
       }
 
       .boxel-select-option-item[aria-disabled='true'] {

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -165,12 +165,20 @@
   --attention-ink: color-mix(in oklch, var(--attention) 60%, var(--foreground));
 
   /* other */
+  /* same values the Switch falls back to; declared so a light region nested
+     in a dark subtree re-resolves them instead of inheriting the dark thumb */
+  --boxel-switch-thumb: var(--background);
+  --boxel-switch-thumb-icon: var(--foreground);
   --boxel-button-default-border: var(--boxel-button-border-color);
   --boxel-button-default-active-background: var(--background);
   --boxel-button-default-active-foreground: var(--foreground);
   --boxel-button-default-active-border: var(--foreground);
   --boxel-button-primary-active-background: var(--boxel-highlight-hover);
   --boxel-button-secondary-background: transparent;
+  /* declared in both scheme blocks: a var() inside a knob resolves where the
+     knob is declared, so a light region nested in a dark subtree would
+     otherwise inherit the dark-resolved color */
+  --boxel-button-secondary-foreground: var(--foreground);
   --boxel-button-secondary-border: var(--boxel-button-border-color);
   --boxel-button-secondary-active-border: var(--foreground);
   --boxel-button-destructive-active-background: var(--boxel-danger-hover);

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -56,7 +56,7 @@
   --hover: var(--boxel-dark-10);
   --stripe: var(--boxel-50);
   --selected: color-mix(in oklch, var(--primary) 15%, var(--card));
-  --tooltip: var(--boxel-dark);
+  --tooltip: var(--boxel-dark-80);
   --tooltip-foreground: var(--boxel-light);
   /* third ink step, fainter than --muted-foreground */
   --subtle-foreground: var(--boxel-400);
@@ -204,6 +204,7 @@
   --boxel-button-default-active-border: initial;
   --boxel-button-primary-active-background: initial;
   --boxel-button-secondary-background: initial;
+  --boxel-button-secondary-foreground: initial;
   --boxel-button-secondary-border: initial;
   --boxel-button-secondary-active-border: initial;
   --boxel-button-link-primary-foreground: initial;
@@ -249,8 +250,8 @@
   --hover: var(--boxel-light-10);
   --stripe: var(--boxel-600);
   --selected: color-mix(in oklch, var(--primary) 15%, var(--card));
-  --tooltip: var(--boxel-200);
-  --tooltip-foreground: var(--boxel-dark);
+  --tooltip: var(--boxel-dark-80);
+  --tooltip-foreground: var(--boxel-light);
   --subtle-foreground: #8a8895;
   --border: var(--boxel-550);
   --border-strong: #6e6c78;
@@ -285,6 +286,7 @@
   --boxel-button-default-active-border: var(--foreground);
   --boxel-button-primary-active-background: var(--boxel-highlight-hover);
   --boxel-button-secondary-background: transparent;
+  --boxel-button-secondary-foreground: var(--foreground);
   --boxel-button-secondary-border: var(--border);
   --boxel-button-secondary-active-border: var(--foreground);
   --boxel-button-destructive-active-background: var(--boxel-danger-hover);
@@ -301,8 +303,11 @@
    own `.dark` variables are applied (see theme-scoped-css.ts), so it follows
    the nearest light/dark switch rather than any `[data-theme]` ancestor.
    `:where()` keeps it at zero specificity so the card's scoped stylesheet
-   still wins. Must declare exactly the dark block's tokens (minus
-   --boxel-color-scheme, which has to keep inheriting) — a test enforces it. */
+   still wins. Declares the dark block's contract tokens, minus
+   --boxel-color-scheme (which has to keep inheriting) and minus the
+   --boxel-switch/button chrome knobs, which the boundary reset above
+   sets to `initial` so themed cards derive them from their own tokens in both
+   schemes — a test enforces both. */
 @container style(--boxel-color-scheme: dark) {
   :where([data-boxel-theme-scope]) {
     --background: var(--boxel-700);
@@ -327,8 +332,8 @@
     --hover: var(--boxel-light-10);
     --stripe: var(--boxel-600);
     --selected: color-mix(in oklch, var(--primary) 15%, var(--card));
-    --tooltip: var(--boxel-200);
-    --tooltip-foreground: var(--boxel-dark);
+    --tooltip: var(--boxel-dark-80);
+    --tooltip-foreground: var(--boxel-light);
     --subtle-foreground: #8a8895;
     --border: var(--boxel-550);
     --border-strong: #6e6c78;
@@ -363,20 +368,5 @@
     --sidebar-accent-foreground: var(--boxel-light);
     --sidebar-border: var(--boxel-550);
     --sidebar-ring: var(--boxel-highlight);
-    --boxel-switch-thumb: var(--boxel-light);
-    --boxel-switch-thumb-icon: var(--background);
-    --boxel-button-default-border: var(--border);
-    --boxel-button-default-active-background: var(--background);
-    --boxel-button-default-active-foreground: var(--foreground);
-    --boxel-button-default-active-border: var(--foreground);
-    --boxel-button-primary-active-background: var(--boxel-highlight-hover);
-    --boxel-button-secondary-background: transparent;
-    --boxel-button-secondary-border: var(--border);
-    --boxel-button-secondary-active-border: var(--foreground);
-    --boxel-button-destructive-active-background: var(--boxel-danger-hover);
-    --boxel-button-disabled-opacity: 1;
-    --boxel-button-disabled-background: #444051;
-    --boxel-button-disabled-foreground: #817c93;
-    --boxel-button-disabled-border: 1px solid#444051;
   }
 }

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -293,3 +293,90 @@
   --boxel-button-disabled-foreground: #817c93;
   --boxel-button-disabled-border: 1px solid#444051;
 }
+
+/* Dark defaults at themed-card boundaries. The light block re-declares the
+   whole contract on `:where([data-boxel-theme-scope])`, so without this a
+   themed card in a dark subtree would reset every token its theme omits to the
+   light default. Keyed off the inherited scheme signal, the same way a card's
+   own `.dark` variables are applied (see theme-scoped-css.ts), so it follows
+   the nearest light/dark switch rather than any `[data-theme]` ancestor.
+   `:where()` keeps it at zero specificity so the card's scoped stylesheet
+   still wins. Must declare exactly the dark block's tokens (minus
+   --boxel-color-scheme, which has to keep inheriting) — a test enforces it. */
+@container style(--boxel-color-scheme: dark) {
+  :where([data-boxel-theme-scope]) {
+    --background: var(--boxel-700);
+    --foreground: var(--boxel-light);
+    --card: var(--boxel-650);
+    --card-foreground: var(--boxel-light);
+    --popover: #4f4b57;
+    --popover-foreground: var(--boxel-light);
+    --primary: var(--boxel-highlight);
+    --primary-foreground: var(--boxel-dark);
+    --secondary: #46434e;
+    --secondary-foreground: var(--boxel-light);
+    --muted: #34313c;
+    --muted-foreground: #b6b6be;
+    --accent: #797788;
+    --accent-foreground: var(--boxel-light);
+    --destructive: var(--boxel-danger);
+    --destructive-foreground: var(--boxel-light-100);
+    --canvas: #1e1b26;
+    --inset: #302d3b;
+    --field: var(--boxel-700);
+    --hover: var(--boxel-light-10);
+    --stripe: var(--boxel-600);
+    --selected: color-mix(in oklch, var(--primary) 15%, var(--card));
+    --tooltip: var(--boxel-200);
+    --tooltip-foreground: var(--boxel-dark);
+    --subtle-foreground: #8a8895;
+    --border: var(--boxel-550);
+    --border-strong: #6e6c78;
+    --input: var(--boxel-550);
+    --ring: var(--boxel-highlight);
+    --overlay: var(--boxel-dark-80);
+    --primary-ink: color-mix(in oklch, var(--primary) 60%, var(--foreground));
+    --secondary-ink: color-mix(
+      in oklch,
+      var(--secondary) 60%,
+      var(--foreground)
+    );
+    --accent-ink: color-mix(in oklch, var(--accent) 60%, var(--foreground));
+    --destructive-ink: color-mix(
+      in oklch,
+      var(--destructive) 60%,
+      var(--foreground)
+    );
+    --success-ink: color-mix(in oklch, var(--success) 60%, var(--foreground));
+    --warning-ink: color-mix(in oklch, var(--warning) 60%, var(--foreground));
+    --info-ink: color-mix(in oklch, var(--info) 60%, var(--foreground));
+    --attention-ink: color-mix(
+      in oklch,
+      var(--attention) 60%,
+      var(--foreground)
+    );
+    --sidebar: #555366;
+    --sidebar-foreground: var(--boxel-light);
+    --sidebar-primary: var(--boxel-highlight);
+    --sidebar-primary-foreground: var(--boxel-dark);
+    --sidebar-accent: #797788;
+    --sidebar-accent-foreground: var(--boxel-light);
+    --sidebar-border: var(--boxel-550);
+    --sidebar-ring: var(--boxel-highlight);
+    --boxel-switch-thumb: var(--boxel-light);
+    --boxel-switch-thumb-icon: var(--background);
+    --boxel-button-default-border: var(--border);
+    --boxel-button-default-active-background: var(--background);
+    --boxel-button-default-active-foreground: var(--foreground);
+    --boxel-button-default-active-border: var(--foreground);
+    --boxel-button-primary-active-background: var(--boxel-highlight-hover);
+    --boxel-button-secondary-background: transparent;
+    --boxel-button-secondary-border: var(--border);
+    --boxel-button-secondary-active-border: var(--foreground);
+    --boxel-button-destructive-active-background: var(--boxel-danger-hover);
+    --boxel-button-disabled-opacity: 1;
+    --boxel-button-disabled-background: #444051;
+    --boxel-button-disabled-foreground: #817c93;
+    --boxel-button-disabled-border: 1px solid#444051;
+  }
+}

--- a/packages/boxel-ui/src/styles/theme.css
+++ b/packages/boxel-ui/src/styles/theme.css
@@ -45,6 +45,21 @@
   --card-foreground: var(--boxel-dark);
   --popover: var(--boxel-light);
   --popover-foreground: var(--boxel-dark);
+  /* Neutral surfaces beyond shadcn's, by role: the workspace ground behind the
+     page, a well sunk into a card, an editable region at rest, the pointer
+     acknowledgement, zebra rows, the selected row. `--foreground` must read on
+     all of them, so none carries its own -foreground. `--hover` is translucent
+     so it composes over whichever surface it lands on. */
+  --canvas: var(--boxel-100);
+  --inset: var(--boxel-50);
+  --field: var(--boxel-light);
+  --hover: var(--boxel-dark-10);
+  --stripe: var(--boxel-50);
+  --selected: color-mix(in oklch, var(--primary) 15%, var(--card));
+  --tooltip: var(--boxel-dark);
+  --tooltip-foreground: var(--boxel-light);
+  /* third ink step, fainter than --muted-foreground */
+  --subtle-foreground: var(--boxel-400);
 
   /* roles */
   --primary: var(--boxel-highlight);
@@ -60,8 +75,10 @@
 
   /* form + focus */
   --border: var(--boxel-border-color);
+  --border-strong: var(--boxel-400);
   --input: var(--boxel-400);
   --ring: var(--boxel-highlight);
+  --control-height: 2.5rem;
 
   /* charts */
   --chart-1: var(--boxel-fuschia);
@@ -69,6 +86,8 @@
   --chart-3: var(--boxel-lime);
   --chart-4: var(--boxel-blue);
   --chart-5: var(--boxel-green);
+  --chart-6: var(--boxel-orange);
+  --chart-7: var(--boxel-cyan);
 
   /* sidebar */
   --sidebar: var(--boxel-light);
@@ -112,10 +131,38 @@
   --shadow-xl:
     0 1px 3px 0px hsl(0 0% 0% / 0.1), 0 8px 10px -1px hsl(0 0% 0% / 0.1);
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
+  --shadow-inset: inset 0 1px 2px hsl(0 0% 0% / 0.1);
 
   /* status */
   --success: var(--boxel-success);
+  --success-foreground: var(--boxel-light);
   --warning: var(--boxel-warning);
+  --warning-foreground: var(--boxel-dark);
+  --info: var(--boxel-blue);
+  --info-foreground: var(--boxel-light);
+  --attention: var(--boxel-pink);
+  --attention-foreground: var(--boxel-light);
+  --overlay: var(--boxel-dark-50);
+
+  /* Hue as ink. `--x`/`--x-foreground` cover ink *on* a hue's fill; `--x-ink` is
+     the hue used *as* ink on a neutral surface (a status label, a link, an icon).
+     The default pulls each hue toward --foreground so it darkens on light and
+     lightens on dark; a theme that sets only `--x` still gets a readable ink.
+     Re-declared in the dark block: a var() inside a custom property resolves
+     where it is declared, so a dark subtree would otherwise inherit the
+     light-resolved color. */
+  --primary-ink: color-mix(in oklch, var(--primary) 60%, var(--foreground));
+  --secondary-ink: color-mix(in oklch, var(--secondary) 60%, var(--foreground));
+  --accent-ink: color-mix(in oklch, var(--accent) 60%, var(--foreground));
+  --destructive-ink: color-mix(
+    in oklch,
+    var(--destructive) 60%,
+    var(--foreground)
+  );
+  --success-ink: color-mix(in oklch, var(--success) 60%, var(--foreground));
+  --warning-ink: color-mix(in oklch, var(--warning) 60%, var(--foreground));
+  --info-ink: color-mix(in oklch, var(--info) 60%, var(--foreground));
+  --attention-ink: color-mix(in oklch, var(--attention) 60%, var(--foreground));
 
   /* other */
   --boxel-button-default-border: var(--boxel-button-border-color);
@@ -196,9 +243,32 @@
   --accent-foreground: var(--boxel-light);
   --destructive: var(--boxel-danger);
   --destructive-foreground: var(--boxel-light-100);
+  --canvas: #1e1b26;
+  --inset: #302d3b;
+  --field: var(--boxel-700);
+  --hover: var(--boxel-light-10);
+  --stripe: var(--boxel-600);
+  --selected: color-mix(in oklch, var(--primary) 15%, var(--card));
+  --tooltip: var(--boxel-200);
+  --tooltip-foreground: var(--boxel-dark);
+  --subtle-foreground: #8a8895;
   --border: var(--boxel-550);
+  --border-strong: #6e6c78;
   --input: var(--boxel-550);
   --ring: var(--boxel-highlight);
+  --overlay: var(--boxel-dark-80);
+  --primary-ink: color-mix(in oklch, var(--primary) 60%, var(--foreground));
+  --secondary-ink: color-mix(in oklch, var(--secondary) 60%, var(--foreground));
+  --accent-ink: color-mix(in oklch, var(--accent) 60%, var(--foreground));
+  --destructive-ink: color-mix(
+    in oklch,
+    var(--destructive) 60%,
+    var(--foreground)
+  );
+  --success-ink: color-mix(in oklch, var(--success) 60%, var(--foreground));
+  --warning-ink: color-mix(in oklch, var(--warning) 60%, var(--foreground));
+  --info-ink: color-mix(in oklch, var(--info) 60%, var(--foreground));
+  --attention-ink: color-mix(in oklch, var(--attention) 60%, var(--foreground));
   --sidebar: #555366;
   --sidebar-foreground: var(--boxel-light);
   --sidebar-primary: var(--boxel-highlight);

--- a/packages/boxel-ui/tests/unit/theme-dark-boundary-test.ts
+++ b/packages/boxel-ui/tests/unit/theme-dark-boundary-test.ts
@@ -71,8 +71,19 @@ module('Unit | theme dark boundary', function () {
       return;
     }
 
+    // the light boundary reset blanks the chrome knobs so themed cards derive
+    // them from their own tokens; the dark boundary must leave those alone too
+    const resetRule = findThemeRule(
+      (rule) =>
+        matchesSelector(rule, BOUNDARY_SELECTOR) &&
+        !(rule.parentRule instanceof CSSContainerRule) &&
+        rule.style.getPropertyValue(customProperties(rule)[0] ?? '') ===
+          'initial',
+    );
+    assert.ok(resetRule, 'found the light boundary reset rule');
+    const resetKnobs = new Set(resetRule ? customProperties(resetRule) : []);
     const expected = customProperties(darkRule).filter(
-      (name) => name !== SCHEME_SIGNAL,
+      (name) => name !== SCHEME_SIGNAL && !resetKnobs.has(name),
     );
     const actual = customProperties(boundaryRule);
     assert.deepEqual(
@@ -84,6 +95,12 @@ module('Unit | theme dark boundary', function () {
       actual.includes(SCHEME_SIGNAL),
       `${SCHEME_SIGNAL} keeps inheriting through the boundary`,
     );
+    for (const knob of resetKnobs) {
+      assert.false(
+        actual.includes(knob),
+        `${knob} is left to the boundary reset in dark mode too`,
+      );
+    }
     for (const name of expected) {
       assert.strictEqual(
         boundaryRule.style.getPropertyValue(name),

--- a/packages/boxel-ui/tests/unit/theme-dark-boundary-test.ts
+++ b/packages/boxel-ui/tests/unit/theme-dark-boundary-test.ts
@@ -1,0 +1,138 @@
+import { module, test } from 'qunit';
+
+// theme.css re-declares the light contract on every `[data-boxel-theme-scope]`
+// boundary so token values can't inherit into a themed card. Under a dark
+// scheme the same boundary must re-declare the dark contract instead, or a
+// themed card that omits a token renders it light inside a dark page. CSS has
+// no way to share the declaration block between the `.dark` rule and the
+// boundary rule, so these tests hold the two copies together.
+
+const DARK_SELECTOR = ".dark, [data-theme='dark']";
+const BOUNDARY_SELECTOR = ':where([data-boxel-theme-scope])';
+const SCHEME_SIGNAL = '--boxel-color-scheme';
+
+// browsers re-serialize selectorText (Chromium switches attribute values to
+// double quotes), so compare a normalized form rather than the source text
+function normalizeSelector(selector: string): string {
+  return selector.replace(/"/g, "'").replace(/\s+/g, ' ').trim();
+}
+
+function matchesSelector(rule: CSSStyleRule, selector: string): boolean {
+  return normalizeSelector(rule.selectorText) === normalizeSelector(selector);
+}
+
+function customProperties(rule: CSSStyleRule): string[] {
+  return Array.from(rule.style).filter((name) => name.startsWith('--'));
+}
+
+function findRule(
+  rules: CSSRuleList,
+  predicate: (rule: CSSStyleRule) => boolean,
+): CSSStyleRule | undefined {
+  for (const rule of Array.from(rules)) {
+    if (rule instanceof CSSStyleRule && predicate(rule)) {
+      return rule;
+    }
+    if ('cssRules' in rule) {
+      const nested = findRule((rule as CSSGroupingRule).cssRules, predicate);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return undefined;
+}
+
+function findThemeRule(
+  predicate: (rule: CSSStyleRule) => boolean,
+): CSSStyleRule | undefined {
+  for (const sheet of Array.from(document.styleSheets)) {
+    const rule = findRule(sheet.cssRules, predicate);
+    if (rule) {
+      return rule;
+    }
+  }
+  return undefined;
+}
+
+module('Unit | theme dark boundary', function () {
+  test('the dark boundary reset declares the same tokens as the dark block', function (assert) {
+    const darkRule = findThemeRule((rule) =>
+      matchesSelector(rule, DARK_SELECTOR),
+    );
+    const boundaryRule = findThemeRule(
+      (rule) =>
+        matchesSelector(rule, BOUNDARY_SELECTOR) &&
+        rule.parentRule instanceof CSSContainerRule,
+    );
+    assert.ok(darkRule, `found the ${DARK_SELECTOR} rule`);
+    assert.ok(boundaryRule, 'found the dark boundary rule');
+    if (!darkRule || !boundaryRule) {
+      return;
+    }
+
+    const expected = customProperties(darkRule).filter(
+      (name) => name !== SCHEME_SIGNAL,
+    );
+    const actual = customProperties(boundaryRule);
+    assert.deepEqual(
+      actual.sort(),
+      expected.sort(),
+      'both dark blocks declare the same custom properties',
+    );
+    assert.false(
+      actual.includes(SCHEME_SIGNAL),
+      `${SCHEME_SIGNAL} keeps inheriting through the boundary`,
+    );
+    for (const name of expected) {
+      assert.strictEqual(
+        boundaryRule.style.getPropertyValue(name),
+        darkRule.style.getPropertyValue(name),
+        `${name} has the same value in both dark blocks`,
+      );
+    }
+  });
+
+  test('a themed card in a dark subtree keeps the dark defaults for tokens its theme omits', function (assert) {
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-theme', 'dark');
+    const card = document.createElement('div');
+    card.setAttribute('data-boxel-theme-scope', 'probe');
+    wrapper.append(card);
+    document.body.append(wrapper);
+    try {
+      const wrapperStyle = getComputedStyle(wrapper);
+      const cardStyle = getComputedStyle(card);
+      for (const name of ['--background', '--canvas', '--inset', '--field']) {
+        assert.strictEqual(
+          cardStyle.getPropertyValue(name),
+          wrapperStyle.getPropertyValue(name),
+          `${name} resolves to the dark default inside the boundary`,
+        );
+      }
+    } finally {
+      wrapper.remove();
+    }
+  });
+
+  test('a light-forced themed card inside a dark subtree stays light', function (assert) {
+    const dark = document.createElement('div');
+    dark.setAttribute('data-theme', 'dark');
+    const light = document.createElement('div');
+    light.setAttribute('data-theme', 'light');
+    const card = document.createElement('div');
+    card.setAttribute('data-boxel-theme-scope', 'probe');
+    light.append(card);
+    dark.append(light);
+    document.body.append(dark);
+    try {
+      assert.strictEqual(
+        getComputedStyle(card).getPropertyValue('--canvas'),
+        getComputedStyle(light).getPropertyValue('--canvas'),
+        'the boundary follows the nearest scheme switch, not the outer dark ancestor',
+      );
+    } finally {
+      dark.remove();
+    }
+  });
+});

--- a/packages/host/tests/acceptance/theme-card-test.gts
+++ b/packages/host/tests/acceptance/theme-card-test.gts
@@ -649,6 +649,32 @@ module('Acceptance | theme-card-test', function (hooks) {
       );
     });
 
+    test('dark mode preview keeps dark defaults for tokens the theme omits', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: themeCardId, format: 'isolated' }]],
+      });
+      // the scope element re-declares the contract at the card boundary, so it
+      // is where an omitted token resolves
+      let scopeSelector = `[data-test-card="${themeCardId}"] [data-test-theme-dashboard]`;
+      assert.strictEqual(
+        computedProperty(scopeSelector, '--canvas'),
+        '#f8f7fa',
+        'an omitted token resolves to the boxel light default',
+      );
+
+      await click('[data-test-mode="toggle-dark"]');
+      assert.strictEqual(
+        computedProperty(scopeSelector, '--canvas'),
+        '#1e1b26',
+        'an omitted token resolves to the boxel dark default in the dark preview',
+      );
+      assert.strictEqual(
+        computedProperty(scopeSelector, '--background'),
+        DARK_MODE_VARS.background,
+        'the theme still overrides the tokens it defines',
+      );
+    });
+
     test('dark mode variables apply when the ambient scheme is dark', async function (assert) {
       await visitOperatorMode({
         stacks: [[{ id: themeCardId, format: 'isolated' }]],

--- a/packages/host/tests/integration/structured-theme-test.gts
+++ b/packages/host/tests/integration/structured-theme-test.gts
@@ -1,4 +1,9 @@
-import { settled, type RenderingTestContext } from '@ember/test-helpers';
+import {
+  click,
+  settled,
+  waitUntil,
+  type RenderingTestContext,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -11,6 +16,7 @@ import { setupRenderingTest } from '../helpers/setup';
 
 import type * as StructuredThemeModule from '@cardstack/base/structured-theme';
 import type * as StructuredThemeVarsModule from '@cardstack/base/structured-theme-variables';
+import type * as StyleReferenceModule from '@cardstack/base/style-reference';
 import type * as TypographyFieldModule from '@cardstack/base/typography';
 
 // A real tweakcn export: alongside the `:root` and `.dark` variable blocks it
@@ -440,6 +446,53 @@ module('Integration | structured-theme', function (hooks) {
     assert.false(
       primaryInk?.startsWith('color-mix'),
       `the color-mix ink formula collapses to a literal color (${primaryInk})`,
+    );
+  });
+
+  // Style Reference renders the palette unconditionally, so flipping the
+  // preview's color mode never tears the swatch grid down — the resolution has
+  // to follow the toggle on its own
+  test("the Style Reference palette's inherited swatches follow the preview's dark toggle", async function (this: RenderingTestContext, assert) {
+    let loader: Loader = getService('loader-service').loader;
+    let StyleReference = (
+      await loader.import<typeof StyleReferenceModule>(
+        '@cardstack/base/style-reference',
+      )
+    ).default;
+    // --primary-ink is unset in both modes, and its default mixes --primary,
+    // which this theme sets to a different color per mode
+    let card = new StyleReference({
+      rootVariables: new ThemeVarField({ primary: '#d04f99' }),
+      darkModeVariables: new ThemeVarField({ primary: '#00e5ff' }),
+    });
+    await renderCard(loader, card, 'isolated');
+    await settled();
+
+    let primaryInk = () =>
+      this.element
+        .querySelector(
+          '[data-test-root-vars] [data-test-var-value="--primary-ink"]',
+        )
+        ?.getAttribute('data-test-var-inherited') ?? '';
+
+    let light = primaryInk();
+    assert.ok(light.length, 'the ink default resolves in light mode');
+
+    await click('[data-test-theme-nav] [data-test-mode] input');
+    // resolution runs off a MutationObserver on the scheme wrapper, so it
+    // lands a microtask after the click settles
+    let dark = await waitUntil(
+      () => {
+        let value = primaryInk();
+        return value === light ? undefined : value;
+      },
+      { timeoutMessage: 'the inherited swatch never re-resolved for dark' },
+    );
+
+    assert.notStrictEqual(
+      dark,
+      light,
+      `the swatch re-resolves against the dark scheme (light ${light}, dark ${dark})`,
     );
   });
 

--- a/packages/host/tests/integration/structured-theme-test.gts
+++ b/packages/host/tests/integration/structured-theme-test.gts
@@ -1,10 +1,12 @@
+import { settled, type RenderingTestContext } from '@ember/test-helpers';
+
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import type { Loader } from '@cardstack/runtime-common';
 
 import { setupBaseRealm } from '../helpers/base-realm';
-
+import { renderCard } from '../helpers/render-component';
 import { setupRenderingTest } from '../helpers/setup';
 
 import type * as StructuredThemeModule from '@cardstack/base/structured-theme';
@@ -390,6 +392,55 @@ module('Integration | structured-theme', function (hooks) {
         `generated CSS declares ${declaration}`,
       );
     }
+  });
+
+  test('unset variables in the isolated preview show the value they inherit from the Boxel defaults', async function (this: RenderingTestContext, assert) {
+    let loader: Loader = getService('loader-service').loader;
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({ primary: '#d04f99' }),
+      darkModeVariables: new ThemeVarField({}),
+    });
+    await renderCard(loader, card, 'isolated');
+    await settled();
+
+    assert
+      .dom('[data-test-root-vars] [data-test-var-value="--primary"]')
+      .doesNotHaveAttribute(
+        'data-test-var-inherited',
+        'a value the theme sets is shown as its own',
+      );
+    assert
+      .dom(
+        '[data-test-root-vars] [data-test-var-value="--primary"] [data-test-swatch="#d04f99"]',
+      )
+      .exists();
+
+    let canvas = this.element.querySelector(
+      '[data-test-root-vars] [data-test-var-value="--canvas"]',
+    );
+    let inherited = canvas?.getAttribute('data-test-var-inherited') ?? '';
+    assert.ok(
+      inherited.length,
+      'an unset variable resolves to the theme.css default at the preview',
+    );
+    assert
+      .dom(canvas)
+      .containsText('inherited', 'the resolved value is tagged as inherited');
+    assert
+      .dom(`[data-test-root-vars] [data-test-swatch="${inherited}"]`)
+      .exists('the swatch paints the resolved default');
+
+    let primaryInk = this.element
+      .querySelector(
+        '[data-test-root-vars] [data-test-var-value="--primary-ink"]',
+      )
+      ?.getAttribute('data-test-var-inherited');
+    // Chrome serializes the mix in oklch; the point is that the formula is gone
+    assert.ok(primaryInk, 'the ink default resolves');
+    assert.false(
+      primaryInk?.startsWith('color-mix'),
+      `the color-mix ink formula collapses to a literal color (${primaryInk})`,
+    );
   });
 
   test('label and eyebrow typography slots emit theme variables, including letter-spacing', function (assert) {

--- a/packages/host/tests/integration/structured-theme-test.gts
+++ b/packages/host/tests/integration/structured-theme-test.gts
@@ -333,4 +333,100 @@ module('Integration | structured-theme', function (hooks) {
       'imports the user added by hand survive a reset',
     );
   });
+
+  test('the extended contract tokens round-trip through setCss and cssVariables', function (assert) {
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({}),
+      darkModeVariables: new ThemeVarField({}),
+    });
+    assert.true(
+      card.setCss(`:root {
+        --canvas: #f1f2f3;
+        --field: #ffffff;
+        --subtle-foreground: #9a9da3;
+        --border-strong: #cfd3da;
+        --info: #2c7a8c;
+        --attention-foreground: #ffffff;
+        --primary-ink: #008f73;
+        --overlay: rgb(16 24 40 / 0.4);
+        --chart-7: #65a30d;
+        --control-height: 1.75rem;
+        --shadow-inset: inset 0 1px 2px rgb(16 24 40 / 0.16);
+      }
+      .dark {
+        --tooltip: #f7f8fa;
+        --tooltip-foreground: #24262b;
+      }`),
+    );
+    let root = card.rootVariables;
+    assert.strictEqual(root.canvas, '#f1f2f3');
+    assert.strictEqual(root.field, '#ffffff');
+    assert.strictEqual(root.subtleForeground, '#9a9da3');
+    assert.strictEqual(root.borderStrong, '#cfd3da');
+    assert.strictEqual(root.info, '#2c7a8c');
+    assert.strictEqual(root.attentionForeground, '#ffffff');
+    assert.strictEqual(root.primaryInk, '#008f73');
+    assert.strictEqual(root.overlay, 'rgb(16 24 40 / 0.4)');
+    assert.strictEqual(root.chart7, '#65a30d');
+    assert.strictEqual(root.controlHeight, '1.75rem');
+    assert.strictEqual(
+      root.shadowInset,
+      'inset 0 1px 2px rgb(16 24 40 / 0.16)',
+    );
+    assert.strictEqual(card.darkModeVariables.tooltip, '#f7f8fa');
+    assert.strictEqual(card.darkModeVariables.tooltipForeground, '#24262b');
+
+    let css = card.cssVariables ?? '';
+    for (let declaration of [
+      '--canvas: #f1f2f3',
+      '--subtle-foreground: #9a9da3',
+      '--primary-ink: #008f73',
+      '--control-height: 1.75rem',
+      '--shadow-inset: inset 0 1px 2px rgb(16 24 40 / 0.16)',
+      '--tooltip-foreground: #24262b',
+    ]) {
+      assert.true(
+        css.includes(declaration),
+        `generated CSS declares ${declaration}`,
+      );
+    }
+  });
+
+  test('label and eyebrow typography slots emit theme variables, including letter-spacing', function (assert) {
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({}),
+      darkModeVariables: new ThemeVarField({}),
+      typography: new ThemeTypographyField({
+        heading: new TypographyField({ letterSpacing: '-0.02em' }),
+        label: new TypographyField({
+          fontSize: '0.75rem',
+          fontWeight: '500',
+          letterSpacing: '0.01em',
+        }),
+        eyebrow: new TypographyField({
+          fontSize: '0.6875rem',
+          letterSpacing: '0.08em',
+          sampleText: 'Kicker',
+        }),
+      }),
+    });
+    let css = card.cssVariables ?? '';
+    for (let declaration of [
+      '--theme-heading-letter-spacing: -0.02em',
+      '--theme-label-font-size: 0.75rem',
+      '--theme-label-font-weight: 500',
+      '--theme-label-letter-spacing: 0.01em',
+      '--theme-eyebrow-font-size: 0.6875rem',
+      '--theme-eyebrow-letter-spacing: 0.08em',
+    ]) {
+      assert.true(
+        css.includes(declaration),
+        `generated CSS declares ${declaration}`,
+      );
+    }
+    assert.false(
+      css.includes('sample-text'),
+      'sample text is not emitted as a variable',
+    );
+  });
 });


### PR DESCRIPTION
Extends the theme contract with the generic tokens a component kit needs beyond shadcn's set, so a kit's cards and the boxel-ui components nested in them read from one contract, and gives the theme dashboards realistic specimens to judge a theme on. Builds on #5982 (merged).

Linear: [CS-12723](https://linear.app/cardstack/issue/CS-12723) (parent CS-12711).

## Naming decisions to review

Names are Boxel's, not copied from the kit. The rules applied:

- **Bare names**, following the `--success`/`--warning` precedent for anything theme.css declares.
- **Map before adding.** A kit token that is the same knob as an existing token, or a step on a scale already derived from a contract knob (`--boxel-sp-*`, `--boxel-border-radius-*`, `--boxel-font-size-*`), gets no new field.
- **Hue as ink.** `--x`/`--x-foreground` cover ink *on* a hue's fill; nothing named the hue used *as* ink on a neutral surface. Added `--x-ink` for all eight hues (primary, secondary, accent, destructive, success, warning, info, attention). The default is `color-mix(in oklch, var(--x) 60%, var(--foreground))`, so a theme that only sets the hue still gets an ink that darkens on light and lightens on dark. The formula is re-declared in `.dark` because a `var()` inside a custom property resolves where it is declared, so a dark subtree would otherwise inherit the light-resolved color.

## New tokens (30 `ThemeVarField` fields)

| Family | Tokens |
| --- | --- |
| Surfaces | `--canvas`, `--inset`, `--field` (input background; `--input` is the border), `--hover` (translucent), `--stripe`, `--selected`, `--tooltip` + `--tooltip-foreground` |
| Inks & lines | `--subtle-foreground` (third ink step), `--border-strong` |
| Status | `--info` + `-foreground`, `--attention` + `-foreground`, `--success-foreground`, `--warning-foreground`, `--overlay` |
| Hue as ink | `--primary-ink`, `--secondary-ink`, `--accent-ink`, `--destructive-ink`, `--success-ink`, `--warning-ink`, `--info-ink`, `--attention-ink` |
| Charts | `--chart-6`, `--chart-7` |
| Size / shadow | `--control-height` (wired into `--boxel-form-control-height` by CardContainer), `--shadow-inset` |

theme.css declares light and dark defaults for every one, in the same block as the existing contract, so they reset at every themed-card boundary too.

## Typography maps onto roles, not new tokens

The kit's flat type ladder maps onto the existing `ThemeTypographyField` slots. The residue became:

- two new slots, `label` (UI/control text) and `eyebrow` (the tracked-out kicker above a title), emitted as `--theme-label-*` / `--theme-eyebrow-*` and derived by CardContainer as `--boxel-ui-label-*` / `--boxel-eyebrow-*` with the same fallback shape as the existing slots. The `--boxel-label-*` family is left alone: it is the Label component's own contract and keeps falling back to the body slot;
- `letterSpacing` on `TypographyField`, so every slot emits `--theme-<slot>-letter-spacing` and CardContainer derives `--boxel-<slot>-letter-spacing`. Body, caption, and label follow the theme's base tracking. Nothing applies these yet; that is the components' call.

Space, radius, shadow composites, and control chrome all map onto tokens the contract already has, so no fields were added for them.

## Dark defaults at themed-card boundaries

theme.css re-declares the whole light contract on every `[data-boxel-theme-scope]` so token values can't leak into a themed card. That reset also applied inside dark subtrees, so a themed card in dark chrome rendered every token its theme omitted with the light default. A new `@container style(--boxel-color-scheme: dark)` block applies the dark contract at those boundaries, keyed off the inherited scheme signal, the same mechanism a card's own `.dark` variables use. The `--boxel-switch/button` chrome knobs are deliberately left out of that block so themed cards keep deriving them from their own tokens in both schemes.

## Theme dashboards

- **Inherited defaults in the preview.** Unset variables in the isolated preview show the value they inherit from the Boxel defaults instead of `/* not set */`: a swatch painted with the resolved default, the value text, and an "inherited" tag whose tooltip shows the declared expression. The value is read at the swatch's position inside the theme scope, so it follows the light/dark toggle.
- **Wide format.** Theme cards open in the wide stack format. The dashboard content, header, and nav share one measure (`--dsr-content-max-width`, 72rem). Style Reference dropped its whole-card 50rem cap to match.
- **Specimens replace the Components block.** Four tabbed scenes built from boxel-ui: Surfaces & Ink (canvas, card, inset well with an input, zebra table with hover and selected rows, tooltip, all eight inks, status chips), Controls (buttons, input, select, switch, progress), Dashboard (stat tiles, chart bars, warning banner), Reading (eyebrow through caption). Every surface carries a pill naming its token. The Brand Guide's UI Components section renders the same specimens.
- **Measured type ladder.** Each typography role shows its resolved size, line-height ratio, and weight beside the specimen, re-measured when the theme stylesheet or the light/dark toggle changes.
- **Key tokens recipe.** Computed Styles opens with a curated `:root` excerpt of the tokens that define the look, following the previewed scheme, with a copy button.
- **Fonts section.** The visualizer's font previews and CSS Imports list sit side by side when they fit. The Brand Guide gains the same section.
- **Generated CSS blocks scroll.** `CSSField` accepts `--css-field-max-height`; the dashboards cap it at 40vh with an edge fade driven by a scroll timeline, shown only at an edge with more content beyond it.

## Select

`BoxelSelect` derives its dropdown colors from contract tokens instead of the fixed palette: selected text from `--primary-foreground`, hover from `--muted`, highlight-hover mixed from the highlight color. A `--boxel-dropdown-hover-text-color` override is added and synced into the portaled dropdown.

## Tests

- `structured-theme-test`: the extended tokens round-trip through `setCss` and `cssVariables`; label/eyebrow slots emit theme variables including letter-spacing; unset variables render as inherited with a resolved literal color and follow the dark toggle.
- `theme-card-test`: an omitted token resolves to the dark default in the dark preview.
- `theme-dark-boundary-test` (boxel-ui): the two dark blocks declare the same tokens with the same values; dark defaults hold inside a dark subtree; a light-forced subtree stays light.

## Follow-ups

- [CS-12807](https://linear.app/cardstack/issue/CS-12807): `BoxelInput` should read `--field` and `--subtle-foreground`. The Surfaces specimen remaps those onto the input's wrapper until then.
- Percy snapshots for the theme cards and Brand Guide change with the new sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
