### PR TITLE
Report a missing file as a missing file, not a missing card

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -3036,7 +3036,7 @@ export default class StoreService extends Service implements StoreInterface {
       deferred.fulfill(fileInstance as T);
       return fileInstance as T;
     } catch (error: any) {
-      let errorResponse = processCardError(id, error);
+      let errorResponse = processCardError(id, error, 'file-meta');
       let cardError = errorResponse.errors[0];
       deferred.fulfill(cardError);
       console.error(
@@ -3611,24 +3611,29 @@ export default class StoreService extends Service implements StoreInterface {
   }
 }
 
+// `readType` names what the failed read asked the realm for. A realm serves
+// card instances and file metadata out of one URL namespace, so the URL alone
+// cannot say which of the two a 404 is about — only the caller knows, and the
+// not-found wording below is written from it.
 function processCardError(
   url: string | undefined,
   error: any,
+  readType: StoreReadType = 'card',
 ): CardErrorsJSONAPI {
   let httpStatus = typeof error?.status === 'number' ? error.status : undefined;
   let errorResponse: CardErrorsJSONAPI;
-  try {
-    let parsed = JSON.parse(error.responseText);
-    errorResponse = formattedError(url, error, parsed.errors?.[0]);
-  } catch (parseError) {
+  let body = errorResponseBody(error);
+  if (body) {
+    errorResponse = formattedError(url, error, body.errors?.[0]);
+  } else {
     switch (error.status) {
       // tailor HTTP responses as necessary for better user feedback
       case 404:
-        errorResponse = formattedError(url, error, {
-          status: 404,
-          title: 'Card Not Found',
-          message: `The card ${url} does not exist`,
-        });
+        errorResponse = formattedError(
+          url,
+          error,
+          notFoundError(url, readType),
+        );
         break;
       default:
         errorResponse = formattedError(url, error, undefined);
@@ -3647,6 +3652,42 @@ function processCardError(
     }
   }
   return errorResponse;
+}
+
+// The raw response body of a failed read, when one survived to here. Only a
+// failure thrown straight from a fetch wrapper carries `responseText`: a realm
+// error response is rebuilt into a `CardError` from the JSON:API document it
+// carried, which keeps the status and message but not the body text. The
+// bodiless and the unparseable case both come back `undefined`, which is what
+// routes a read to the status-tailored fallback in `processCardError`.
+function errorResponseBody(error: any): { errors?: any[] } | undefined {
+  if (typeof error?.responseText !== 'string') {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(error.responseText);
+  } catch {
+    return undefined;
+  }
+  return parsed != null && typeof parsed === 'object'
+    ? (parsed as { errors?: any[] })
+    : undefined;
+}
+
+function notFoundError(
+  url: string | undefined,
+  readType: StoreReadType,
+): Partial<CardErrorJSONAPI> {
+  let { title, noun } =
+    readType === 'file-meta'
+      ? { title: 'File Not Found', noun: 'file' }
+      : { title: 'Card Not Found', noun: 'card' };
+  return {
+    status: 404,
+    title,
+    message: `The ${noun} ${url} does not exist`,
+  };
 }
 
 function needsServerStateMerge(

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -846,6 +846,26 @@ module('Integration | Store', function (hooks) {
     );
   });
 
+  test('a file the realm does not hold is reported as a missing file', async function (assert) {
+    let missingFileUrl = `${testRealmURL}missing.png`;
+
+    let error = (await storeService.get(missingFileUrl, {
+      type: 'file-meta',
+    })) as CardErrorJSONAPI;
+
+    assert.strictEqual(error.status, 404, 'the error carries the HTTP status');
+    assert.strictEqual(
+      error.title,
+      'File Not Found',
+      'a missing file is titled as a missing file, not a missing card',
+    );
+    assert.strictEqual(
+      error.message,
+      `The file ${missingFileUrl} does not exist`,
+      'the message names a file, not a card',
+    );
+  });
+
   test('garbage collects cards that only consume each other', async function (assert) {
     let alpha = new PersonDef({ name: 'Alpha' });
     let beta = new PersonDef({ name: 'Beta' });


### PR DESCRIPTION
## What this changes

A realm serves card instances and file metadata out of one URL namespace, so a 404 URL alone cannot say which of the two is missing. The store's 404 fallback in `processCardError` was written for card instances and applied to every 404, so a file the realm does not hold surfaced to the user as:

```
title:   'Card Not Found'
message: 'The card https://…/images/photo.jpg does not exist'
```

`processCardError` now takes the read type from its caller, and `getFileMetaInstance` — which knows it is loading a file — passes `file-meta`. A missing file reads as `File Not Found` / `The file … does not exist`; card reads keep their existing wording. The HTTP status is untouched either way, so consumers branching on `status` are unaffected.

The second change is to how that fallback is reached. Every realm 404 got there by way of a thrown `JSON.parse(error.responseText)`: a realm error response arrives as a `CardError` rebuilt from the JSON:API document it carried, and that rebuild keeps status/message/title but not the body text, so the parse threw on `undefined`. The probe is now a guard — `errorResponseBody` returns the parsed body or `undefined` — so the status-tailored branch is reached deliberately rather than as an exception path. The bodiless, `null`-body, and unparseable-body cases all route there exactly as they did before.

## Scope

Only the file-meta load path is retyped. A card read whose URL turns out to be a binary file is rerouted to file-meta on a *successful* fetch, so a 404 on that path still has no caller-side signal about what was wanted; that surface is left alone.

## Test plan

- New store integration test: a file-meta read of a URL the realm does not hold reports status 404, title `File Not Found`, and a message naming a file.
- `pnpm lint:js` and `pnpm lint:hbs` clean in `packages/host`; `pnpm lint:types` reports nothing in the changed files.
- The error shaping was checked directly against the real `formattedError` / `CardError` from `runtime-common` for the shapes that reach this code — a realm 404 rebuilt with no `responseText` (card and file), a `fetchJSON`-style error carrying a JSON:API body, a `null` body, a non-JSON body, and a 5xx carrying a propagated inner 404 (whose status fixup is unchanged). The full host suite was not runnable in this environment, so the wiring rests on the integration test in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192TC32CP5QJPRNVmFRpqDi

---
_Generated by [Claude Code](https://claude.ai/code/session_0192TC32CP5QJPRNVmFRpqDi)_