### PR TITLE
Stop telling the model it cannot edit cards when no patch tool is loaded

### DIFF
--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -1733,13 +1733,9 @@ Current date and time: 2025-06-11T11:43:00.533Z
     });
   });
 
-  test('Never tells the model it cannot edit cards; the skills index carries the SEARCH/REPLACE rule', async () => {
-    // What grants card editing is a card-patch tool in the request
-    // (patch-fields from a skill, or a legacy patchCardInstance in an old
-    // room's history) — interactive messages carry no tools themselves, so
-    // neither an open card nor an attached one implies edit access. The
-    // note keys off the tools array; an attached file also suppresses it
-    // (files are editable through SEARCH/REPLACE patches).
+  test('Never tells the model it cannot edit cards', async () => {
+    // Fixture: a card attached to the message, no patch tool in the request,
+    // no room-skills state (so no skills index in the prompt either).
     const eventList: DiscreteMatrixEvent[] = [
       {
         type: 'm.room.message',
@@ -1812,9 +1808,13 @@ Current date and time: 2025-06-11T11:43:00.533Z
       fakeMatrixClient,
     );
 
-    // Every room carries the skills index, which says every file — instance
-    // JSON included — is written with SEARCH/REPLACE. Nothing in the request
-    // (attached cards, open cards, absent patch tools) may contradict that.
+    // The edit path is SEARCH/REPLACE blocks parsed out of the assistant's
+    // own text (extractCodePatchBlocks). No tool in the request grants it and
+    // none can withhold it, and SYSTEM_MESSAGE, present in every prompt, says
+    // all code and data changes are applied immediately. A sentence telling
+    // the model it cannot edit was therefore false, not merely stale, so
+    // nothing in the request (attached cards, open cards, absent patch tools)
+    // may produce one.
     let contextMessage = messageText(messages?.[messages.length - 1]);
     assert.notOk(
       contextMessage.includes('unable to edit'),

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -222,7 +222,6 @@ module('buildPromptForModel', (hooks) => {
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -321,7 +320,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -406,7 +404,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -477,7 +474,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -565,7 +561,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -645,7 +640,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
       await buildPromptForModel(
         history,
         '@aibot@localhost',
-        undefined,
         undefined,
         [],
         fakeMatrixClient,
@@ -1085,7 +1079,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -1421,7 +1414,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -1741,7 +1733,7 @@ Current date and time: 2025-06-11T11:43:00.533Z
     });
   });
 
-  test('Adds the "unable to edit cards" note only when no card-patch tool is in the request', async () => {
+  test('Never tells the model it cannot edit cards; the skills index carries the SEARCH/REPLACE rule', async () => {
     // What grants card editing is a card-patch tool in the request
     // (patch-fields from a skill, or a legacy patchCardInstance in an old
     // room's history) — interactive messages carry no tools themselves, so
@@ -1820,84 +1812,28 @@ Current date and time: 2025-06-11T11:43:00.533Z
       fakeMatrixClient,
     );
 
-    let nonEditableCardsMessage = 'You are unable to edit any cards:';
-
-    let userContextMessage = messages?.[messages.length - 1];
-    assert.ok(
-      messageText(userContextMessage).includes(nonEditableCardsMessage),
-      'The note appears when cards are attached but no card-patch tool is in the request, but was ' +
-        userContextMessage?.content,
+    // Every room carries the skills index, which says every file — instance
+    // JSON included — is written with SEARCH/REPLACE. Nothing in the request
+    // (attached cards, open cards, absent patch tools) may contradict that.
+    let contextMessage = messageText(messages?.[messages.length - 1]);
+    assert.notOk(
+      contextMessage.includes('unable to edit'),
+      'no card-editing prohibition when a card is attached and no patch tool is in the request',
     );
 
-    // An open card grants nothing by itself — no tool, no edit path.
     let cardMessageContent = eventList[0].content as CardMessageContent;
     cardMessageContent.data.context ||= {};
     cardMessageContent.data.context.openCardIds = [
       rri('http://localhost:4201/drafts/Author/1'),
     ];
-
     const { messages: messages2 } = await getPromptParts(
       historyWithStringifiedData(eventList),
       '@aibot:localhost',
       fakeMatrixClient,
     );
-
-    assert.ok(
-      messageText(messages2?.[messages2.length - 1]).includes(
-        nonEditableCardsMessage,
-      ),
-      'The note stays when a card is open but the request still carries no card-patch tool',
-    );
-
-    // A card-patch tool in the request is the grant.
-    cardMessageContent.data.context.tools = [
-      {
-        type: 'function',
-        function: {
-          name: 'patchFields',
-          description: 'Patch fields on a card',
-          parameters: { type: 'object', properties: {} },
-        },
-      } as Tool,
-    ];
-
-    const { messages: messages3 } = await getPromptParts(
-      historyWithStringifiedData(eventList),
-      '@aibot:localhost',
-      fakeMatrixClient,
-    );
-
-    assert.ok(
-      !messageText(messages3?.[messages3.length - 1]).includes(
-        nonEditableCardsMessage,
-      ),
-      'The note is suppressed when the request carries a card-patch tool',
-    );
-
-    // Now remove the tool and add an attached file
-    cardMessageContent.data.context.openCardIds = [];
-    cardMessageContent.data.context.tools = [];
-    cardMessageContent.data.attachedFiles = [
-      {
-        url: 'https://example.com/file.txt',
-        sourceUrl: 'https://example.com/file.txt',
-        name: 'file.txt',
-        contentType: 'text/plain',
-        content: 'Hello, world!',
-      },
-    ];
-
-    const { messages: messages4 } = await getPromptParts(
-      historyWithStringifiedData(eventList),
-      '@aibot:localhost',
-      fakeMatrixClient,
-    );
-
-    assert.ok(
-      !messageText(messages4?.[messages4.length - 1]).includes(
-        nonEditableCardsMessage,
-      ),
-      'The note is suppressed when there is an attached file',
+    assert.notOk(
+      messageText(messages2?.[messages2.length - 1]).includes('unable to edit'),
+      'no card-editing prohibition when a card is open either',
     );
   });
 
@@ -2766,16 +2702,9 @@ Current date and time: 2025-06-11T11:43:00.533Z
         status: EventStatus.SENT,
       },
     ];
-    const tools = await getTools(
-      history,
-      [],
-      '@aibot:localhost',
-      fakeMatrixClient,
-    );
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      tools,
       [],
       [],
       fakeMatrixClient,
@@ -2876,7 +2805,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
       '@aibot:localhost',
       [],
       [],
-      [],
       fakeMatrixClient,
     );
     let toolMessages = result.filter((m) => m.role === 'tool');
@@ -2963,7 +2891,6 @@ Current date and time: 2025-06-11T11:43:00.533Z
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      [],
       [],
       [],
       fakeMatrixClient,
@@ -5549,7 +5476,6 @@ new
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      [],
       skillCards,
       [],
       fakeMatrixClient,
@@ -5644,7 +5570,6 @@ new
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      [],
       [],
       [],
       fakeMatrixClient,
@@ -5785,13 +5710,11 @@ new
       '@aibot:localhost',
       [],
       [],
-      [],
       fakeMatrixClient,
     );
     const promptTwo = await buildPromptForModel(
       turnTwo,
       '@aibot:localhost',
-      [],
       [],
       [],
       fakeMatrixClient,
@@ -5839,7 +5762,6 @@ new
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      [],
       [],
       [],
       fakeMatrixClient,
@@ -5927,7 +5849,6 @@ new
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -6032,7 +5953,6 @@ new
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -6116,7 +6036,6 @@ new
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -6226,7 +6145,6 @@ new
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -6299,7 +6217,6 @@ new
     let prompt = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -6388,7 +6305,6 @@ new
     let prompt = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -6485,7 +6401,6 @@ new
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -6550,7 +6465,6 @@ new
     let prompt = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -6661,7 +6575,6 @@ new
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -6725,7 +6638,6 @@ new
     let prompt = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -6801,7 +6713,6 @@ new
     let prompt = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -6882,7 +6793,6 @@ new
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -6962,7 +6872,6 @@ new
     let prompt = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -7071,7 +6980,6 @@ new
       history,
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -7164,7 +7072,6 @@ new
       [firstMessage],
       '@aibot:localhost',
       undefined,
-      undefined,
       [],
       fakeMatrixClient,
     );
@@ -7181,7 +7088,6 @@ new
         ),
       ],
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -7329,7 +7235,6 @@ new
     let prompt = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      undefined,
       undefined,
       [],
       fakeMatrixClient,
@@ -7489,7 +7394,6 @@ module('set model in prompt', (hooks) => {
       '@aibot:localhost',
       [],
       [],
-      [],
       fakeMatrixClient,
     );
 
@@ -7589,7 +7493,6 @@ module('set model in prompt', (hooks) => {
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      [],
       [],
       [],
       fakeMatrixClient,
@@ -7804,7 +7707,6 @@ module('set model in prompt', (hooks) => {
     const result = await buildPromptForModel(
       history,
       '@aibot:localhost',
-      [],
       [],
       [],
       fakeMatrixClient,

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -251,7 +251,6 @@ export async function getPromptParts(
   let messages = await buildPromptForModel(
     history,
     aiBotUserId,
-    tools,
     skills,
     disabledSkillIds,
     client,
@@ -699,33 +698,6 @@ export function getRelevantCards(
     mostRecentlyAttachedCard: mostRecentlyAttachedCard,
     attachedCards: sortedCards,
   };
-}
-
-export function hasSomeAttachedCards(
-  history: DiscreteMatrixEvent[],
-  aiBotUserId: string,
-): boolean {
-  for (let event of history) {
-    if (event.type !== 'm.room.message') {
-      continue;
-    }
-
-    if (event.sender !== aiBotUserId) {
-      let { content } = event;
-      let attachedCards = (content as CardMessageContent).data?.attachedCards
-        ?.map((attachedCard: SerializedFileDef) =>
-          attachedCard.content
-            ? (JSON.parse(attachedCard.content) as LooseSingleCardDocument)
-            : undefined,
-        )
-        .filter((card) => card !== undefined);
-      if (attachedCards?.length) {
-        return true;
-      }
-    }
-  }
-
-  return false;
 }
 
 // A message's rendering must depend only on the message itself, never on
@@ -1566,7 +1538,6 @@ function toCheckCorrectnessResultContent(
 export async function buildPromptForModel(
   history: DiscreteMatrixEvent[],
   aiBotUserId: string,
-  tools: Tool[] = [],
   skillCards: EnabledSkill[] = [],
   disabledSkillIds: string[] = [],
   client: MatrixClient,
@@ -1674,7 +1645,6 @@ export async function buildPromptForModel(
   let contextContent = await buildContextMessage(
     history,
     aiBotUserId,
-    tools,
     disabledSkillIds,
   );
   // The context carries the current time, so its bytes change on every
@@ -2342,7 +2312,6 @@ export const buildCurrentTurnMediaParts = async (
 export const buildContextMessage = async (
   history: DiscreteMatrixEvent[],
   aiBotUserId: string,
-  tools: Tool[],
   disabledSkillIds: string[],
 ): Promise<string> => {
   let result = '';
@@ -2449,30 +2418,6 @@ export const buildContextMessage = async (
     result += `The user has no open cards.\n`;
   }
   result += `\nCurrent date and time: ${new Date().toISOString()}\n`;
-
-  // What grants card editing is a card-patch tool in the request —
-  // patch-fields supplied by a skill, or a legacy patchCardInstance sitting
-  // in an old room's history. Interactive messages themselves carry no
-  // tools, so nothing about the UI state (open cards, attachments) implies
-  // edit access. When cards are in play but no such tool is present, say so
-  // — otherwise the model proposes patches it has no way to apply. Reading
-  // the tools array here is cache-safe: this message trails the cache
-  // breakpoint and is re-serialized every turn anyway.
-  let hasCardPatchTool = tools.some((t) =>
-    CARD_PATCH_COMMAND_NAMES.has(t.function.name),
-  );
-  let currentMessageHasAttachedFiles = Boolean(
-    (lastEventWithContext as MatrixEventWithBoxelContext | undefined)?.content
-      ?.data?.attachedFiles?.length,
-  );
-  if (
-    !currentMessageHasAttachedFiles &&
-    !hasCardPatchTool &&
-    hasSomeAttachedCards(history, aiBotUserId)
-  ) {
-    result +=
-      'You are unable to edit any cards: no card-editing tool is available in this room. Editing becomes possible when the user enables a skill that provides one (such as patch-fields). Ask them to do that if they want changes made.';
-  }
 
   return result;
 };


### PR DESCRIPTION
This is a remnant from times when we were conditionally loading skills and tools, depending on host mode. Now patching happens using search/replace blocks and skills for that are always reachable using index.md skill file.

More context:

In a fresh room with a card open, the assistant refused to build anything. Asked for "a simple facebook profile card and 5 instances" with a LinkedIn profile card attached, Sonnet 5 read no skills, wrote no files, and answered that it "currently doesn't have any card/file-editing tool enabled in this room", asking the user to enable a skill such as patch-fields. Its reasoning quoted the system prompt for that.

The prompt builder appended this to the trailing context message whenever a card was attached and the request carried no card-patch tool:

> You are unable to edit any cards: no card-editing tool is available in this room. Editing becomes possible when the user enables a skill that provides one (such as patch-fields). Ask them to do that if they want changes made.

Patch tools are lazy. They enter the request only after the model reads the boxel-environment skill, so every fresh room with an open card started with this sentence. The premise behind it is stale: the skills index is in every room and says every text file, instance JSON included, is written with SEARCH/REPLACE, and there is no file-writing tool. The two instructions contradicted each other, and a model that follows instructions closely picked the prohibition.

This removes the sentence and its gate. The skills index carries the editing rule alone.

- `buildContextMessage` no longer looks at the tools list, and `buildPromptForModel` no longer takes one. The tools list still goes to the provider as the request's `tools`, unchanged.
- The helper that scanned history for attached cards, used only by the gate, is removed.
- The ai-bot test that asserted the sentence now asserts its absence, with a card attached and with a card open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
