### PR TITLE
Wire useAsThumbnail captures into the cardThumbnailURL fallback chain

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3847,14 +3847,17 @@ export class CardDef extends BaseDef {
   // ImageDef link, then the capture the card's `static screenshots` flags
   // `useAsThumbnail` — so every opted-in card gets a live preview with no
   // template edits (the default fitted template already renders this field).
-  // Nullish past all three rungs is the absence signal consumers use to fall
+  // Falsy past all three rungs is the absence signal consumers use to fall
   // through to the icon default, which is why the capture rung reads
-  // `undefined` (never a placeholder) until a capture exists.
+  // `undefined` (never a placeholder) until a capture exists. `||` rather
+  // than `??`: a text edit can leave `''` in the authored URL (only the
+  // picker's clear button writes `null`), and `''` is never a meaningful
+  // URL — it must not mask the rungs below it.
   @field cardThumbnailURL = contains(MaybeBase64Field, {
     computeVia: function (this: CardDef) {
       return (
-        this.cardInfo.cardThumbnailURL ??
-        this.cardInfo.cardThumbnail?.url ??
+        this.cardInfo.cardThumbnailURL ||
+        this.cardInfo.cardThumbnail?.url ||
         thumbnailScreenshotURL(this)
       );
     },

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2896,8 +2896,26 @@ export type ScreenshotSpec = {
   // 'transparent' or any CSS color. Default 'white'. 'transparent' requires
   // an alpha-capable `type` ('png' or 'webp') — jpeg has no alpha channel.
   background?: string;
-  // Feed this capture to `cardThumbnailURL`. At most one entry across a
-  // card's merged declarations may set this.
+  // Feed this capture to `cardThumbnailURL` (its fallback chain prefers an
+  // author-set URL, then an authored ImageDef link, then this capture). At
+  // most one entry across a card's merged declarations may set this.
+  //
+  // Recommended (not enforced) box: 170×250 — the CardsGrid tile — at the
+  // default deviceScaleFactor of 2, so the capture crops predictably under
+  // consumers' `object-fit`/`background-size`. The declared width×height is
+  // the capture envelope, used exactly as given; for a format-based capture
+  // the rendered variant is emergent from the template's own container-query
+  // breakpoints, deterministic per box. Preview a candidate box with
+  // `?format=fitted&envelope=WxH` via the `_screenshot/` DSL on a dev realm,
+  // then codify it here. A box declared near one of the template's
+  // breakpoints can flip variants when those breakpoints are tuned — the
+  // same fragility any responsive design has.
+  //
+  // Point the capture at content: a capture-only `render` component, an
+  // isolated/embedded format, or a fitted template that does not itself
+  // render `cardThumbnailURL`. A fitted capture of the default fitted
+  // template would capture the tile chrome — including its own thumbnail
+  // slot, which shows the previous capture.
   useAsThumbnail?: boolean;
   // What invalidates the capture: the instance's index generation (any
   // edit), or — for file-backed defs — the file's content hash, so a
@@ -3210,6 +3228,30 @@ function composeScreenshotURLs(
     }
   }
   return urls;
+}
+
+// The durable URL of the capture feeding `cardThumbnailURL`: the declared
+// slot flagged `useAsThumbnail` (at most one across the merged declarations,
+// enforced by `getScreenshots`), read with `screenshotURLs`' semantics — a
+// URL exactly when `meta.screenshots` holds the slot, `undefined` otherwise,
+// so the fallback chain's terminal rung (the icon default) still engages.
+// Same render-safety posture as `composeScreenshotURLs`: an invalid
+// declaration reads as "no thumbnail capture".
+function thumbnailScreenshotURL(
+  instance: CardDef | FileDef,
+): string | undefined {
+  let name: string | undefined;
+  try {
+    name = Object.entries(
+      getScreenshots(instance.constructor as typeof CardDef | typeof FileDef),
+    ).find(([, spec]) => spec.useAsThumbnail)?.[0];
+  } catch {
+    return undefined;
+  }
+  if (!name) {
+    return undefined;
+  }
+  return getCardMeta(instance, 'screenshots')?.[name]?.url;
 }
 
 export class FieldDef extends BaseDef {
@@ -3801,12 +3843,20 @@ export class CardDef extends BaseDef {
       return this.cardInfo.theme;
     },
   });
-  // TODO: this will probably be an image or image url field card when we have it
-  // UPDATE: we now have a Base64ImageField card. we can probably refactor this
-  // to use it directly now (or wait until a better image field comes along)
+  // The thumbnail fallback chain: an author-set URL wins, then an authored
+  // ImageDef link, then the capture the card's `static screenshots` flags
+  // `useAsThumbnail` — so every opted-in card gets a live preview with no
+  // template edits (the default fitted template already renders this field).
+  // Nullish past all three rungs is the absence signal consumers use to fall
+  // through to the icon default, which is why the capture rung reads
+  // `undefined` (never a placeholder) until a capture exists.
   @field cardThumbnailURL = contains(MaybeBase64Field, {
     computeVia: function (this: CardDef) {
-      return this.cardInfo.cardThumbnailURL;
+      return (
+        this.cardInfo.cardThumbnailURL ??
+        this.cardInfo.cardThumbnail?.url ??
+        thumbnailScreenshotURL(this)
+      );
     },
   });
   static displayName = 'Card';

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3233,8 +3233,14 @@ function composeScreenshotURLs(
 // The durable URL of the capture feeding `cardThumbnailURL`: the declared
 // slot flagged `useAsThumbnail` (at most one across the merged declarations,
 // enforced by `getScreenshots`), read with `screenshotURLs`' semantics — a
-// URL exactly when `meta.screenshots` holds the slot, `undefined` otherwise,
-// so the fallback chain's terminal rung (the icon default) still engages.
+// URL exactly when `meta.screenshots` holds the slot, `undefined` otherwise.
+// On live loads meta joins the persisted manifest, so an uncaptured slot
+// reads `undefined` and the fallback chain's terminal rung (the icon
+// default) engages. In the prerender render context meta is
+// declaration-derived (`screenshotsMetaFromRoster`), so this rung asserts
+// the durable URL before any capture exists: persisted HTML embeds a URL
+// that 404s until the capture lands, then self-heals — and a slot whose
+// capture never succeeds stays a 404 (a blank tile), not the icon default.
 // Same render-safety posture as `composeScreenshotURLs`: an invalid
 // declaration reads as "no thumbnail capture".
 function thumbnailScreenshotURL(

--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -512,11 +512,15 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
   }
 
   private clearThumbnail = () => {
+    // Select Image sets both the URL and the cardThumbnail link, and the
+    // link is a rung of the cardThumbnailURL fallback chain — clearing must
+    // remove both or the linked image serves straight back.
     let cardInfo = this.args.model?.cardInfo as
-      | { cardThumbnailURL: string | null }
+      | { cardThumbnailURL: string | null; cardThumbnail: unknown }
       | undefined;
     if (cardInfo) {
       cardInfo.cardThumbnailURL = null;
+      cardInfo.cardThumbnail = null;
     }
   };
 

--- a/packages/base/default-templates/head.gts
+++ b/packages/base/default-templates/head.gts
@@ -18,11 +18,11 @@ export default class DefaultHeadTemplate extends GlimmerComponent<{
     return this.args.model?.cardDescription;
   }
 
+  // cardThumbnailURL carries the whole thumbnail fallback chain (explicit
+  // URL, then ImageDef link, then useAsThumbnail capture), so the social
+  // preview shows the same image as every other consumer.
   get image(): string | undefined {
-    return (
-      this.args.model?.cardInfo?.cardThumbnail?.url ??
-      this.args.model?.cardThumbnailURL
-    );
+    return this.args.model?.cardThumbnailURL || undefined;
   }
 
   get themeIcon(): string | undefined {

--- a/packages/base/default-templates/head.gts
+++ b/packages/base/default-templates/head.gts
@@ -20,9 +20,12 @@ export default class DefaultHeadTemplate extends GlimmerComponent<{
 
   // cardThumbnailURL carries the whole thumbnail fallback chain (explicit
   // URL, then ImageDef link, then useAsThumbnail capture), so the social
-  // preview shows the same image as every other consumer.
+  // preview shows the same image as every other consumer — except a base64
+  // value (MaybeBase64Field allows one): no scraper accepts a data: URI for
+  // og:image, and the payload would inline into every prerendered head.
   get image(): string | undefined {
-    return this.args.model?.cardThumbnailURL || undefined;
+    let url = this.args.model?.cardThumbnailURL;
+    return url && !url.startsWith('data:') ? url : undefined;
   }
 
   get themeIcon(): string | undefined {

--- a/packages/host/tests/integration/components/card-info-thumbnail-picker-test.gts
+++ b/packages/host/tests/integration/components/card-info-thumbnail-picker-test.gts
@@ -203,6 +203,37 @@ module('Integration | card-info | thumbnail picker edit', function (hooks) {
     assert.dom('[data-test-thumbnail-clear]').exists();
   });
 
+  test('clicking X after Select Image clears the linked image too', async function (this: RenderingTestContext, assert) {
+    let image = new ImageDef({
+      id: 'https://example.com/uploaded.png',
+      url: 'https://example.com/uploaded.png',
+      sourceUrl: 'https://example.com/uploaded.png',
+      name: 'uploaded.png',
+      contentType: 'image/png',
+    });
+    stubFileChooser(image);
+
+    class Thing extends CardDef {
+      static displayName = 'Thing';
+    }
+    let instance = new Thing({ cardInfo: new CardInfoField({ name: 'x' }) });
+    await renderCard(loader, instance, 'edit');
+    await click('[data-test-toggle-thumbnail-editor]');
+
+    await click('[data-test-thumbnail-select-image]');
+    await click('[data-test-thumbnail-clear]');
+
+    assert.notOk(
+      instance.cardInfo.cardThumbnail,
+      'the cardThumbnail link is cleared',
+    );
+    assert.notOk(
+      instance.cardThumbnailURL,
+      'the computed chain no longer serves the cleared image through the link rung',
+    );
+    assert.dom('[data-test-thumbnail-select-image]').hasText('Select Image');
+  });
+
   test('cancelling the file chooser leaves the field unchanged', async function (this: RenderingTestContext, assert) {
     stubFileChooser(undefined);
 

--- a/packages/host/tests/integration/components/preview-test.gts
+++ b/packages/host/tests/integration/components/preview-test.gts
@@ -174,6 +174,40 @@ module('Integration | preview', function (hooks) {
       .includesText('<meta property="og:type" content="article">');
   });
 
+  test('the default head template omits og:image for a base64 thumbnail', async function (assert) {
+    let { CardDef, CardInfoField } = cardApi;
+
+    class PlainCard extends CardDef {}
+
+    let base64Card = new PlainCard({
+      cardInfo: new CardInfoField({
+        name: 'Base64 Thumb',
+        cardThumbnailURL: 'data:image/png;base64,AAAA',
+      }),
+    });
+
+    class TestDriver extends GlimmerComponent<{ Args: { format?: Format } }> {
+      card = base64Card;
+
+      <template>
+        <CardRenderer @card={{this.card}} @format={{@format}} />
+      </template>
+    }
+
+    await renderComponent(TestDriver, 'head');
+
+    let rawMarkup =
+      document.querySelector('[data-test-head-markup]')?.textContent ?? '';
+    assert.notOk(
+      rawMarkup.includes('og:image'),
+      'a data: URI never reaches og:image',
+    );
+    assert.ok(
+      rawMarkup.includes('twitter:card" content="summary"'),
+      'the head falls back to the no-image twitter card',
+    );
+  });
+
   test('toggling between isolated and edit reuses the component instance when the templates are reference-equal', async function (assert) {
     let { field, contains, CardDef } = cardApi;
     let { default: StringField } = string;

--- a/packages/host/tests/unit/declared-screenshots-test.ts
+++ b/packages/host/tests/unit/declared-screenshots-test.ts
@@ -664,6 +664,42 @@ module('Unit | declared screenshots', function (hooks) {
     );
   });
 
+  test('an empty-string authored URL falls through to the capture', function (assert) {
+    class Product extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        tile: {
+          format: 'fitted',
+          width: 170,
+          height: 250,
+          useAsThumbnail: true,
+        },
+      };
+    }
+    let instance = new Product();
+    (instance as any)[cardApi.meta] = {
+      screenshots: {
+        tile: {
+          url: 'http://example.com/r/_screenshot/card-1?name=tile',
+          hash: 'bbb',
+          contentType: 'image/png',
+          width: 170,
+          height: 250,
+          deviceScaleFactor: 2,
+          useAsThumbnail: true,
+        },
+      },
+    };
+    // A text edit can leave '' in the authored URL (only the picker's clear
+    // button writes null); '' is never a meaningful URL, so it must not mask
+    // the rungs below it.
+    instance.cardInfo.cardThumbnailURL = '';
+    assert.strictEqual(
+      instance.cardThumbnailURL,
+      'http://example.com/r/_screenshot/card-1?name=tile',
+      'an emptied authored URL does not mask the capture',
+    );
+  });
+
   test('a card without a useAsThumbnail declaration ignores captured slots', function (assert) {
     class Product extends cardApi.CardDef {
       static screenshots: Screenshots = {

--- a/packages/host/tests/unit/declared-screenshots-test.ts
+++ b/packages/host/tests/unit/declared-screenshots-test.ts
@@ -573,6 +573,122 @@ module('Unit | declared screenshots', function (hooks) {
     );
   });
 
+  test('cardThumbnailURL falls back to the useAsThumbnail capture', function (assert) {
+    class Product extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        tile: {
+          format: 'fitted',
+          width: 170,
+          height: 250,
+          useAsThumbnail: true,
+        },
+        hero: { format: 'isolated', width: 800, height: 600 },
+      };
+    }
+    let instance = new Product();
+    assert.notOk(
+      instance.cardThumbnailURL,
+      'nullish until a capture exists — the absence signal the icon default engages on',
+    );
+
+    (instance as any)[cardApi.meta] = {
+      screenshots: {
+        hero: {
+          url: 'http://example.com/r/_screenshot/card-1?name=hero',
+          hash: 'aaa',
+          contentType: 'image/png',
+          width: 800,
+          height: 600,
+          deviceScaleFactor: 2,
+        },
+        tile: {
+          url: 'http://example.com/r/_screenshot/card-1?name=tile',
+          hash: 'bbb',
+          contentType: 'image/png',
+          width: 170,
+          height: 250,
+          deviceScaleFactor: 2,
+          useAsThumbnail: true,
+        },
+      },
+    };
+    assert.strictEqual(
+      instance.cardThumbnailURL,
+      'http://example.com/r/_screenshot/card-1?name=tile',
+      'the declared useAsThumbnail slot feeds the thumbnail, not other captures',
+    );
+  });
+
+  test('author-set thumbnails win over the capture', function (assert) {
+    class Product extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        tile: {
+          format: 'fitted',
+          width: 170,
+          height: 250,
+          useAsThumbnail: true,
+        },
+      };
+    }
+    let instance = new Product();
+    (instance as any)[cardApi.meta] = {
+      screenshots: {
+        tile: {
+          url: 'http://example.com/r/_screenshot/card-1?name=tile',
+          hash: 'bbb',
+          contentType: 'image/png',
+          width: 170,
+          height: 250,
+          deviceScaleFactor: 2,
+          useAsThumbnail: true,
+        },
+      },
+    };
+
+    let img = new cardApi.ImageDef({
+      id: 'http://example.com/authored.png',
+      url: 'http://example.com/authored.png',
+    });
+    instance.cardInfo.cardThumbnail = img;
+    assert.strictEqual(
+      instance.cardThumbnailURL,
+      'http://example.com/authored.png',
+      'an authored ImageDef link outranks the capture',
+    );
+
+    instance.cardInfo.cardThumbnailURL = 'http://example.com/explicit.png';
+    assert.strictEqual(
+      instance.cardThumbnailURL,
+      'http://example.com/explicit.png',
+      'an explicit URL outranks everything',
+    );
+  });
+
+  test('a card without a useAsThumbnail declaration ignores captured slots', function (assert) {
+    class Product extends cardApi.CardDef {
+      static screenshots: Screenshots = {
+        hero: { format: 'isolated', width: 800, height: 600 },
+      };
+    }
+    let instance = new Product();
+    (instance as any)[cardApi.meta] = {
+      screenshots: {
+        hero: {
+          url: 'http://example.com/r/_screenshot/card-1?name=hero',
+          hash: 'aaa',
+          contentType: 'image/png',
+          width: 800,
+          height: 600,
+          deviceScaleFactor: 2,
+        },
+      },
+    };
+    assert.notOk(
+      instance.cardThumbnailURL,
+      'no declared thumbnail slot means no capture rung',
+    );
+  });
+
   test('the @field decorator refuses the reserved screenshotURLs name', function (assert) {
     class Bad extends cardApi.CardDef {}
     assert.throws(

--- a/packages/realm-server/tests/declared-screenshots-indexing-test.ts
+++ b/packages/realm-server/tests/declared-screenshots-indexing-test.ts
@@ -75,6 +75,22 @@ function makeFileSystem() {
         @field name = contains(StringField);
       }
 
+      // Default fitted template + a content-bearing capture flagged
+      // useAsThumbnail: the persisted tile HTML must carry the capture's
+      // durable URL through the cardThumbnailURL fallback chain, with no
+      // template edits.
+      export class Gallery extends CardDef {
+        @field name = contains(StringField);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <h1>Gallery: <@fields.name/></h1>
+          </template>
+        }
+        static screenshots: Record<string, ScreenshotSpec> = {
+          tile: { format: 'isolated', width: 170, height: 250, useAsThumbnail: true },
+        };
+      }
+
       // Consumes its own declared capture in a display format — pins the
       // render context's declaration-derived meta.screenshots: the durable
       // URL must land in persisted HTML on the instance's very first
@@ -356,6 +372,40 @@ module(basename(import.meta.filename), function (hooks) {
         `${testRealm}_screenshot/self-promo-1?name=card`,
       ),
       `the very first persisted isolated_html embeds the durable URL (render-context declaration-derived meta); got: ${row!.isolated_html}`,
+    );
+  });
+
+  test('a useAsThumbnail capture feeds the default fitted tile with no template edits', async function (assert) {
+    await writeAndSettle(
+      'gallery-1.json',
+      JSON.stringify({
+        data: {
+          attributes: { name: 'First' },
+          meta: {
+            adoptsFrom: { module: rri('./product'), name: 'Gallery' },
+          },
+        },
+      }),
+    );
+
+    let row = await prerenderedHtmlRowFor(
+      testDbAdapter,
+      `${testRealm}gallery-1.json`,
+    );
+    assert.ok(row, 'the instance row exists');
+    let manifest = row!.screenshots as ScreenshotManifest | null;
+    assert.ok(manifest?.tile, 'the thumbnail capture landed');
+    assert.true(
+      manifest!.tile.useAsThumbnail,
+      'the manifest carries the thumbnail flag',
+    );
+
+    let fittedHtml = Object.values(
+      (row!.fitted_html ?? {}) as Record<string, string>,
+    ).join('\n');
+    assert.true(
+      fittedHtml.includes(`${testRealm}_screenshot/gallery-1?name=tile`),
+      `the default fitted tile renders the capture through the cardThumbnailURL chain; got: ${fittedHtml.slice(0, 2000)}`,
     );
   });
 


### PR DESCRIPTION
Completes the declared-screenshots consumption story for thumbnails. Linear: CS-12566.

## What this does

`cardThumbnailURL` on CardDef now computes through the full fallback chain:

1. `cardInfo.cardThumbnailURL` — an explicit author-set URL always wins
2. `cardInfo.cardThumbnail?.url` — an authored ImageDef link
3. `screenshotURLs[<useAsThumbnail slot>]` — the capture the card's `static screenshots` declarations flag `useAsThumbnail` (at most one across the merged declarations, enforced by `getScreenshots`)
4. nullish — the absence signal consumers use to fall through to the icon default

The chain coalesces with `||` rather than `??`: a text edit can leave `''` in the authored URL (only the picker's clear button writes `null`), and `''` is never a meaningful URL — it must not mask the rungs below it.

The capture rung reads through the same meta-derived semantics as `screenshotURLs`: a URL exactly when `meta.screenshots` holds the slot, `undefined` otherwise, and render-safe against invalid declarations. Because the default fitted template already renders `cardThumbnailURL` (via BasicFitted's background-image with an icon fallback), every card that opts a capture in gets a live grid-tile preview with **no template edits** — and since the prerender render context supplies declaration-derived `meta.screenshots`, the durable URL lands in persisted `fitted_html` from the instance's very first pass.

`DefaultHeadTemplate.image` (og:image / twitter:image) reads `cardThumbnailURL` alone, so social previews carry the same chain — and the same precedence — as every other consumer.

## Author docs (in the `useAsThumbnail` spec comment)

- **Recommended (not enforced) capture box: 170×250** — the CardsGrid tile — at the default deviceScaleFactor of 2, so captures crop predictably under consumers' `object-fit`/`background-size`.
- The declared width×height is the capture envelope, used exactly as given; for format-based captures the rendered variant is emergent from the template's own container-query breakpoints, deterministic per box. Authors preview with `?format=fitted&envelope=WxH` via the `_screenshot/` DSL on a dev realm, then codify the box.
- The breakpoint-boundary caveat: a box declared near a template breakpoint can flip variants when the template's breakpoints are tuned — the same fragility any responsive design has.
- Point the capture at content (a capture-only `render` component, an isolated/embedded format, or a fitted template that doesn't itself render `cardThumbnailURL`) — a fitted capture of the default fitted template would capture the tile chrome, including its own thumbnail slot.

## Test plan

- Unit (`declared-screenshots-test.ts`): each rung's precedence (explicit URL > ImageDef link > capture), the uncaptured case reading nullish, a card with captures but no `useAsThumbnail` declaration ignoring them, and an emptied (`''`) authored URL falling through to the capture (verified failing under `??`). All 27 pass locally.
- Integration (`declared-screenshots-indexing-test.ts`, CI-arbitrated): a fixture with the **default** fitted template and an isolated-format `useAsThumbnail` capture — asserts the manifest carries the flag and the persisted `fitted_html` embeds the durable `?name=` URL, pinning the no-template-edits path end to end.
- Adjacent suites run locally: thumbnail-picker (10/10), card-basics (103/103); the one serialization failure reproduces identically on unmodified main (pre-existing local-harness issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
