### PR TITLE
DIAGNOSTIC: log base module caching and mapping-change discards

### DIFF
--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -321,6 +321,18 @@ export class Loader {
     // Discard the RRI-keyed caches whenever a mapping is added or removed so an
     // entry can't outlive the spelling it was keyed under.
     this.unsubscribeMappingChange = this.virtualNetwork?.onMappingChange(() => {
+      // TEMPORARY DIAGNOSTIC — remove before merging. A clear here is what
+      // turns one module into two class objects: instances already built hold
+      // the old classes while the next import evaluates fresh ones.
+      let discarded = [...this.modules.keys()].filter((k) =>
+        /(^|\/)(@cardstack\/base|base)\/(spec|card-api)$/.test(k),
+      );
+      if (discarded.length > 0) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[dup-diag] mapping change discarding ${this.modules.size} modules, including ${JSON.stringify(discarded)}`,
+        );
+      }
       this.modules.clear();
       this.moduleCanonicalURLs.clear();
       this.knownDepsCache.clear();
@@ -1366,7 +1378,17 @@ export class Loader {
   }
 
   private setModule(moduleIdentifier: string, module: Module) {
-    this.modules.set(this.moduleCacheKey(moduleIdentifier), module);
+    let key = this.moduleCacheKey(moduleIdentifier);
+    // TEMPORARY DIAGNOSTIC — remove before merging. Records every caching of a
+    // base `spec`/`card-api` module with the key it lands under, so a second
+    // evaluation of the same key (two class objects, one module) is visible.
+    if (/(^|\/)(@cardstack\/base|base)\/(spec|card-api)$/.test(key)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[dup-diag] setModule state=${module.state} key=${key} id=${moduleIdentifier}`,
+      );
+    }
+    this.modules.set(key, module);
   }
 
   private setCanonicalModuleURL(


### PR DESCRIPTION
Not for merging. Establishes why seeding the base realm canonically produces `instanceof` failures against classes that look correct.

Two keys coexisting is already ruled out: `moduleCacheKey` runs the identifier through `unresolveURL`, and all three spellings of a base module — the `cardstack.com` alias, the served URL, and the prefix — collapse to `@cardstack/base/<name>`. So one module cannot be cached twice at once.

What remains is the cache being discarded mid-flight. Every realm-mapping change clears `modules` wholesale, by design, because the RRI keys are only stable between mapping changes. Anything already holding a class from a discarded module keeps it while the next import evaluates a fresh one, and the two diverge — which is the reported symptom exactly.

`setModule` logs every caching of a base `spec`/`card-api` with its key and state, and the mapping-change handler logs what it discards. A second `state=evaluated` for one key, with a discard between, is the proof.