### PR TITLE
fix: identify and date `boxel test`'s local module mounts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1139,6 +1139,14 @@ jobs:
       - name: Build
         run: pnpm build
         working-directory: packages/boxel-cli
+      # The unit suite drives a real browser: local-mode `boxel test` runs the
+      # host's compiled test bundle in chromium, so `tests/local-mode.test.ts`
+      # launches one. Chromium only — `loadChromium` is the sole browser this
+      # package launches, and firefox/webkit would pull system libraries this
+      # job has no other use for.
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install chromium
+        working-directory: packages/boxel-cli
       - name: Run unit tests
         run: pnpm test:unit
         working-directory: packages/boxel-cli

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -822,11 +822,13 @@ export async function startTestPageServer(
     });
   }
 
-  // Headers every mount response carries, mirroring the set a realm-server
-  // stamps via `createResponse`. A mount serves a realm's modules without
-  // being a realm, so these headers are the only thing that can name the
-  // realm a mounted module belongs to — whoever needs that owner asks the
-  // module URL for it.
+  // Headers every mount response carries. The realm-identity pair —
+  // `X-Boxel-Realm-Url` and `X-Boxel-Realm-Public-Readable` — is what a
+  // realm-server stamps via `createResponse`; the blanket allow-origin is
+  // this server's own, carried by every response it serves. A mount serves a
+  // realm's modules without being a realm, so that pair is the only thing
+  // that can name the realm a mounted module belongs to — whoever needs that
+  // owner asks the module URL for it.
   //
   // `CachingDefinitionLookup.buildLookupContext` is the consequential asker:
   // for a module outside every realm registered with it, it HEADs the module
@@ -845,8 +847,9 @@ export async function startTestPageServer(
       'Access-Control-Allow-Origin': '*',
       'X-Boxel-Realm-Url': realmUrl,
       'X-Boxel-Realm-Public-Readable': 'true',
-      // Only the custom headers need naming; `Last-Modified` is on the CORS
-      // response safelist and reaches a cross-origin reader regardless.
+      // Just the identity pair, which is all a mount adds — a realm-server
+      // names a longer list. `Last-Modified` is absent because it is on the
+      // CORS response safelist and reaches a cross-origin reader regardless.
       'Access-Control-Expose-Headers':
         'X-Boxel-Realm-Url,X-Boxel-Realm-Public-Readable',
     };

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -751,14 +751,14 @@ function buildQunitTestPageHtml(opts: {
 </html>`;
 }
 
-interface RealmMount {
+export interface RealmMount {
   /** URL path segment (no slashes), e.g. "workspace" or "base". */
   prefix: string;
   /** Absolute path to the directory served at that prefix. */
   root: string;
 }
 
-interface TestPageServerOptions {
+export interface TestPageServerOptions {
   hostDistDir: string;
   /** Realm mounts served from this same server (local-mode only). */
   realmMounts?: RealmMount[];
@@ -780,8 +780,13 @@ interface TestPageServerOptions {
  * The two responsibilities live in one server so chromium issues every
  * request against the same origin; that sidesteps CORS preflights and
  * the loader's URL-mapping edge cases.
+ *
+ * Every mount response identifies the realm it serves — see `realmHeaders`
+ * for what depends on that.
  */
-async function startTestPageServer(opts: TestPageServerOptions): Promise<{
+export async function startTestPageServer(
+  opts: TestPageServerOptions,
+): Promise<{
   url: string;
   server: Server;
   setHtml: (h: string) => void;
@@ -812,6 +817,34 @@ async function startTestPageServer(opts: TestPageServerOptions): Promise<{
       prefix: mount.prefix,
       root: resolve(mount.root),
     });
+  }
+
+  // Headers every mount response carries, mirroring the set a realm-server
+  // stamps via `createResponse`. A mount serves a realm's modules without
+  // being a realm, so these headers are the only thing that can name the
+  // realm a mounted module belongs to — whoever needs that owner asks the
+  // module URL for it.
+  //
+  // `CachingDefinitionLookup.buildLookupContext` is the consequential asker:
+  // for a module outside every realm registered with it, it HEADs the module
+  // URL and reads `x-boxel-realm-url`. With no owner to name it throws
+  // `FilterRefersToNonexistentTypeError`, which aborts the field-tree walk
+  // behind every card GET and turns it into a 500 — and that walk reaches a
+  // mounted module for every card there is, because `CardDef.cardInfo` holds
+  // a `CardInfoField` served from the base mount.
+  //
+  // Public-readable is the truth here rather than a convenience: the mounts
+  // are unauthenticated static file serving. Expose-Headers pairs with the
+  // blanket `Access-Control-Allow-Origin` these responses already carry;
+  // without it a cross-origin reader gets the body but not the identity.
+  function realmHeaders(realmUrl: string): Record<string, string> {
+    return {
+      'Access-Control-Allow-Origin': '*',
+      'X-Boxel-Realm-Url': realmUrl,
+      'X-Boxel-Realm-Public-Readable': 'true',
+      'Access-Control-Expose-Headers':
+        'X-Boxel-Realm-Url,X-Boxel-Realm-Public-Readable',
+    };
   }
   let transpileCache = new Map<string, { mtimeMs: number; body: string }>();
 
@@ -906,7 +939,7 @@ async function startTestPageServer(opts: TestPageServerOptions): Promise<{
           walkRealm(mount.root, '', realmUrl, mtimes);
           reply.writeHead(200, {
             'Content-Type': 'application/vnd.api+json',
-            'Access-Control-Allow-Origin': '*',
+            ...realmHeaders(realmUrl),
           });
           reply.end(
             JSON.stringify({
@@ -922,13 +955,13 @@ async function startTestPageServer(opts: TestPageServerOptions): Promise<{
 
         let normalized = normalize(rest).split(sep).join('/');
         if (normalized.startsWith('..') || normalized.startsWith('/')) {
-          reply.writeHead(403, { 'Access-Control-Allow-Origin': '*' });
+          reply.writeHead(403, realmHeaders(realmUrl));
           reply.end('Forbidden');
           return;
         }
         let filePath = resolveExisting(mount.root, normalized);
         if (!filePath) {
-          reply.writeHead(404, { 'Access-Control-Allow-Origin': '*' });
+          reply.writeHead(404, realmHeaders(realmUrl));
           reply.end('Not found');
           return;
         }
@@ -949,7 +982,7 @@ async function startTestPageServer(opts: TestPageServerOptions): Promise<{
               let message = err instanceof Error ? err.message : String(err);
               reply.writeHead(500, {
                 'Content-Type': 'text/plain',
-                'Access-Control-Allow-Origin': '*',
+                ...realmHeaders(realmUrl),
               });
               reply.end(`transpile failed: ${message}`);
               return;
@@ -958,8 +991,8 @@ async function startTestPageServer(opts: TestPageServerOptions): Promise<{
           }
           reply.writeHead(200, {
             'Content-Type': 'application/javascript',
-            'Access-Control-Allow-Origin': '*',
             'X-Boxel-Cli-Transpiled': '1',
+            ...realmHeaders(realmUrl),
           });
           reply.end(cached.body);
           return;
@@ -968,11 +1001,11 @@ async function startTestPageServer(opts: TestPageServerOptions): Promise<{
         try {
           reply.writeHead(200, {
             'Content-Type': mimeTypes[ext] ?? 'application/octet-stream',
-            'Access-Control-Allow-Origin': '*',
+            ...realmHeaders(realmUrl),
           });
           reply.end(readFileSync(filePath));
         } catch {
-          reply.writeHead(404, { 'Access-Control-Allow-Origin': '*' });
+          reply.writeHead(404, realmHeaders(realmUrl));
           reply.end('Not found');
         }
         return;

--- a/packages/boxel-cli/src/lib/test-engine.ts
+++ b/packages/boxel-cli/src/lib/test-engine.ts
@@ -783,6 +783,9 @@ export interface TestPageServerOptions {
  *
  * Every mount response identifies the realm it serves — see `realmHeaders`
  * for what depends on that.
+ *
+ * @internal Exported for tests, which drive the mounts without a browser.
+ * `api.ts` names its exports explicitly, so this stays inside the package.
  */
 export async function startTestPageServer(
   opts: TestPageServerOptions,
@@ -842,6 +845,8 @@ export async function startTestPageServer(
       'Access-Control-Allow-Origin': '*',
       'X-Boxel-Realm-Url': realmUrl,
       'X-Boxel-Realm-Public-Readable': 'true',
+      // Only the custom headers need naming; `Last-Modified` is on the CORS
+      // response safelist and reaches a cross-origin reader regardless.
       'Access-Control-Expose-Headers':
         'X-Boxel-Realm-Url,X-Boxel-Realm-Public-Readable',
     };
@@ -968,6 +973,20 @@ export async function startTestPageServer(
         let stat = statSync(filePath);
         let ext = filePath.match(/\.[^.]+$/)?.[0] ?? '';
         let needsTranspile = ext === '.gts' || ext === '.ts';
+        // A realm-server stamps this on every file serve, and the module
+        // prerender requires it: `buildModuleModel` HEADs the module with
+        // `Accept: card-source` and treats only a 404 as a shimmed module, so
+        // for a served module it reads `last-modified` and fails the render
+        // outright without one. That failure is not a 404, so the definition
+        // lookup persists it as a module error and `lookupDefinition` throws
+        // `FilterRefersToNonexistentTypeError` — the same 500 an unidentified
+        // mount produces, one step further along. `x-created` is the optional
+        // half of the pair: absent, the module's created time falls back to
+        // this, which is the best a file mount can honestly report anyway.
+        //
+        // `toUTCString` is RFC 7231 IMF-fixdate, the format `formatRFC7231`
+        // writes and the host's reader parses.
+        let lastModified = new Date(stat.mtimeMs).toUTCString();
 
         if (needsTranspile) {
           let cached = transpileCache.get(filePath);
@@ -991,6 +1010,7 @@ export async function startTestPageServer(
           }
           reply.writeHead(200, {
             'Content-Type': 'application/javascript',
+            'Last-Modified': lastModified,
             'X-Boxel-Cli-Transpiled': '1',
             ...realmHeaders(realmUrl),
           });
@@ -1001,6 +1021,7 @@ export async function startTestPageServer(
         try {
           reply.writeHead(200, {
             'Content-Type': mimeTypes[ext] ?? 'application/octet-stream',
+            'Last-Modified': lastModified,
             ...realmHeaders(realmUrl),
           });
           reply.end(readFileSync(filePath));

--- a/packages/boxel-cli/tests/fixtures/local-mode/sample.gts
+++ b/packages/boxel-cli/tests/fixtures/local-mode/sample.gts
@@ -1,0 +1,17 @@
+import { CardDef, Component, field, contains } from '@cardstack/base/card-api';
+import StringField from '@cardstack/base/string';
+
+// One field and one probe element is the whole point: rendering any card at
+// all is what the accompanying test asserts, so nothing here should be
+// interesting enough to fail on its own.
+export class Sample extends CardDef {
+  static displayName = 'Sample';
+
+  @field nickname = contains(StringField);
+
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <div data-sample-probe>{{@model.nickname}}</div>
+    </template>
+  };
+}

--- a/packages/boxel-cli/tests/fixtures/local-mode/sample.test.gts
+++ b/packages/boxel-cli/tests/fixtures/local-mode/sample.test.gts
@@ -1,0 +1,71 @@
+import { module, test } from 'qunit';
+import { waitFor } from '@ember/test-helpers';
+
+import { setupApplicationTest } from '@cardstack/host/tests/helpers/setup';
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  visitOperatorMode,
+} from '@cardstack/host/tests/helpers';
+import { setupMockMatrix } from '@cardstack/host/tests/helpers/mock-matrix';
+
+// The card module resolves against this file's own URL, so it names the
+// workspace mount — the shape a realm author's test has, and the one that puts
+// a mounted module in front of the very first definition lookup a card GET
+// makes. Walking on from there into `CardDef.cardInfo` reaches the base mount
+// as well, so rendering this one card exercises both mounts.
+// @ts-expect-error import.meta is ESM, not CJS
+const sampleModule: string = new URL('./sample', import.meta.url).href;
+const sampleId = `${testRealmURL}Sample/one`;
+
+export function runTests() {
+  module('local-mode card render', function (hooks) {
+    setupApplicationTest(hooks);
+    setupLocalIndexing(hooks);
+    setupOnSave(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
+    });
+
+    hooks.beforeEach(async function () {
+      await setupAcceptanceTestRealm({
+        realmURL: testRealmURL,
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'Sample/one.json': {
+            data: {
+              type: 'card',
+              attributes: { nickname: 'probe' },
+              meta: {
+                adoptsFrom: { module: sampleModule, name: 'Sample' },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // The card GET behind this render resolves a definition for the instance's
+    // own type and then walks its field tree, and both legs land on a mounted
+    // module. A mount that cannot be resolved to an owning realm, or whose
+    // module cannot be modelled, fails that GET — the stack item renders the
+    // error card and the probe never appears.
+    test('renders a card served from the local mounts', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: sampleId, format: 'isolated' }]],
+      });
+      await waitFor('[data-sample-probe]');
+
+      assert.dom('[data-sample-probe]').hasText('probe');
+      assert
+        .dom('[data-test-card-error]')
+        .doesNotExist('the stack item is not an error card');
+    });
+  });
+}

--- a/packages/boxel-cli/tests/lib/test-page-server.test.ts
+++ b/packages/boxel-cli/tests/lib/test-page-server.test.ts
@@ -6,8 +6,9 @@ import { join } from 'node:path';
 
 import { startTestPageServer } from '../../src/lib/test-engine.ts';
 
-// What `CachingDefinitionLookup.probeRemoteRealm` accepts as "yes" when it
-// reads `x-boxel-realm-public-readable`.
+// A copy of what `CachingDefinitionLookup.probeRemoteRealm` accepts as "yes"
+// when it reads `x-boxel-realm-public-readable`. Its accept-list is private,
+// so this restates it rather than sharing it; keep the two in step.
 const TRUTHY_PUBLIC_READABLE = ['true', '1', 'yes'];
 
 describe('local-mode test page server realm mounts', () => {
@@ -51,8 +52,13 @@ describe('local-mode test page server realm mounts', () => {
     realmURL = started.realmURL;
   });
 
-  afterEach(() => {
-    server?.close();
+  afterEach(async () => {
+    if (server) {
+      let closing = server;
+      // `fetch` leaves keep-alive sockets behind, and `close` waits on them.
+      closing.closeAllConnections?.();
+      await new Promise<void>((resolve) => closing.close(() => resolve()));
+    }
     server = undefined;
     for (let dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
@@ -89,7 +95,11 @@ describe('local-mode test page server realm mounts', () => {
     expect(fromBase.headers.get('x-boxel-realm-url')).toBe(realmURL('base'));
   });
 
-  it('exposes the realm headers to a cross-origin reader', async () => {
+  // The mounts are reached same-origin in local mode, so nothing here depends
+  // on the exposure list today. It names what the identity headers are worth
+  // to a reader that is not same-origin, alongside the blanket allow-origin
+  // these responses already carry.
+  it('names the realm headers in its exposure list', async () => {
     let response = await fetch(`${baseUrl}/workspace/sample`);
 
     let exposed = (response.headers.get('access-control-expose-headers') ?? '')
@@ -105,6 +115,39 @@ describe('local-mode test page server realm mounts', () => {
 
     expect(response.status).toBe(404);
     expect(response.headers.get('x-boxel-realm-url')).toBe(realmURL('base'));
+  });
+
+  // `buildModuleModel` HEADs a module with `Accept: card-source` and treats
+  // only a 404 as shimmed, so for a module the mount actually serves it reads
+  // `last-modified` and fails the render without one — which the definition
+  // lookup persists as a module error, throwing the same
+  // `FilterRefersToNonexistentTypeError` an unidentified mount throws.
+  it('dates a mounted module so its prerender can model it', async () => {
+    let head = await fetch(`${baseUrl}/base/card-api`, { method: 'HEAD' });
+    let raw = await fetch(`${baseUrl}/base/realm-info.json`);
+
+    for (let response of [head, raw]) {
+      let lastModified = response.headers.get('last-modified');
+      expect(lastModified).toBeTruthy();
+      // The host parses this as RFC 7231 IMF-fixdate.
+      expect(lastModified).toMatch(
+        /^[A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT$/,
+      );
+      expect(Number.isNaN(Date.parse(lastModified!))).toBe(false);
+    }
+  });
+
+  // The realm URL a mount reports has to be the one the browser is handed for
+  // that prefix, which local mode derives from this same server's origin (the
+  // test page, the mounts and the host config all share it). A mount naming
+  // any other host, port or shape would resolve to a realm the definition
+  // cache and the loader's realm mapping never agree on.
+  it('reports a realm URL derived from the origin serving the page', async () => {
+    let response = await fetch(`${baseUrl}/base/card-api`, { method: 'HEAD' });
+
+    let expected = new URL('/base/', baseUrl).href;
+    expect(realmURL('base')).toBe(expected);
+    expect(response.headers.get('x-boxel-realm-url')).toBe(expected);
   });
 
   it('still transpiles a mounted .gts module', async () => {

--- a/packages/boxel-cli/tests/lib/test-page-server.test.ts
+++ b/packages/boxel-cli/tests/lib/test-page-server.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import type { Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { startTestPageServer } from '../../src/lib/test-engine.ts';
+
+// What `CachingDefinitionLookup.probeRemoteRealm` accepts as "yes" when it
+// reads `x-boxel-realm-public-readable`.
+const TRUTHY_PUBLIC_READABLE = ['true', '1', 'yes'];
+
+describe('local-mode test page server realm mounts', () => {
+  let tempDirs: string[] = [];
+  let server: Server | undefined;
+  let baseUrl: string;
+  let realmURL: (prefix: string) => string;
+
+  function tempDir(): string {
+    let dir = mkdtempSync(join(tmpdir(), 'boxel-test-page-server-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  beforeEach(async () => {
+    // `hostDistDir` backs only the fall-through static branch, so an empty
+    // directory is enough to exercise the mounts.
+    let hostDistDir = tempDir();
+    let workspaceDir = tempDir();
+    let baseDir = tempDir();
+
+    writeFileSync(
+      join(workspaceDir, 'sample.gts'),
+      'export const nickname = "sample";\n',
+    );
+    writeFileSync(
+      join(baseDir, 'card-api.gts'),
+      'export class CardInfoField {}\n',
+    );
+    writeFileSync(join(baseDir, 'realm-info.json'), '{"name":"base"}\n');
+
+    let started = await startTestPageServer({
+      hostDistDir,
+      realmMounts: [
+        { prefix: 'workspace', root: workspaceDir },
+        { prefix: 'base', root: baseDir },
+      ],
+    });
+    server = started.server;
+    baseUrl = started.url;
+    realmURL = started.realmURL;
+  });
+
+  afterEach(() => {
+    server?.close();
+    server = undefined;
+    for (let dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  // A mount serves a realm's modules without being a realm, so these headers
+  // are the only thing that can name the owner of a module served from one.
+  // `CachingDefinitionLookup.buildLookupContext` resolves an owner for any
+  // module outside its registered realms by HEADing the module URL and reading
+  // them; with no owner to name, `lookupDefinition` throws
+  // `FilterRefersToNonexistentTypeError` and fails the field-tree walk behind
+  // every card GET — `CardDef.cardInfo` holds a `CardInfoField` served from
+  // the base mount, so that walk reaches a mounted module for every card.
+  it('answers the owning-realm probe on a HEAD of a mounted module', async () => {
+    let response = await fetch(`${baseUrl}/base/card-api`, { method: 'HEAD' });
+
+    expect(response.ok).toBe(true);
+    expect(response.headers.get('x-boxel-realm-url')).toBe(realmURL('base'));
+    expect(TRUTHY_PUBLIC_READABLE).toContain(
+      response.headers.get('x-boxel-realm-public-readable')?.toLowerCase(),
+    );
+  });
+
+  it('names the mount that served the module, not one shared realm', async () => {
+    let fromWorkspace = await fetch(`${baseUrl}/workspace/sample`);
+    let fromBase = await fetch(`${baseUrl}/base/realm-info.json`);
+
+    expect(realmURL('workspace')).not.toBe(realmURL('base'));
+    expect(fromWorkspace.headers.get('x-boxel-realm-url')).toBe(
+      realmURL('workspace'),
+    );
+    expect(fromBase.headers.get('x-boxel-realm-url')).toBe(realmURL('base'));
+  });
+
+  it('exposes the realm headers to a cross-origin reader', async () => {
+    let response = await fetch(`${baseUrl}/workspace/sample`);
+
+    let exposed = (response.headers.get('access-control-expose-headers') ?? '')
+      .split(',')
+      .map((header) => header.trim().toLowerCase());
+    expect(exposed).toContain('x-boxel-realm-url');
+    expect(exposed).toContain('x-boxel-realm-public-readable');
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+  });
+
+  it('carries the realm headers on a missing module', async () => {
+    let response = await fetch(`${baseUrl}/base/does-not-exist`);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('x-boxel-realm-url')).toBe(realmURL('base'));
+  });
+
+  it('still transpiles a mounted .gts module', async () => {
+    let response = await fetch(`${baseUrl}/workspace/sample`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('application/javascript');
+    expect(response.headers.get('x-boxel-cli-transpiled')).toBe('1');
+    expect(await response.text()).toContain('nickname');
+  });
+
+  it('identifies the realm on the _mtimes discovery document', async () => {
+    let response = await fetch(`${baseUrl}/workspace/_mtimes`, {
+      headers: { Accept: 'application/vnd.api+json' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-boxel-realm-url')).toBe(
+      realmURL('workspace'),
+    );
+    let { data } = (await response.json()) as {
+      data: { id: string; attributes: { mtimes: Record<string, number> } };
+    };
+    expect(data.id).toBe(realmURL('workspace'));
+    expect(Object.keys(data.attributes.mtimes)).toContain(
+      `${realmURL('workspace')}sample.gts`,
+    );
+  });
+});

--- a/packages/boxel-cli/tests/local-mode.test.ts
+++ b/packages/boxel-cli/tests/local-mode.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { runTestsLocally } from '../src/lib/test-engine.ts';
+
+const FIXTURE_DIR = resolve(import.meta.dirname, 'fixtures', 'local-mode');
+
+// Where `resolveHostDistDir` looks, in its order of preference. Local mode
+// runs the host's compiled test bundle in a real browser, so without one there
+// is nothing to drive.
+function hostDistDir(): string | undefined {
+  let candidates = [
+    process.env.TEST_HARNESS_HOST_DIST_PACKAGE_DIR
+      ? join(resolve(process.env.TEST_HARNESS_HOST_DIST_PACKAGE_DIR), 'dist')
+      : undefined,
+    resolve(import.meta.dirname, '..', 'bundled-test-harness'),
+    resolve(import.meta.dirname, '..', '..', 'host', 'dist'),
+  ].filter((dir): dir is string => Boolean(dir));
+  return candidates.find((dir) => existsSync(join(dir, 'tests', 'index.html')));
+}
+
+// A run boots a browser and the host app before a single assertion is reached.
+// This is a ceiling for a wedged run, not a target — the runner's own run-end
+// wait (300s) is lower, so a hang reports as "did not reach runEnd" rather
+// than as a bare vitest timeout that names nothing.
+const RUN_TIMEOUT_MS = 360_000;
+
+let dist = hostDistDir();
+
+// The suite that has a host dist is CI's: the boxel-cli job restores the
+// test-web-assets artifact, `packages/host/dist` included, before running
+// this. Skipping there would hide the only coverage of the browser-level
+// path, so CI fails instead of skipping; a developer without a host build
+// gets the skip and the command that produces one.
+if (!dist && process.env.CI) {
+  throw new Error(
+    'Host dist not found, so local-mode `boxel test` cannot be exercised. ' +
+      'Build it with `pnpm build` in packages/host (needs ' +
+      '`mise run build:ui` first), or point ' +
+      'TEST_HARNESS_HOST_DIST_PACKAGE_DIR at a package dir that has one.',
+  );
+}
+
+describe.skipIf(!dist)('local-mode `boxel test`', () => {
+  // Everything the mounts have to get right to render one card, end to end:
+  // the CLI serves the workspace and base realms itself, the host resolves
+  // `@cardstack/base/` onto that server, and the browser loads a card whose
+  // module the mount serves. The card GET behind that render resolves a
+  // definition for the instance's type and walks its field tree, so it needs
+  // each mounted module to name an owning realm and to be modellable. Failing
+  // either, the GET 500s and the stack item renders the error card — which is
+  // what the fixture's own assertions catch.
+  it(
+    'renders a card whose module is served from a local mount',
+    async () => {
+      let result = await runTestsLocally({ workspaceDir: FIXTURE_DIR });
+
+      // Print the failures rather than only the count: a failure here is a
+      // browser-side assertion this process never saw.
+      expect(
+        result.failures.map((f) => `${f.module} > ${f.testName}: ${f.message}`),
+      ).toEqual([]);
+      expect(result.errorMessage).toBeUndefined();
+      expect(result.status).toBe('passed');
+      expect(result.passedCount).toBeGreaterThan(0);
+      expect(result.testFiles).toEqual(['sample.test.gts']);
+    },
+    RUN_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
Local-mode `boxel test` (the default, no realm-server) serves the workspace, base and skills realms from its own in-process transpiling file server, and remaps `@cardstack/base/` and `@cardstack/skills/` onto those mounts. Those responses described the bytes and nothing else. Two things a realm-server says about a file are load-bearing on the path behind a card GET, and a mount now says both:

- **`X-Boxel-Realm-Url` / `X-Boxel-Realm-Public-Readable`** on every mount response — the realm-identity pair `createResponse` stamps — plus an `Access-Control-Expose-Headers` naming the two. The blanket allow-origin these responses already carried is unchanged and is this server's own.
- **`Last-Modified`**, on both served-file branches, from the `statSync` the handler already has, in the RFC 7231 form the host's reader parses.

## Why each is load-bearing

A mount serves a realm's modules without being a realm, so nothing else can name the realm a mounted module belongs to.

**Resolving an owner.** `CachingDefinitionLookup.buildLookupContext` does it two ways: a prefix match against a realm registered with it, or — for anything outside those — a HEAD of the module URL that reads `x-boxel-realm-url`. The mounted realms are neither, so an unidentified mount left it with no owner to name and it threw `FilterRefersToNonexistentTypeError`.

**Modelling the module.** Identity alone only moves the failure one step. The lookup then populates through the prerenderer, and `buildModuleModel` HEADs the module with `Accept: card-source` and treats *only* a 404 as a shimmed module — so for a module the mount actually serves it requires `last-modified` and errors the render without one. That error is not a 404, so `isMissingModuleError` declines it, the lookup persists it as a module error, and `lookupDefinition` throws the same `FilterRefersToNonexistentTypeError`.

Either way the throw is uncaught: nothing on the field-tree walk catches it, `loadLinks` rethrows, and the router's catch-all turns the card GET into a bare 500.

That reached every card. `CardDef.cardInfo` holds a `CardInfoField` served from the base mount, so `walkAndPopulateQueryFields` recurses into a mounted module for any card there is. It also reaches the workspace mount directly: a test whose card module comes from `import.meta.url` — the shape the software-factory realm suites use — puts its own `adoptsFrom.module` on the mount, so `populateQueryFields`' first lookup goes through this path before `cardInfo` is reached. Any test loading a card through `visitOperatorMode` rendered an error card instead, which ruled out DOM-level render and interaction tests for realm authors; unit tests of pure modules were unaffected.

Indexing and prerender were not affected, and that asymmetry is the same mechanism: a request made during a prerender sets `cacheOnlyDefinitions`, taking the stored-metadata path that never asks for an owner. Only the interactive read does the live lookup.

## Scope

The change is confined to the CLI's mount branch, plus the one CI step the new browser-level coverage needs. Four adjacent things are deliberately left alone:

- **`buildLookupContext` is untouched.** Resolving a registered realm prefix straight from `virtualNetwork.knownRealms()` without a probe would also clear the symptom, but it changes visibility and cache-scope determination on production paths — too much blast radius for a harness gap.
- **A nested field-definition miss still escalates to a 500 on the whole card GET.** `walkAndPopulateQueryFields` reads as though a soft miss were expected (`if (!childDef) continue;`) while `lookupDefinition` throws instead of returning undefined. Softening that would have degraded this into a missing computed link rather than an error card, but it would equally mask a genuinely broken type, so it wants a deliberate decision rather than a drive-by change here.
- **`_info` is not synthesized.** Now that a mount identifies itself, `RealmService.identifyRealm` creates a realm resource for it and background-fetches `{realm}_info` (QUERY, JSON:API), which a mount 404s. It is non-fatal — `info()` returns an `UNKNOWN_REALM_NAME` placeholder synchronously and the error is swallowed with a warning under test — so the cost is a "Unknown Realm" label and console noise, not a broken render. Answering it properly means synthesizing a realm-info document, which is wider surface with its own failure mode; worth doing on its own terms.
- **`X-Boxel-Realm-Public-Readable` is unconditional**, where `createResponse` emits it only for a publicly-readable realm. That makes workspace modules cache under `public`/empty-user where a private remote realm would use `realm-auth` plus an owner id. It is accurate here — the mounts are unauthenticated static serving bound to loopback — and inert, since the in-browser database is per-run and the test prerenderer ignores auth entirely.

Two pre-existing gaps of the same class, neither touched: nothing mounts `openrouter` even though the config rewrite names it (dead only because a test build leaves that config key unset), and `@cardstack/catalog/` is never rewritten, so it keeps a build-baked URL that local mode cannot reach.

## Test plan

**End to end** — `packages/boxel-cli/tests/local-mode.test.ts` drives `runTestsLocally` against the fixture workspace in `tests/fixtures/local-mode/`: headless Chromium, the host's compiled test bundle, a card loaded through `visitOperatorMode`, asserting its probe element renders and no error card does. ~16s.

The fixture card's module resolves against `import.meta.url`, so it names the workspace mount — the realm-author shape, and the one that puts a mounted module in front of the GET's first definition lookup. Walking on into `CardDef.cardInfo` reaches the base mount too, so one card covers both.

Verified to fail with either header reverted, checked separately: with no realm identity, and with identity but no `Last-Modified`, the probe never appears and the run reports the browser-side timeout. Neither half of the fix is redundant.

This is the first thing in the boxel-cli unit suite to launch a browser, so the `boxel-cli-test` job now installs one (`playwright install chromium`, matching what the matrix and software-factory jobs do). Chromium only: `loadChromium` is the sole browser this package launches. The host dist it also needs was already restored by that job from the test-web-assets artifact; absent one the test fails under CI rather than skipping silently, and skips elsewhere with the command that builds it.

**Mount level** — `packages/boxel-cli/tests/lib/test-page-server.test.ts` drives `startTestPageServer` directly (no browser, ~200ms) for the contracts the browser test cannot localize: the owning-realm probe answered on a HEAD, a parseable RFC 7231 date, a realm URL derived from the page-serving origin, per-mount realm identity, the exposure list, identity on a missing module, the `_mtimes` document, and that `.gts` transpilation still carries `X-Boxel-Cli-Transpiled`.

Also run: `lint:js` and `lint:types` clean, and the package's non-integration suite at 584 passing. Nine failures in `tests/smoke.test.ts` and `tests/lib/deadline-ladder.test.ts` reproduce identically on an unmodified tree — both need a built `dist/`, which that environment did not have.

`startTestPageServer` and its two option types are exported for the mount-level test and marked `@internal`; `api.ts` names its exports explicitly, so the published surface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vr1NmFYrKUN23cZYTwLbF