### PR TITLE
fix: percent-encode file names carried in HTTP headers

### DIFF
--- a/packages/boxel-cli/src/commands/file/lint.ts
+++ b/packages/boxel-cli/src/commands/file/lint.ts
@@ -7,6 +7,10 @@ import {
 } from '../../lib/profile-manager.ts';
 import { ensureTrailingSlash } from '@cardstack/runtime-common/paths';
 import { SupportedMimeType } from '@cardstack/runtime-common/supported-mime-type';
+import {
+  encodeLintFilename,
+  LINT_FILENAME_HEADER,
+} from '@cardstack/runtime-common/lint-headers';
 import { FG_GREEN, FG_RED, FG_YELLOW, DIM, RESET } from '../../lib/colors.ts';
 import { cliLog } from '../../lib/cli-log.ts';
 import { resolveRealmIdentifier } from '../../lib/resolve-realm-identifier.ts';
@@ -37,7 +41,8 @@ export interface LintCommandOptions {
 /**
  * Lint a single file's source code via the realm's `_lint` endpoint.
  *
- * Sends the source to `POST <realmUrl>/_lint` with `X-Filename` and
+ * Sends the source to `POST <realmUrl>/_lint` with `X-Filename`
+ * (percent-encoded, so a name outside Latin-1 survives the header) and
  * `X-HTTP-Method-Override: QUERY` headers. Returns the lint result
  * containing messages and optionally auto-fixed output.
  *
@@ -72,7 +77,7 @@ export async function lint(
       headers: {
         Accept: 'application/json',
         'Content-Type': SupportedMimeType.CardSource,
-        'X-Filename': filename,
+        [LINT_FILENAME_HEADER]: encodeLintFilename(filename),
         'X-HTTP-Method-Override': 'QUERY',
       },
       body: source,

--- a/packages/host/app/tools/lint-and-fix.ts
+++ b/packages/host/app/tools/lint-and-fix.ts
@@ -1,6 +1,10 @@
 import { service } from '@ember/service';
 
-import { SupportedMimeType } from '@cardstack/runtime-common';
+import {
+  encodeLintFilename,
+  LINT_FILENAME_HEADER,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
 
 import HostBaseTool from '../lib/host-base-tool';
 import {
@@ -39,7 +43,9 @@ export default class LintAndFixTool extends HostBaseTool<
         Accept: 'application/json',
         'Content-Type': SupportedMimeType.CardSource,
         'X-HTTP-Method-Override': 'QUERY',
-        'X-Filename': input.filename || 'input.gts',
+        [LINT_FILENAME_HEADER]: encodeLintFilename(
+          input.filename || 'input.gts',
+        ),
       },
     });
     if (response.status === 200) {

--- a/packages/host/app/tools/patch-code.ts
+++ b/packages/host/app/tools/patch-code.ts
@@ -1,6 +1,10 @@
 import { service } from '@ember/service';
 
-import { hasExecutableExtension, rri } from '@cardstack/runtime-common';
+import {
+  decodeLintFilename,
+  hasExecutableExtension,
+  rri,
+} from '@cardstack/runtime-common';
 
 import HostBaseTool from '../lib/host-base-tool';
 import { parseSearchReplace } from '../lib/search-replace-block-parsing';
@@ -235,7 +239,14 @@ export default class PatchCodeTool extends HostBaseTool<
   ): Promise<BaseToolModule.LintAndFixResult> {
     let lintCommand = new LintAndFixTool(this.toolContext);
     let realmURL = this.realm.url(fileUrl);
-    let filename = new URL(fileUrl).pathname.split('/').pop() || 'input.gts';
+    // `pathname` is percent-encoded, so the last segment of an emoji-named
+    // file reads as `ai%F0%9F%8E%89app-card.gts`. The tool takes the name as
+    // it is on disk, and re-encoding it for the header it travels in is
+    // `lint-and-fix`'s job — the same percent-encoding either way, which is
+    // why the header's decoder recovers the name here too.
+    let filename =
+      decodeLintFilename(new URL(fileUrl).pathname.split('/').pop()) ||
+      'input.gts';
 
     return await lintCommand.execute({
       realm: realmURL,

--- a/packages/host/app/tools/patch-code.ts
+++ b/packages/host/app/tools/patch-code.ts
@@ -240,10 +240,11 @@ export default class PatchCodeTool extends HostBaseTool<
     let lintCommand = new LintAndFixTool(this.toolContext);
     let realmURL = this.realm.url(fileUrl);
     // `pathname` is percent-encoded, so the last segment of an emoji-named
-    // file reads as `ai%F0%9F%8E%89app-card.gts`. The tool takes the name as
-    // it is on disk, and re-encoding it for the header it travels in is
-    // `lint-and-fix`'s job — the same percent-encoding either way, which is
-    // why the header's decoder recovers the name here too.
+    // file reads as `ai%F0%9F%8E%89app-card.gts`. The tool's `filename` is the
+    // name as it is on disk — the same thing the code editor passes it from
+    // `readyFile.name` — and encoding it for the header it travels in belongs
+    // to the tool, not to each caller. The header's decoder recovers the name
+    // here because `URL.pathname` carries it under that same encoding.
     let filename =
       decodeLintFilename(new URL(fileUrl).pathname.split('/').pop()) ||
       'input.gts';

--- a/packages/host/tests/integration/tools/lint-and-fix-test.gts
+++ b/packages/host/tests/integration/tools/lint-and-fix-test.gts
@@ -1,0 +1,100 @@
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import {
+  decodeLintFilename,
+  LINT_FILENAME_HEADER,
+  type LintResult,
+} from '@cardstack/runtime-common';
+
+import LintAndFixTool from '@cardstack/host/tools/lint-and-fix';
+
+import {
+  testRealmURL,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupRealmCacheTeardown,
+  withCachedRealmSetup,
+} from '../../helpers';
+import { setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+module('Integration | tools | lint-and-fix', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+
+  setupLocalIndexing(hooks);
+  let mockMatrixUtils = setupMockMatrix(hooks, { autostart: true });
+
+  // The name as it is on disk, which is what the tool's `filename` input means
+  // and what its callers hold: the code editor's format action reads
+  // `readyFile.name`, which the file resource has already percent-decoded.
+  const emojiFileName = 'ai\u{1F389}app-card.gts';
+  let adapter: any;
+
+  setupRealmCacheTeardown(hooks);
+
+  hooks.beforeEach(async function () {
+    let realmSetup = await withCachedRealmSetup(async () =>
+      setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          [emojiFileName]: `import {
+  contains,
+  field,
+  CardDef,
+} from '@cardstack/base/card-api';
+import NumberField from '@cardstack/base/number';
+export class EmojiCard extends CardDef {
+  static displayName = 'EmojiCard';
+  @field priority = contains(NumberField);
+}`,
+        },
+      }),
+    );
+    adapter = realmSetup.adapter;
+    let realmService = getService('realm');
+    await realmService.login(testRealmURL);
+  });
+
+  // A header value is a ByteString, so the tool cannot put a name outside
+  // Latin-1 into `X-Filename` verbatim — assembling the request throws
+  // `Cannot convert argument to a ByteString` in the caller, before anything
+  // is sent. The name travels percent-encoded, and arrives as itself.
+  test('lints a file whose name is outside Latin-1', async function (assert) {
+    assert.expect(2);
+
+    let toolService = getService('tool-service');
+    let lintCommand = new LintAndFixTool(toolService.toolContext);
+
+    adapter.lintStub = async (
+      request: Request,
+      _requestContext: any,
+    ): Promise<LintResult> => {
+      assert.strictEqual(
+        decodeLintFilename(request.headers.get(LINT_FILENAME_HEADER)),
+        emojiFileName,
+        'the realm sees the name as it is on disk',
+      );
+      return {
+        output: await request.text(),
+        fixed: true,
+        messages: [],
+      };
+    };
+
+    let result = await lintCommand.execute({
+      realm: testRealmURL,
+      fileContent: '// content of an emoji-named module\n',
+      filename: emojiFileName,
+    });
+
+    assert.strictEqual(
+      result.output,
+      '// content of an emoji-named module\n',
+      'the lint result comes back to the caller',
+    );
+  });
+});

--- a/packages/host/tests/integration/tools/patch-code-test.gts
+++ b/packages/host/tests/integration/tools/patch-code-test.gts
@@ -38,8 +38,6 @@ module('Integration | tools | patch-code', function (hooks) {
 
   const testFileName = 'task.gts';
   const fileUrl = `${testRealmURL}${testFileName}`;
-  const emojiFileName = 'ai\u{1F389}app-card.gts';
-  const emojiFileUrl = `${testRealmURL}${encodeURIComponent(emojiFileName)}`;
   const jsonFileName = 'task.json';
   const jsonFileUrl = `${testRealmURL}${jsonFileName}`;
   let adapter: any;
@@ -70,16 +68,6 @@ export class Task extends CardDef {
   "count": 1
 }
 `,
-          [emojiFileName]: `import {
-  contains,
-  field,
-  CardDef,
-} from '@cardstack/base/card-api';
-import NumberField from '@cardstack/base/number';
-export class EmojiCard extends CardDef {
-  static displayName = 'EmojiCard';
-  @field priority = contains(NumberField);
-}`,
         },
       }),
     );
@@ -111,7 +99,8 @@ export class EmojiCard extends CardDef {
     ): Promise<LintResult> => {
       // The X-Filename header travels percent-encoded, so that a name outside
       // Latin-1 can be carried in a header at all. Read it back through the
-      // same codec.
+      // same codec, which is what pins the name the realm sees to the name on
+      // disk rather than to whichever spelling the caller happened to hold.
       const filename = decodeLintFilename(
         request.headers.get(LINT_FILENAME_HEADER),
       );
@@ -168,49 +157,6 @@ export class Task extends CardDef {
   </template>
 }`;
     assert.strictEqual(result.patchedContent, expectedResult);
-  });
-
-  // The lint endpoint takes the file name in a header, and a header value is a
-  // ByteString — a name with an emoji in it cannot be assembled into the
-  // request verbatim, so it travels percent-encoded. Patching such a file has
-  // to reach the realm, and the name that arrives has to be the one on disk.
-  test('lint-fixes a file whose name is outside Latin-1', async function (assert) {
-    assert.expect(2);
-
-    let toolService = getService('tool-service');
-    let patchCodeCommand = new PatchCodeTool(toolService.toolContext);
-
-    adapter.lintStub = async (
-      request: Request,
-      _requestContext: any,
-    ): Promise<LintResult> => {
-      assert.strictEqual(
-        decodeLintFilename(request.headers.get(LINT_FILENAME_HEADER)),
-        emojiFileName,
-        'the emoji-named file reaches the realm under its own name',
-      );
-      return {
-        output: await request.text(),
-        fixed: true,
-        messages: [],
-      };
-    };
-
-    const codeBlock = `${SEARCH_MARKER}
-  static displayName = 'EmojiCard';
-${SEPARATOR_MARKER}
-  static displayName = 'Emoji Card';
-${REPLACE_MARKER}`;
-
-    let result = await patchCodeCommand.execute({
-      fileIdentifier: emojiFileUrl,
-      codeBlocks: [codeBlock],
-    });
-
-    assert.ok(
-      result.patchedContent?.includes("static displayName = 'Emoji Card';"),
-      'the patch is applied to the emoji-named file',
-    );
   });
 
   test('uses the open file resource when the target file is open', async function (assert) {

--- a/packages/host/tests/integration/tools/patch-code-test.gts
+++ b/packages/host/tests/integration/tools/patch-code-test.gts
@@ -5,7 +5,9 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
+  decodeLintFilename,
   Deferred,
+  LINT_FILENAME_HEADER,
   REPLACE_MARKER,
   SEARCH_MARKER,
   SEPARATOR_MARKER,
@@ -36,6 +38,8 @@ module('Integration | tools | patch-code', function (hooks) {
 
   const testFileName = 'task.gts';
   const fileUrl = `${testRealmURL}${testFileName}`;
+  const emojiFileName = 'ai\u{1F389}app-card.gts';
+  const emojiFileUrl = `${testRealmURL}${encodeURIComponent(emojiFileName)}`;
   const jsonFileName = 'task.json';
   const jsonFileUrl = `${testRealmURL}${jsonFileName}`;
   let adapter: any;
@@ -66,6 +70,16 @@ export class Task extends CardDef {
   "count": 1
 }
 `,
+          [emojiFileName]: `import {
+  contains,
+  field,
+  CardDef,
+} from '@cardstack/base/card-api';
+import NumberField from '@cardstack/base/number';
+export class EmojiCard extends CardDef {
+  static displayName = 'EmojiCard';
+  @field priority = contains(NumberField);
+}`,
         },
       }),
     );
@@ -95,8 +109,12 @@ export class Task extends CardDef {
       request: Request,
       _requestContext: any,
     ): Promise<LintResult> => {
-      // Verify that X-Filename header is passed correctly
-      const filename = request.headers.get('X-Filename');
+      // The X-Filename header travels percent-encoded, so that a name outside
+      // Latin-1 can be carried in a header at all. Read it back through the
+      // same codec.
+      const filename = decodeLintFilename(
+        request.headers.get(LINT_FILENAME_HEADER),
+      );
       assert.strictEqual(
         filename,
         testFileName,
@@ -150,6 +168,49 @@ export class Task extends CardDef {
   </template>
 }`;
     assert.strictEqual(result.patchedContent, expectedResult);
+  });
+
+  // The lint endpoint takes the file name in a header, and a header value is a
+  // ByteString — a name with an emoji in it cannot be assembled into the
+  // request verbatim, so it travels percent-encoded. Patching such a file has
+  // to reach the realm, and the name that arrives has to be the one on disk.
+  test('lint-fixes a file whose name is outside Latin-1', async function (assert) {
+    assert.expect(2);
+
+    let toolService = getService('tool-service');
+    let patchCodeCommand = new PatchCodeTool(toolService.toolContext);
+
+    adapter.lintStub = async (
+      request: Request,
+      _requestContext: any,
+    ): Promise<LintResult> => {
+      assert.strictEqual(
+        decodeLintFilename(request.headers.get(LINT_FILENAME_HEADER)),
+        emojiFileName,
+        'the emoji-named file reaches the realm under its own name',
+      );
+      return {
+        output: await request.text(),
+        fixed: true,
+        messages: [],
+      };
+    };
+
+    const codeBlock = `${SEARCH_MARKER}
+  static displayName = 'EmojiCard';
+${SEPARATOR_MARKER}
+  static displayName = 'Emoji Card';
+${REPLACE_MARKER}`;
+
+    let result = await patchCodeCommand.execute({
+      fileIdentifier: emojiFileUrl,
+      codeBlocks: [codeBlock],
+    });
+
+    assert.ok(
+      result.patchedContent?.includes("static displayName = 'Emoji Card';"),
+      'the patch is applied to the emoji-named file',
+    );
   });
 
   test('uses the open file resource when the target file is open', async function (assert) {

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -338,6 +338,56 @@ module(basename(import.meta.filename), function () {
           );
         });
 
+        // A redirect target is a header value, and a header value is a
+        // ByteString — so a file name carrying anything outside Latin-1 (an
+        // emoji, a CJK character) cannot go into `Location` as the local path
+        // spells it. The realm has to percent-encode the target, which is also
+        // the form the client asked for on the wire.
+        test('serves a card-source redirect to a module whose name is outside Latin-1', async function (assert) {
+          let stem = 'ai\u{1F389}app-card';
+          await testRealm.write(`${stem}.gts`, '// a module named with emoji');
+
+          let response = await request
+            .get(new URL(stem, realmURL).pathname)
+            .set('Accept', 'application/vnd.card+source');
+
+          assert.strictEqual(response.status, 302, 'HTTP 302 status');
+          assert.strictEqual(
+            response.headers['location'],
+            new URL(`${stem}.gts`, realmURL).pathname,
+            'the redirect target is percent-encoded',
+          );
+
+          let followed = await request
+            .get(response.headers['location'])
+            .set('Accept', 'application/vnd.card+source');
+          assert.strictEqual(
+            followed.status,
+            200,
+            'following the redirect reaches the module',
+          );
+          assert.strictEqual(
+            followed.text,
+            '// a module named with emoji',
+            'the redirect resolves back to the same file',
+          );
+        });
+
+        test('serves a card instance .json redirect for a name outside Latin-1', async function (assert) {
+          let stem = 'ai\u{1F389}app-card-instance';
+
+          let response = await request
+            .get(new URL(`${stem}.json`, realmURL).pathname)
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(response.status, 302, 'HTTP 302 status');
+          assert.strictEqual(
+            response.headers['location'],
+            new URL(stem, realmURL).pathname,
+            'the redirect target is percent-encoded',
+          );
+        });
+
         test('serves a card instance GET request with card-source accept header that results in redirect', async function (assert) {
           let response = await request
             .get('/person-1')

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -3,6 +3,10 @@ const { module, test } = QUnit;
 import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
 import type { Realm } from '@cardstack/runtime-common';
+import {
+  encodeLintFilename,
+  LINT_FILENAME_HEADER,
+} from '@cardstack/runtime-common';
 import { setupPermissionedRealmCached, createJWT } from '../helpers/index.ts';
 import {
   benchmarkOperation,
@@ -1010,6 +1014,40 @@ export class MyCard extends CardDef {
 }
 `,
         'X-Filename header is used for parser detection',
+      );
+    });
+
+    // A header value is a ByteString, so a name outside Latin-1 travels
+    // percent-encoded (`encodeLintFilename`). The realm decodes it back before
+    // reading the extension off it, so `.gts` is still what picks the parser.
+    test('supports an X-Filename outside Latin-1 for parser detection', async function (assert) {
+      let encodedFilename = encodeLintFilename('ai\u{1F389}app-card.gts');
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set(LINT_FILENAME_HEADER, encodedFilename)
+        .send(`import { CardDef } from '@cardstack/base/card-api';
+export class MyCard extends CardDef {
+@field name = contains(StringField);
+}
+`);
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let responseJson = JSON.parse(response.text);
+      assert.strictEqual(
+        responseJson.output,
+        `import StringField from '@cardstack/base/string';
+import { CardDef, field, contains } from '@cardstack/base/card-api';
+export class MyCard extends CardDef {
+  @field name = contains(StringField);
+}
+`,
+        'an emoji-named .gts file is linted as .gts',
       );
     });
 

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -1018,8 +1018,11 @@ export class MyCard extends CardDef {
     });
 
     // A header value is a ByteString, so a name outside Latin-1 travels
-    // percent-encoded (`encodeLintFilename`). The realm decodes it back before
-    // reading the extension off it, so `.gts` is still what picks the parser.
+    // percent-encoded (`encodeLintFilename`). This covers the round trip an
+    // emoji-named file takes through the endpoint — encode, decode, `.gts`
+    // parser. It does not pin the decode on its own: percent-encoding never
+    // touches `.` or an ASCII letter, so the extension survives either way.
+    // The traversal test below is what the decode itself is answerable to.
     test('supports an X-Filename outside Latin-1 for parser detection', async function (assert) {
       let encodedFilename = encodeLintFilename('ai\u{1F389}app-card.gts');
       let response = await request
@@ -1048,6 +1051,37 @@ export class MyCard extends CardDef {
 }
 `,
         'an emoji-named .gts file is linted as .gts',
+      );
+    });
+
+    // The traversal guard runs on the decoded name, which is the reason the
+    // decode happens before validation rather than after. Percent-encoded,
+    // `../../../etc/passwd.gts` presents to `path.resolve` as one long
+    // innocuous segment that stays inside the lint anchor; decoded, it is the
+    // escape the guard exists to catch and is rejected exactly as the
+    // unencoded spelling is.
+    test('rejects a percent-encoded traversal in X-Filename', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .set(LINT_FILENAME_HEADER, '..%2F..%2F..%2Fetc%2Fpasswd.gts')
+        .send(`let x = 1;\n`);
+
+      assert.strictEqual(response.status, 200);
+      let body = JSON.parse(response.text);
+      assert.false(body.passed, 'lint reports failure');
+      assert.ok(
+        body.messages.some((m: { message: string }) =>
+          m.message.includes('invalid filename'),
+        ),
+        `payload carries the validation problem: ${JSON.stringify(
+          body.messages,
+        )}`,
       );
     });
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1290,6 +1290,7 @@ export * from './utils.ts';
 export * from './authorization-middleware.ts';
 export * from './resource-types.ts';
 export * from './prerender-headers.ts';
+export * from './lint-headers.ts';
 export * from './query.ts';
 export * from './query-signature.ts';
 export * from './instance-filter-matcher.ts';

--- a/packages/runtime-common/lint-headers.ts
+++ b/packages/runtime-common/lint-headers.ts
@@ -1,17 +1,30 @@
-// The file name a `_lint` caller is linting on behalf of. The realm only reads
-// it to pick a parser (`extname`) and to reject path traversal, so the value is
-// advisory — but it still has to survive the wire, and a header value is a
-// ByteString. A name carrying anything outside Latin-1 — an emoji, a CJK
-// character — cannot be written into one at all: `new Headers` rejects it with
-// `Cannot convert argument to a ByteString`, so a file named `ai🎉app-card.gts`
-// cannot be named in this header verbatim, and the failure lands in the caller
-// before the request is sent. Percent-encoding is therefore part of this
-// header's contract.
+// The file name a `_lint` caller is linting on behalf of. The realm reads it to
+// pick a parser (`extname`) and to reject a name that escapes the lint anchor,
+// so the value is advisory — but it still has to survive the wire, and a header
+// value is a ByteString. A name carrying anything outside Latin-1 — an emoji, a
+// CJK character — cannot be written into one at all: `new Headers` rejects it
+// with `Cannot convert argument to a ByteString`, so a file named
+// `ai🎉app-card.gts` cannot be named in this header verbatim, and the failure
+// lands in the caller before the request is sent. Senders therefore
+// percent-encode the name; the realm decodes it back, and tolerates a value
+// that arrives unencoded.
 export const LINT_FILENAME_HEADER = 'X-Filename';
 
 export function encodeLintFilename(filename: string): string {
   return encodeURIComponent(filename);
 }
+
+// Control characters are dropped rather than decoded through. A header can
+// never carry a bare CR or LF, but a percent-encoded one decodes into a value
+// that can, and the name reaches a log line before the lint task validates it.
+// Nothing else about the name is filtered here: the traversal check runs on the
+// decoded value, which is the point of decoding before it — `..%2F..%2Fetc` is
+// a single innocuous-looking segment until it is decoded.
+// The control characters in this range are the whole point of the pattern, so
+// the lint that guards against writing one into a regex by accident does not
+// apply.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001F\u007F-\u009F]/g;
 
 // Recovers the name from its percent-encoded form. Also used on the last
 // segment of a `URL.pathname`, which carries a file name under the same
@@ -21,18 +34,23 @@ export function encodeLintFilename(filename: string): string {
 // that sends the name verbatim still gets the parser it asked for. An ASCII
 // name encodes to itself, which leaves only names holding a bare `%` for this
 // to be lenient about — there `decodeURIComponent` throws instead of returning
-// the name. Falling back to the raw string costs nothing: the name is advisory,
-// and a `%` can't reach a realm file name anyway (`toSafeFileName` replaces
-// it).
+// the name. Falling back to the raw string costs nothing: such a name cannot be
+// a realm file in the first place, because `RealmPaths.local` recovers a path
+// with `decodeURI`, which throws `URIError` on an escape that isn't valid hex.
 export function decodeLintFilename(
   raw: string | null | undefined,
 ): string | undefined {
   if (typeof raw !== 'string' || raw === '') {
     return undefined;
   }
+  let decoded: string;
   try {
-    return decodeURIComponent(raw);
+    decoded = decodeURIComponent(raw);
   } catch {
-    return raw;
+    decoded = raw;
   }
+  let stripped = decoded.replace(CONTROL_CHARS, '');
+  // A value that was nothing but control characters names no file, so it reads
+  // the same as an absent header and lets the caller's own default stand.
+  return stripped === '' ? undefined : stripped;
 }

--- a/packages/runtime-common/lint-headers.ts
+++ b/packages/runtime-common/lint-headers.ts
@@ -1,0 +1,38 @@
+// The file name a `_lint` caller is linting on behalf of. The realm only reads
+// it to pick a parser (`extname`) and to reject path traversal, so the value is
+// advisory — but it still has to survive the wire, and a header value is a
+// ByteString. A name carrying anything outside Latin-1 — an emoji, a CJK
+// character — cannot be written into one at all: `new Headers` rejects it with
+// `Cannot convert argument to a ByteString`, so a file named `ai🎉app-card.gts`
+// cannot be named in this header verbatim, and the failure lands in the caller
+// before the request is sent. Percent-encoding is therefore part of this
+// header's contract.
+export const LINT_FILENAME_HEADER = 'X-Filename';
+
+export function encodeLintFilename(filename: string): string {
+  return encodeURIComponent(filename);
+}
+
+// Recovers the name from its percent-encoded form. Also used on the last
+// segment of a `URL.pathname`, which carries a file name under the same
+// encoding, to get back the name as it is on disk.
+//
+// A value that isn't encoded is tolerated rather than rejected, so a caller
+// that sends the name verbatim still gets the parser it asked for. An ASCII
+// name encodes to itself, which leaves only names holding a bare `%` for this
+// to be lenient about — there `decodeURIComponent` throws instead of returning
+// the name. Falling back to the raw string costs nothing: the name is advisory,
+// and a `%` can't reach a realm file name anyway (`toSafeFileName` replaces
+// it).
+export function decodeLintFilename(
+  raw: string | null | undefined,
+): string | undefined {
+  if (typeof raw !== 'string' || raw === '') {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4997,11 +4997,22 @@ export class Realm {
   // `Cannot convert argument to a ByteString`. Resolving through `fileURL`
   // percent-encodes the path the same way the client's own URL was encoded on
   // the wire, so the header stays ASCII and `paths.local` recovers the same
-  // file from it. `pathname` (not `href`) keeps the target realm-relative,
-  // which is what a client reaching the realm through a different published
-  // host needs.
+  // file from it.
+  //
+  // The `./` prefix is what keeps that resolution path-relative, and it is not
+  // optional. A bare local path whose first segment reads as a URL scheme is
+  // otherwise parsed as an absolute or opaque URL, and everything up to and
+  // including the colon — the realm's own mount path along with it — is dropped
+  // from `pathname`: `notes:x.gts` yields `x.gts`, `https:x.gts` yields `/`,
+  // and a name as ordinary as `re: notes.gts` yields ` notes.gts`, which a
+  // header then trims to `notes.gts`. Each of those addresses a different file
+  // than the one that was found. `./` cannot begin a scheme, so every name
+  // resolves as a path under the realm.
+  //
+  // `pathname` (not `href`) keeps the target realm-relative, which is what a
+  // client reaching the realm through a different published host needs.
   private redirectTarget(localPath: LocalPath): string {
-    return this.paths.fileURL(localPath).pathname;
+    return this.paths.fileURL(`./${localPath}`).pathname;
   }
 
   private async getSourceOrRedirect(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -169,6 +169,7 @@ import {
 import { parseQuery } from './query.ts';
 import type { Readable } from 'stream';
 import { createResponse } from './create-response.ts';
+import { decodeLintFilename, LINT_FILENAME_HEADER } from './lint-headers.ts';
 import stableStringify from 'safe-stable-stringify';
 import {
   captureSpecHash,
@@ -4989,6 +4990,20 @@ export class Realm {
     }
   }
 
+  // The realm-relative target for a 302, built from a local path. A header
+  // value is a ByteString, so a local path carrying anything outside Latin-1 —
+  // an emoji in a file name, a CJK character — cannot go into `Location` as the
+  // path spells it: `new Response` rejects the value outright with
+  // `Cannot convert argument to a ByteString`. Resolving through `fileURL`
+  // percent-encodes the path the same way the client's own URL was encoded on
+  // the wire, so the header stays ASCII and `paths.local` recovers the same
+  // file from it. `pathname` (not `href`) keeps the target realm-relative,
+  // which is what a client reaching the realm through a different published
+  // host needs.
+  private redirectTarget(localPath: LocalPath): string {
+    return this.paths.fileURL(localPath).pathname;
+  }
+
   private async getSourceOrRedirect(
     request: Request,
     requestContext: RequestContext,
@@ -5076,7 +5091,7 @@ export class Realm {
           return notFound(request, requestContext, `${localName} not found`);
         }
         let headers = {
-          Location: `${new URL(this.url).pathname}${handle.path}`,
+          Location: this.redirectTarget(handle.path),
           [CACHE_HEADER]: CACHE_MISS_VALUE,
         };
         let response = createResponse({
@@ -6196,7 +6211,7 @@ export class Realm {
         init: {
           status: 302,
           headers: {
-            Location: `${new URL(this.url).pathname}${canonicalPath}`,
+            Location: this.redirectTarget(canonicalPath),
           },
         },
       });
@@ -6376,7 +6391,7 @@ export class Realm {
           body: null,
           init: {
             status: 302,
-            headers: { Location: `${new URL(this.url).pathname}${foundPath}` },
+            headers: { Location: this.redirectTarget(foundPath) },
           },
         });
       }
@@ -6878,7 +6893,9 @@ export class Realm {
     } else {
       // Get source from plain text request body
       const source = await request.text();
-      const filename = request.headers.get('X-Filename') || 'input.gts';
+      const filename =
+        decodeLintFilename(request.headers.get(LINT_FILENAME_HEADER)) ??
+        'input.gts';
       if (!source || source.trim() === '') {
         return createResponse({
           body: JSON.stringify({


### PR DESCRIPTION
## Problem

An HTTP header value is a ByteString. A string carrying a code point above U+00FF cannot be written into one — `new Response` and `new Headers` reject it with `TypeError: Cannot convert argument to a ByteString because the character at index N has a value of ... which is greater than 255`.

Two realm surfaces put a file name into a header verbatim, so any file named with an emoji — or CJK, or anything else outside Latin-1 — was unreachable through them.

**1. The realm's 302 `Location` headers.** Three of them are built from a local path, and each concatenated the raw local path onto the realm's mount pathname:

- the card-source extension fallback (`GET <realm>/foo` → `foo.gts`),
- the card `.json` canonical redirect (`GET <realm>/foo.json` → `foo`),
- the card path-normalization redirect.

The throw happened while assembling the response, so it propagated out of `Realm.handle` to the realm-server's error middleware as a 500 instead of the redirect. Loading a card whose module reference has no extension, or requesting the `.json` form of such an instance, hit this.

**2. `X-Filename` on `POST /_lint`.** The name was sent as-is, so the throw landed in the caller before the request was sent. Two callers pass a decoded name and genuinely threw: the code editor's Format action (`readyFile.name`, which the file resource percent-decodes) and `bxl file lint <path>` (the raw CLI path). The assistant's patch-code path did *not* throw — it derives the name from `URL.pathname`, which is already percent-encoded — so its change here is a semantics cleanup, not a fix.

## Fix

`Realm.redirectTarget(localPath)` builds every 302 target through `RealmPaths.fileURL('./' + localPath).pathname`, which percent-encodes the path exactly as the client's own request URL was encoded on the wire and which `RealmPaths.local` decodes back to the same file. `pathname` (not `href`) keeps the target realm-relative and same-origin, so a client reaching the realm through a published host still follows it.

The `./` prefix is load-bearing. Resolving a bare local path through `new URL` applies WHATWG scheme detection, so a name whose first segment reads as a scheme is parsed as an absolute or opaque URL and everything through the colon — the realm's mount path included — falls out of `pathname`: `notes:x.gts` → `x.gts`, `https:x.gts` → `/`, and a name as ordinary as `re: notes.gts` → ` notes.gts`, which a header then trims to `notes.gts`. Each addresses a different file than the one that was found, and the realm's write handlers apply no name sanitization, so such names are creatable. `./` cannot begin a scheme. It also keeps a leading-slash local path inside the mount.

`X-Filename` now travels percent-encoded, via `encodeLintFilename` / `decodeLintFilename` in a new `runtime-common/lint-headers.ts` that also owns the header name. The decoder tolerates an unencoded value, so a caller that sends the name verbatim still gets the parser it asked for. It also strips control characters: a header can never carry a bare CR/LF, but a percent-encoded one decodes into a value that can, and the name reaches a log line before the lint task validates it.

Decoding happens *before* the traversal guard, which makes the guard stronger: `..%2F..%2F..%2Fetc%2Fpasswd.gts` previously presented to `path.resolve` as one innocuous segment that stayed inside the lint anchor, and is now rejected exactly as the unencoded spelling is. Double-encoding cannot get around it — one decode of `%252e%252e%252f` yields a literal `%2e%2e%2f`, which `resolve` treats as a directory name.

## Emoji in module names is supported, not something to prevent at creation

The ticket asked whether emoji in a module file name is within spec, and proposed blocking creation of such files if not. It is within spec, so this fixes the transport rather than restricting names:

- ECMA-262 treats a module specifier as an opaque `StringLiteral` and delegates resolution to the host — it places no character restrictions on it.
- The web host resolves a specifier as a URL. URL serialization percent-encodes everything above U+007E in a path, so `./ai🎉app-card.gts` goes over the wire as `./ai%F0%9F%8E%89app-card.gts`.
- Node's ESM resolver resolves to a `file:` URL and percent-decodes the path to reach the file. It rejects `%2F` and `%5C` in a specifier specifically; nothing outside ASCII ever encodes to those.
- Boxel's own loader never uses Node's resolver for realm modules: it resolves specifiers as URLs against the module's own URL and fetches them from the realm. `X-Boxel-Canonical-Path` already carries the encoded `href`, and `extractModuleDependencyKeys` resolves with `new URL(specifier, moduleURL)`.

Nothing in the resolution chain needed changing. `toSafeFileName` continues to replace only the characters a name genuinely cannot survive a `fileURL`/`local` round trip (`# ? \ / %`, tab/newline/CR, a scheme-shaped prefix); a code point above U+00FF round-trips cleanly and is left alone.

## Test plan

- `packages/realm-server/tests/card-source-endpoints-test.ts` — an emoji-named module 302s to a percent-encoded target, and following that target serves the file's bytes; the `.json` canonical redirect does the same for an emoji-named instance path. Both fail pre-change with a 500 rather than a 302.
- `packages/realm-server/tests/realm-endpoints/lint-test.ts` — a percent-encoded traversal in `X-Filename` is rejected. This is what the server-side decode is answerable to: the same value passes the guard pre-change. Alongside it, an emoji `X-Filename` round trip covers encode → decode → `.gts` parser, but does not pin the decode on its own, since percent-encoding never touches `.` or an ASCII letter.
- `packages/host/tests/integration/tools/lint-and-fix-test.gts` — the lint tool carries a decoded emoji file name to the realm and gets its result back. This is the caller shape that threw: the same `filename` the code editor's Format action passes.
- `packages/host/tests/integration/tools/patch-code-test.gts` — the existing header assertion reads through the codec, pinning the name the realm sees to the name on disk.
- Verified locally against the real `RealmPaths`: 32 file names × 5 realm bases (astral and BMP emoji, CJK, Thai, Cyrillic, NFC and NFD forms, spaces, quotes, parens, `+ & @ ; = , $ ~ [ ] ^ | { } < > ! *`, scheme-shaped names, nested directories, a 300-char name; realm bases at the origin root, a sub-path, and percent-encoded/non-ASCII mounts) — every target is header-writable, unmangled by `Headers`, inside the realm mount, and recovered byte-exact by `RealmPaths.local`. The names that still fail (`%`, `#`, `?`, `\`, tab) fail identically before and after, and are the ones `paths.ts` documents as unsurvivable.
- `pnpm lint` clean in `runtime-common`, `realm-server`, `boxel-cli`, and `host`. The realm-server and host suites need Docker (Postgres, Synapse), so they run on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148KTLcNjtqY3J2S3i8CMGA