### PR TITLE
Fix local lint: ignore realms/ in realm-server, add @types/node to runtime-common

### DIFF
--- a/packages/realm-server/.eslintignore
+++ b/packages/realm-server/.eslintignore
@@ -1,1 +1,2 @@
 scripts/bench-realm/fixtures/
+realms/

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -104,6 +104,7 @@
     "@types/js-string-escape": "catalog:",
     "@types/mime-types": "catalog:",
     "@types/ms": "catalog:",
+    "@types/node": "catalog:",
     "@types/qunit": "catalog:",
     "@types/statuses": "catalog:",
     "concurrently": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3266,6 +3266,9 @@ importers:
       '@types/ms':
         specifier: 'catalog:'
         version: 2.1.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
       '@types/qunit':
         specifier: 'catalog:'
         version: 2.19.14


### PR DESCRIPTION
Fixes two `pnpm lint` failures that only show up locally. Ticket: [CS-12765](https://linear.app/cardstack/issue/CS-12765)

**realm-server: `lint:js` never finishes.** `eslint .` walks `realms/`, the directory where the dev realm server writes every workspace created through the app. It is gitignored but was not eslint-ignored, so workspaces containing vendored minified bundles make Prettier-through-eslint effectively hang. CI never has this directory. Adds `realms/` to `.eslintignore`, matching the existing tsconfig exclude.

**runtime-common: `lint:types` fails on `import.meta.main`.** The package never declared `@types/node`, so its Node typings came in transitively from `super-fast-md5` (v20 types) and `ethers` (v22 types), neither of which declares `import.meta.main`. Which copy wins depends on the local `node_modules` layout, so CI passes while a fresh local install fails. Adds `@types/node` from the catalog to devDependencies, as `realm-server`, `bxl` and `boxel-cli` already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)