### PR TITLE
Clean switch-submode's codePath and skip the switch when already on that file

### DIFF
--- a/packages/host/app/tools/switch-submode.ts
+++ b/packages/host/app/tools/switch-submode.ts
@@ -12,6 +12,26 @@ import type OperatorModeStateService from '../services/operator-mode-state-servi
 import type StoreService from '../services/store';
 import type * as BaseToolModule from '@cardstack/base/command';
 
+// Models sometimes hand this tool the SEARCH/REPLACE file header instead of a
+// path — "https://realm/card.gts (new)" — or prose. Strip the new-file marker,
+// which is harmless, and refuse anything that is not one file URL or realm
+// resource identifier, so the tab is never pointed at a path that cannot exist.
+export function cleanCodePath(raw: string | undefined): string | undefined {
+  if (raw == null) {
+    return undefined;
+  }
+  let path = raw.trim().replace(/\s*\(new\)\s*$/i, '');
+  if (!path) {
+    return undefined;
+  }
+  if (/\s/.test(path) || !/^(https?:\/\/|@[a-z0-9-]+\/)/i.test(path)) {
+    throw new Error(
+      `codePath must be a single file URL or realm resource identifier, got "${raw}"`,
+    );
+  }
+  return path;
+}
+
 export default class SwitchSubmodeTool extends HostBaseTool<
   typeof BaseToolModule.SwitchSubmodeInput,
   typeof BaseToolModule.SwitchSubmodeResult | undefined
@@ -62,7 +82,7 @@ export default class SwitchSubmodeTool extends HostBaseTool<
       case Submodes.Code: {
         let lastId = this.lastCardInRightMostStack;
         let codePath =
-          input.codePath ??
+          cleanCodePath(input.codePath) ??
           (lastId
             ? this.lastStackItem?.type === 'file'
               ? lastId
@@ -70,6 +90,16 @@ export default class SwitchSubmodeTool extends HostBaseTool<
             : null);
         let codeRRI = codePath ? rri(codePath) : null;
         let currentSubmode = this.operatorModeStateService.state.submode;
+        // Already in code mode on that very file: there is nothing to switch.
+        // A model that re-asserts its position gets an applied result at
+        // once instead of the file being re-resolved and re-opened.
+        if (
+          currentSubmode === Submodes.Code &&
+          codeRRI &&
+          this.operatorModeStateService.codePathString === codeRRI
+        ) {
+          break;
+        }
         let finalCodePath = codeRRI;
         if (
           codeRRI &&

--- a/packages/host/tests/integration/tools/switch-submode-test.gts
+++ b/packages/host/tests/integration/tools/switch-submode-test.gts
@@ -8,7 +8,9 @@ import { localId } from '@cardstack/runtime-common';
 
 import RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
-import SwitchSubmodeTool from '@cardstack/host/tools/switch-submode';
+import SwitchSubmodeTool, {
+  cleanCodePath,
+} from '@cardstack/host/tools/switch-submode';
 
 import {
   setupIntegrationTestRealm,
@@ -190,6 +192,95 @@ module('Integration | tools | switch-submode', function (hooks) {
     );
     assert.strictEqual(status, 200);
     assert.strictEqual(content, '');
+  });
+
+  test('a codePath carrying the SEARCH/REPLACE new-file marker is cleaned before use', async function (assert) {
+    let toolService = getService('tool-service');
+    let cardService = getService('card-service');
+    let operatorModeStateService = getService('operator-mode-state-service');
+    operatorModeStateService.restore({
+      stacks: [[]],
+      submode: 'interact',
+    });
+    let switchSubmodeCommand = new SwitchSubmodeTool(toolService.toolContext);
+    let fileUrl = `${testRealmURL}marked-file.gts`;
+
+    await switchSubmodeCommand.execute({
+      submode: 'code',
+      codePath: `${fileUrl} (new)`,
+      createFile: true,
+    });
+
+    assert.strictEqual(operatorModeStateService.state?.codePath?.href, fileUrl);
+    let { status, content } = await cardService.getSource(new URL(fileUrl));
+    assert.strictEqual(status, 200);
+    assert.strictEqual(content, '');
+  });
+
+  test('a codePath that is not a file URL is rejected', async function (assert) {
+    let toolService = getService('tool-service');
+    let operatorModeStateService = getService('operator-mode-state-service');
+    operatorModeStateService.restore({
+      stacks: [[]],
+      submode: 'interact',
+    });
+    let switchSubmodeCommand = new SwitchSubmodeTool(toolService.toolContext);
+
+    await assert.rejects(
+      switchSubmodeCommand.execute({
+        submode: 'code',
+        codePath: 'Wedding card def — SEARCH/REPLACE (new)',
+      }),
+      /codePath must be a single file URL/,
+    );
+    assert.strictEqual(
+      operatorModeStateService.state?.submode,
+      'interact',
+      'the tab stays where it was',
+    );
+
+    assert.strictEqual(cleanCodePath(undefined), undefined);
+    assert.strictEqual(cleanCodePath('  '), undefined);
+    assert.strictEqual(
+      cleanCodePath('@cardstack/base/card-api.gts (new)'),
+      '@cardstack/base/card-api.gts',
+    );
+  });
+
+  test('switching to the file already open in code mode is a no-op', async function (assert) {
+    let toolService = getService('tool-service');
+    let cardService = getService('card-service');
+    let operatorModeStateService = getService('operator-mode-state-service');
+    operatorModeStateService.restore({
+      stacks: [[]],
+      submode: 'interact',
+    });
+    let switchSubmodeCommand = new SwitchSubmodeTool(toolService.toolContext);
+    let fileUrl = `${testRealmURL}already-open.gts`;
+
+    await switchSubmodeCommand.execute({
+      submode: 'code',
+      codePath: fileUrl,
+      createFile: true,
+    });
+    await cardService.saveSource(new URL(fileUrl), 'export {};', 'editor');
+    assert.strictEqual(operatorModeStateService.state?.codePath?.href, fileUrl);
+
+    let result = await switchSubmodeCommand.execute({
+      submode: 'code',
+      codePath: fileUrl,
+      createFile: true,
+    });
+
+    assert.notOk(result, 'no result card for a no-op');
+    assert.strictEqual(operatorModeStateService.state?.submode, 'code');
+    assert.strictEqual(operatorModeStateService.state?.codePath?.href, fileUrl);
+    let { content } = await cardService.getSource(new URL(fileUrl));
+    assert.strictEqual(content, 'export {};', 'the file was not touched');
+    let sibling = await cardService.getSource(
+      new URL(`${testRealmURL}already-open-1.gts`),
+    );
+    assert.strictEqual(sibling.status, 404, 'no sibling file was created');
   });
 
   test('createFile reuses an existing blank file', async function (assert) {


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

Two local Sonnet 5 sessions froze on a `switch-submode` call while the tab was already in code mode on the target file. In the latest one the model sent `"codePath": "https://localhost:4201/user/.../facebook-profile-card.gts (new)"`, the SEARCH/REPLACE new-file marker appended to the URL. The tool used the string as is and pointed code mode at a path that cannot exist. No result ever reached the room and the pill stayed on its spinner.

Two guards in the tool:

- `codePath` is cleaned. A trailing `(new)` is stripped, since the intent is clear, and anything that is not one file URL or realm resource identifier is rejected with an error the model can read: `codePath must be a single file URL or realm resource identifier, got "..."`. That error becomes a failed tool result, so the model can correct itself.
- Switching to code mode on the file the tab already shows is a no-op. The tool returns at once with no work, so a model that re-asserts its position gets an applied result for one cheap turn instead of re-resolving and re-opening the file.

Tests cover the cleaned marker creating the right file, the rejection leaving the tab where it was, the pure `cleanCodePath` helper, and the no-op leaving file and state untouched.

The redundant calls themselves come from the environment skill's wording, which tells the model to switch modes before every new file. That is changed in boxel-skills (https://github.com/cardstack/boxel-skills, branch `cs-12784-switch-submode-is-not-a-write-step`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
