### PR TITLE
Stop apt-installing Playwright's system deps in Software Factory CI

### DIFF
--- a/.github/workflows/ci-software-factory.yaml
+++ b/.github/workflows/ci-software-factory.yaml
@@ -98,7 +98,12 @@ jobs:
         # be a missing codec or tofu boxes rather than a browser that cannot
         # launch — reinstate the deps step for that, ideally cached.
         timeout-minutes: 10
-        run: pnpm exec playwright install
+        # Chromium only. Bare `playwright install` fetches Firefox and WebKit
+        # too, which these specs never launch — and it is those browsers'
+        # libraries (libgtk-4, libgst*, libflite*) that Playwright's host
+        # validation then warns are missing, which reads alarmingly like a
+        # broken install rather than two unused browsers.
+        run: pnpm exec playwright install chromium
         working-directory: packages/software-factory
       - name: Run Node tests
         if: ${{ matrix.shard.index == 1 }}

--- a/.github/workflows/ci-software-factory.yaml
+++ b/.github/workflows/ci-software-factory.yaml
@@ -80,21 +80,25 @@ jobs:
           shopt -s dotglob
           cp -a .test-web-assets-artifact/. ./
       - name: Install Playwright Browsers
-        # `--with-deps` bundles two unrelated operations: fetching the browsers
-        # from Microsoft's CDN, and apt-installing the system libraries they
-        # link against. Only the second reaches Ubuntu's mirrors, and that is
-        # where this step stalls — it has sat here for as long as 170 minutes,
-        # holding a runner, while the browser download itself has never been
-        # implicated. Splitting them bounds the half that fails without
-        # touching the half that works.
+        # Browsers only. `install-deps` apt-installs 182 packages (114 MB) from
+        # Ubuntu's mirrors, and that half is what stalls: it has held a runner
+        # for as long as 170 minutes, and even bounded by a timeout it burned
+        # five Software Factory shards in a single day, each failing before any
+        # test ran.
         #
-        # A healthy install of both takes about a minute, so five is generous.
-        # The deps half is still required: without it Playwright reports "Host
-        # system is missing dependencies to run browsers".
+        # What it installs is fonts and GStreamer media codecs. These specs use
+        # Playwright's default Chromium and neither play media nor render
+        # non-Latin text, and the runner image already carries what Chromium
+        # links against — the Matrix suite in ci.yaml has always run Chromium
+        # with no deps step. Measured over all three shards without it: 62
+        # tests pass, the same as with it, and the step takes ~22s rather than
+        # timing out at five minutes.
+        #
+        # If a future spec needs media playback or CJK glyphs, the failure will
+        # be a missing codec or tofu boxes rather than a browser that cannot
+        # launch — reinstate the deps step for that, ideally cached.
         timeout-minutes: 10
-        run: |
-          pnpm exec playwright install
-          timeout 5m pnpm exec playwright install-deps
+        run: pnpm exec playwright install
         working-directory: packages/software-factory
       - name: Run Node tests
         if: ${{ matrix.shard.index == 1 }}

--- a/.github/workflows/ci-software-factory.yaml
+++ b/.github/workflows/ci-software-factory.yaml
@@ -80,30 +80,30 @@ jobs:
           shopt -s dotglob
           cp -a .test-web-assets-artifact/. ./
       - name: Install Playwright Browsers
-        # Browsers only. `install-deps` apt-installs 182 packages (114 MB) from
-        # Ubuntu's mirrors, and that half is what stalls: it has held a runner
-        # for as long as 170 minutes, and even bounded by a timeout it burned
-        # five Software Factory shards in a single day, each failing before any
-        # test ran.
-        #
-        # What it installs is fonts and GStreamer media codecs. These specs use
-        # Playwright's default Chromium and neither play media nor render
-        # non-Latin text, and the runner image already carries what Chromium
-        # links against — the Matrix suite in ci.yaml has always run Chromium
-        # with no deps step. Measured over all three shards without it: 62
-        # tests pass, the same as with it, and the step takes ~22s rather than
-        # timing out at five minutes.
+        # Browsers only. `install-deps` apt-installs fonts and GStreamer media
+        # codecs from Ubuntu's mirrors, and that half is what stalls a runner.
+        # These specs neither play media nor render non-Latin text, and the
+        # runner image already carries the libraries Chromium links against —
+        # the Matrix suite in ci.yaml runs Chromium with no deps step.
         #
         # If a future spec needs media playback or CJK glyphs, the failure will
         # be a missing codec or tofu boxes rather than a browser that cannot
         # launch — reinstate the deps step for that, ideally cached.
-        timeout-minutes: 10
-        # Chromium only. Bare `playwright install` fetches Firefox and WebKit
-        # too, which these specs never launch — and it is those browsers'
-        # libraries (libgtk-4, libgst*, libflite*) that Playwright's host
-        # validation then warns are missing, which reads alarmingly like a
-        # broken install rather than two unused browsers.
-        run: pnpm exec playwright install chromium
+        #
+        # A healthy fetch is well under a minute. The ceiling is here so that a
+        # wedged download fails this job instead of holding a runner.
+        timeout-minutes: 5
+        # Every launch in this job is headless and sets no channel — the
+        # Playwright specs, `boxel test`, and screenshot execution — and
+        # Playwright resolves that combination to `chromium-headless-shell`
+        # rather than to the full browser. `--only-shell` fetches the shell
+        # alone, which is what scripts/factory-setup.ts installs and what
+        # src/preflight.ts requires, so CI and the factory's own setup name the
+        # same target. Naming a browser also stops Playwright's host validation
+        # warning about Firefox's and WebKit's libraries (libgtk-4, libgst*,
+        # libflite*), which reads like a broken install rather than browsers
+        # nothing here launches.
+        run: pnpm exec playwright install --only-shell chromium
         working-directory: packages/software-factory
       - name: Run Node tests
         if: ${{ matrix.shard.index == 1 }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -464,7 +464,12 @@ jobs:
           shopt -s dotglob
           cp -a .test-web-assets-artifact/. ./
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install
+        # Chromium only: playwright.config.ts declares no other project and no
+        # spec here launches Firefox or WebKit. Fetching them anyway makes
+        # Playwright's host validation warn that their libraries (libgtk-4,
+        # libgst*, libflite*) are missing, which reads like a broken install
+        # rather than two browsers this suite never uses.
+        run: pnpm exec playwright install chromium
         working-directory: packages/matrix
       # Warm the test images from the GHCR mirror so the services
       # below (and the Playwright synapse/smtp fixtures) start from a local


### PR DESCRIPTION
While this doesn’t noticeably improve software factory job run times, it does reduce dependency installation, which should help with stability. See the installation [on `main`](https://github.com/cardstack/boxel/actions/runs/31157568432/job/92800822747#step:6:1) vs [on this branch](https://github.com/cardstack/boxel/actions/runs/33873835631/job/101027042778?pr=6015#step:6:1) for comparison: 1200+ lines vs 80 lines.

Claude: `playwright install-deps` fetches 182 packages (114 MB) from Ubuntu's mirrors, and that half of the browser install is the one that stalls. It has held a runner for as long as 170 minutes; bounded by the five-minute timeout added to contain that, it still burned five Software Factory shards in a single day, each dying before a single test ran and each passing on a plain re-run.

The packages are fonts and GStreamer media codecs. These specs use Playwright's default Chromium, play no media and render no non-Latin text, and the runner image already carries the libraries Chromium links against — the Matrix suite in ci.yaml has always run Chromium with no deps step at all.

Measured rather than assumed: with the step removed, all three shards pass 62 tests, the same count as with it, and no missing-library error appears. The install step goes from a five-minute timeout to about 22 seconds.

Reinstating it is the fix if a future spec needs media playback or CJK glyphs; that would present as a missing codec or tofu boxes, not as a browser that cannot launch.