### PR TITLE
Stop pinning the Synapse container's address on the boxel Docker network

### DIFF
--- a/packages/matrix/support/docker.ts
+++ b/packages/matrix/support/docker.ts
@@ -118,7 +118,14 @@ export function dockerExec(args: {
 }
 
 /**
- * Create a docker network; does not fail if network already exists
+ * Create a docker network; does not fail if network already exists.
+ *
+ * The address range is left to Docker. Containers on a user-defined network
+ * reach each other by container name through Docker's embedded DNS, so no
+ * caller needs to know the range — and naming one is a liability: Docker
+ * refuses to create a network whose requested subnet another network already
+ * holds ("Pool overlaps with other one on this address space"), which would
+ * make network creation itself depend on the rest of the daemon's state.
  */
 export function dockerCreateNetwork(args: {
   networkName: string;
@@ -126,7 +133,7 @@ export function dockerCreateNetwork(args: {
   return new Promise<void>((resolve, reject) => {
     childProcess.execFile(
       'docker',
-      ['network', 'create', '--subnet=172.20.0.0/16', args.networkName],
+      ['network', 'create', args.networkName],
       { encoding: 'utf8' },
       (err, _stdout, stderr) => {
         if (err) {
@@ -135,8 +142,10 @@ export function dockerCreateNetwork(args: {
               `network with name ${args.networkName} already exists`,
             )
           ) {
-            // Don't consider this as error
+            // Creation is idempotent: a concurrent harness or an earlier run
+            // may already have created it.
             resolve();
+            return;
           }
           reject(err);
           return;

--- a/packages/matrix/support/synapse/index.ts
+++ b/packages/matrix/support/synapse/index.ts
@@ -29,8 +29,11 @@ const TEST_SYNAPSE_CONTAINER_PREFIX = 'sf-test-synapse-';
 
 // Records which process started a container, so a later run can tell a
 // container whose owner is still running from one left behind by an owner that
-// is gone.
+// is gone. A pid is only meaningful alongside the machine it was issued on —
+// two processes in different pid namespaces against the same Docker daemon
+// number their processes independently — so the host is recorded with it.
 const SYNAPSE_OWNER_LABEL = 'boxel.synapse-owner-pid';
+const SYNAPSE_OWNER_HOST_LABEL = 'boxel.synapse-owner-host';
 
 // Synapse's listeners bind to "::" (IPv6 dual-stack) by default. Hosts whose
 // kernel lacks IPv6 (some minimal cloud VMs / containers) can't bind it and
@@ -237,12 +240,15 @@ export function synapseDockerParams(args: {
   configDir: string;
   hostPort: number;
   ownerPid: number;
+  ownerHost: string;
   runAsRoot?: boolean;
 }): string[] {
   return [
     '--rm',
     '--label',
     `${SYNAPSE_OWNER_LABEL}=${args.ownerPid}`,
+    '--label',
+    `${SYNAPSE_OWNER_HOST_LABEL}=${args.ownerHost}`,
     '-v',
     `${args.configDir}:/data`,
     '-v',
@@ -332,9 +338,9 @@ export async function describeHostPortConflict(
 // either: an abandoned Synapse is running and healthy, on the same port and
 // under the same name shape as one whose suite is mid-run. The owning process
 // is the only signal that separates them, so each container carries its
-// owner's pid and only those whose owner has exited are swept. The dev Synapse
-// is excluded by name — it outlives the process that starts it, and callers
-// meaning to replace it stop it explicitly.
+// owner's pid and host, and only those whose owner has exited are swept. The
+// dev Synapse is excluded by name — it outlives the process that starts it,
+// and callers meaning to replace it stop it explicitly.
 export function abandonedSynapseQuery(): string[] {
   return [
     'ps',
@@ -342,26 +348,31 @@ export function abandonedSynapseQuery(): string[] {
     `name=${TEST_SYNAPSE_CONTAINER_PREFIX}`,
     '--filter',
     `label=${SYNAPSE_OWNER_LABEL}`,
+    '--filter',
+    `label=${SYNAPSE_OWNER_HOST_LABEL}`,
     '--format',
-    `{{.ID}} {{.Label "${SYNAPSE_OWNER_LABEL}"}}`,
+    `{{.ID}} {{.Label "${SYNAPSE_OWNER_LABEL}"}} {{.Label "${SYNAPSE_OWNER_HOST_LABEL}"}}`,
   ];
 }
 
 // Select the containers in that listing whose owning process is gone.
 //
-// Every unreadable answer fails toward leaving the container alone: an owner
-// that does not parse, and a pid that is alive only because it was reused, both
-// read as live. Declining to sweep costs a clear port-conflict message on the
-// next start, while sweeping a container whose run is still going destroys it.
+// A pid can only be asked about from the machine that issued it, so a container
+// labelled with another host is not answerable here and is left alone. Every
+// other unreadable answer resolves the same way: an owner that does not parse,
+// and a pid that is alive only because it was reused, both read as live.
+// Declining to sweep costs a clear port-conflict message on the next start,
+// while sweeping a container whose run is still going destroys it.
 export function abandonedContainerIds(
   listing: string | undefined,
+  sweeperHost: string,
   isOwnerAlive: (pid: number) => boolean,
 ): string[] {
   return (listing ?? '')
     .split('\n')
     .map((line) => line.trim().split(/\s+/))
-    .filter(([id, ownerPid]) => {
-      if (!id) {
+    .filter(([id, ownerPid, ownerHost]) => {
+      if (!id || ownerHost !== sweeperHost) {
         return false;
       }
       let pid = Number(ownerPid);
@@ -386,6 +397,7 @@ function processIsAlive(pid: number): boolean {
 export async function removeAbandonedTestSynapseContainers(): Promise<void> {
   let containerIds = abandonedContainerIds(
     await dockerCapture(abandonedSynapseQuery()),
+    os.hostname(),
     processIsAlive,
   );
   if (containerIds.length === 0) {
@@ -463,6 +475,7 @@ export async function synapseStart(
       configDir: synCfg.configDir,
       hostPort,
       ownerPid: process.pid,
+      ownerHost: os.hostname(),
       runAsRoot: process.getuid?.() === 0,
     });
 

--- a/packages/matrix/support/synapse/index.ts
+++ b/packages/matrix/support/synapse/index.ts
@@ -297,16 +297,29 @@ export async function describeHostPortConflict(
 
 // Synapse containers are named after the temp config directory they are given,
 // so a run killed before its teardown leaves one behind under a name no later
-// run can predict. Such a container keeps holding the host port the next run
-// needs, so clearing the way means sweeping by name prefix rather than by an
-// individual name.
-async function removeAbandonedTestSynapseContainers(): Promise<void> {
-  let ids = await dockerCapture([
+// run can predict — which rules out clearing it by name.
+//
+// What separates debris from a live tenant is the port. A container still
+// publishing the fixed Synapse port is holding the one this launch is about to
+// claim; a harness that chose its port dynamically is deliberately sharing the
+// host (it starts with `stopExisting: false` precisely so it can coexist with a
+// dev Synapse) and is left alone. So the sweep is the intersection: this
+// harness's own containers, on the port being claimed.
+export function abandonedSynapseQuery(hostPort: number): string[] {
+  return [
     'ps',
-    '-aq',
+    '-q',
     '--filter',
     `name=${TEST_SYNAPSE_CONTAINER_PREFIX}`,
-  ]);
+    '--filter',
+    `publish=${hostPort}`,
+  ];
+}
+
+async function removeAbandonedTestSynapseContainers(
+  hostPort: number,
+): Promise<void> {
+  let ids = await dockerCapture(abandonedSynapseQuery(hostPort));
   let containerIds = ids.split(/\s+/).filter(Boolean);
   if (containerIds.length === 0) {
     return;
@@ -327,6 +340,9 @@ export async function synapseStart(
   opts?: StartOptions,
   stopExisting = true,
 ): Promise<SynapseInstance> {
+  let useDynamicHostPort = Boolean(
+    isEnvironmentMode() || opts?.dynamicHostPort,
+  );
   if (stopExisting) {
     // Stop the main server if it's running
     let defaultContainerName = getSynapseContainerName();
@@ -336,14 +352,12 @@ export async function synapseStart(
       stopPromises.push(synapseStop(id));
     }
     await Promise.allSettled(stopPromises);
-    // `stopExisting` means this Synapse is to be the only one on the host, so
-    // it also covers containers abandoned by a run that never reached its
-    // teardown. Callers that share the host with other harnesses pass false.
-    await removeAbandonedTestSynapseContainers();
+    // Only a fixed-port launch has a port to be blocked out of: the dynamic
+    // path picks one nothing holds.
+    if (!useDynamicHostPort) {
+      await removeAbandonedTestSynapseContainers(SYNAPSE_PORT);
+    }
   }
-  let useDynamicHostPort = Boolean(
-    isEnvironmentMode() || opts?.dynamicHostPort,
-  );
   await dockerCreateNetwork({ networkName: 'boxel' });
 
   let hostPort = SYNAPSE_PORT;

--- a/packages/matrix/support/synapse/index.ts
+++ b/packages/matrix/support/synapse/index.ts
@@ -27,6 +27,11 @@ export const SYNAPSE_PORT = 8008;
 // which `cfgDirFromTemplate` creates with this prefix.
 const TEST_SYNAPSE_CONTAINER_PREFIX = 'sf-test-synapse-';
 
+// Records which process started a container, so a later run can tell a
+// container whose owner is still running from one left behind by an owner that
+// is gone.
+const SYNAPSE_OWNER_LABEL = 'boxel.synapse-owner-pid';
+
 // Synapse's listeners bind to "::" (IPv6 dual-stack) by default. Hosts whose
 // kernel lacks IPv6 (some minimal cloud VMs / containers) can't bind it and
 // synapse dies at startup with "Address family not supported by protocol". We
@@ -55,7 +60,6 @@ interface SynapseConfig {
   // Synapse must be configured with its public_baseurl so we have to allocate a port & url at this stage
   baseUrl: string;
   port: number;
-  host: string;
 }
 
 export interface SynapseInstance extends SynapseConfig {
@@ -145,7 +149,6 @@ export async function cfgDirFromTemplate(
   dataDir?: string,
   options?: {
     publicBaseUrl?: string;
-    host?: string;
     port?: number;
   },
 ): Promise<SynapseConfig> {
@@ -157,7 +160,7 @@ export async function cfgDirFromTemplate(
   }
   const configDir = dataDir
     ? dataDir
-    : await fse.mkdtemp(path.join(os.tmpdir(), 'sf-test-synapse-'));
+    : await fse.mkdtemp(path.join(os.tmpdir(), TEST_SYNAPSE_CONTAINER_PREFIX));
 
   // copy the contents of the template dir, omitting homeserver.yaml as we'll template that
   console.log(`Copy ${templateDir} -> ${configDir}`);
@@ -169,9 +172,8 @@ export async function cfgDirFromTemplate(
   const macaroonSecret = randB64Bytes(16);
   const formSecret = randB64Bytes(16);
 
-  const host = options?.host ?? '127.0.0.1';
   const port = options?.port ?? SYNAPSE_PORT;
-  const baseUrl = options?.publicBaseUrl ?? `http://${host}:${port}`;
+  const baseUrl = options?.publicBaseUrl ?? `http://127.0.0.1:${port}`;
 
   // now copy homeserver.yaml, applying substitutions
   console.log(`Gen ${path.join(templateDir, 'homeserver.yaml')}`);
@@ -206,7 +208,6 @@ export async function cfgDirFromTemplate(
 
   return {
     port,
-    host,
     baseUrl,
     configDir,
     registrationSecret,
@@ -235,10 +236,13 @@ interface StartOptions {
 export function synapseDockerParams(args: {
   configDir: string;
   hostPort: number;
+  ownerPid: number;
   runAsRoot?: boolean;
 }): string[] {
   return [
     '--rm',
+    '--label',
+    `${SYNAPSE_OWNER_LABEL}=${args.ownerPid}`,
     '-v',
     `${args.configDir}:/data`,
     '-v',
@@ -265,7 +269,10 @@ function dockerCapture(params: string[]): Promise<string | undefined> {
     childProcess.execFile(
       'docker',
       params,
-      { encoding: 'utf8' },
+      // Bounded so an unresponsive daemon cannot hang startup, and — since
+      // this also runs while reporting a failure — cannot turn a fast, clear
+      // error into an indefinite stall.
+      { encoding: 'utf8', timeout: 10_000 },
       (err, stdout) => resolve(err ? undefined : stdout.trim()),
     );
   });
@@ -321,28 +328,66 @@ export async function describeHostPortConflict(
 // so a run killed before its teardown leaves one behind under a name no later
 // run can predict — which rules out clearing it by name.
 //
-// What separates debris from a live tenant is the port. A container still
-// publishing the fixed Synapse port is holding the one this launch is about to
-// claim; a harness that chose its port dynamically is deliberately sharing the
-// host (it starts with `stopExisting: false` precisely so it can coexist with a
-// dev Synapse) and is left alone. So the sweep is the intersection: this
-// harness's own containers, on the port being claimed.
-export function abandonedSynapseQuery(hostPort: number): string[] {
+// Nothing about the container itself distinguishes debris from a live tenant
+// either: an abandoned Synapse is running and healthy, on the same port and
+// under the same name shape as one whose suite is mid-run. The owning process
+// is the only signal that separates them, so each container carries its
+// owner's pid and only those whose owner has exited are swept. The dev Synapse
+// is excluded by name — it outlives the process that starts it, and callers
+// meaning to replace it stop it explicitly.
+export function abandonedSynapseQuery(): string[] {
   return [
     'ps',
-    '-q',
     '--filter',
     `name=${TEST_SYNAPSE_CONTAINER_PREFIX}`,
     '--filter',
-    `publish=${hostPort}`,
+    `label=${SYNAPSE_OWNER_LABEL}`,
+    '--format',
+    `{{.ID}} {{.Label "${SYNAPSE_OWNER_LABEL}"}}`,
   ];
 }
 
-async function removeAbandonedTestSynapseContainers(
-  hostPort: number,
-): Promise<void> {
-  let ids = await dockerCapture(abandonedSynapseQuery(hostPort));
-  let containerIds = (ids ?? '').split(/\s+/).filter(Boolean);
+// Select the containers in that listing whose owning process is gone.
+//
+// Every unreadable answer fails toward leaving the container alone: an owner
+// that does not parse, and a pid that is alive only because it was reused, both
+// read as live. Declining to sweep costs a clear port-conflict message on the
+// next start, while sweeping a container whose run is still going destroys it.
+export function abandonedContainerIds(
+  listing: string | undefined,
+  isOwnerAlive: (pid: number) => boolean,
+): string[] {
+  return (listing ?? '')
+    .split('\n')
+    .map((line) => line.trim().split(/\s+/))
+    .filter(([id, ownerPid]) => {
+      if (!id) {
+        return false;
+      }
+      let pid = Number(ownerPid);
+      if (!Number.isInteger(pid) || pid <= 0) {
+        return false;
+      }
+      return !isOwnerAlive(pid);
+    })
+    .map(([id]) => id);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    // EPERM means the process exists but belongs to another user.
+    return e?.code === 'EPERM';
+  }
+}
+
+async function removeAbandonedTestSynapseContainers(): Promise<void> {
+  let containerIds = abandonedContainerIds(
+    await dockerCapture(abandonedSynapseQuery()),
+    processIsAlive,
+  );
   if (containerIds.length === 0) {
     return;
   }
@@ -374,11 +419,7 @@ export async function synapseStart(
       stopPromises.push(synapseStop(id));
     }
     await Promise.allSettled(stopPromises);
-    // Only a fixed-port launch has a port to be blocked out of: the dynamic
-    // path picks one nothing holds.
-    if (!useDynamicHostPort) {
-      await removeAbandonedTestSynapseContainers(SYNAPSE_PORT);
-    }
+    await removeAbandonedTestSynapseContainers();
   }
   await dockerCreateNetwork({ networkName: 'boxel' });
 
@@ -421,6 +462,7 @@ export async function synapseStart(
     let dockerParams = synapseDockerParams({
       configDir: synCfg.configDir,
       hostPort,
+      ownerPid: process.pid,
       runAsRoot: process.getuid?.() === 0,
     });
 
@@ -495,7 +537,6 @@ export async function synapseStart(
   const synapse: SynapseInstance = {
     synapseId,
     ...synCfg,
-    host: '127.0.0.1',
     port: hostPort,
     baseUrl: `http://localhost:${hostPort}`,
   };

--- a/packages/matrix/support/synapse/index.ts
+++ b/packages/matrix/support/synapse/index.ts
@@ -383,7 +383,7 @@ function processIsAlive(pid: number): boolean {
   }
 }
 
-async function removeAbandonedTestSynapseContainers(): Promise<void> {
+export async function removeAbandonedTestSynapseContainers(): Promise<void> {
   let containerIds = abandonedContainerIds(
     await dockerCapture(abandonedSynapseQuery()),
     processIsAlive,

--- a/packages/matrix/support/synapse/index.ts
+++ b/packages/matrix/support/synapse/index.ts
@@ -258,13 +258,15 @@ export function synapseDockerParams(args: {
   ];
 }
 
-function dockerCapture(params: string[]): Promise<string> {
+// Trimmed stdout of a docker command, or undefined when it could not be run —
+// which is distinct from running and producing nothing.
+function dockerCapture(params: string[]): Promise<string | undefined> {
   return new Promise((resolve) => {
     childProcess.execFile(
       'docker',
       params,
       { encoding: 'utf8' },
-      (err, stdout) => resolve(err ? '' : stdout.trim()),
+      (err, stdout) => resolve(err ? undefined : stdout.trim()),
     );
   });
 }
@@ -273,16 +275,21 @@ function dockerCapture(params: string[]): Promise<string> {
 // which address it means, which reads equally like the published host port and
 // like the container's address on the network. Name the port and whatever
 // already publishes it, so the message points at something actionable.
-export async function describeHostPortConflict(
+//
+// `holders` is the `docker ps` listing of containers publishing the port:
+// undefined when Docker could not be asked, empty when it was asked and named
+// nobody. Those are different answers and the message says which it is, so a
+// failed query is never reported as a host process.
+export function formatHostPortConflict(
   hostPort: number,
-): Promise<string> {
-  let holders = await dockerCapture([
-    'ps',
-    '--filter',
-    `publish=${hostPort}`,
-    '--format',
-    '{{.Names}} ({{.Image}})',
-  ]);
+  holders: string | undefined,
+): string {
+  if (holders === undefined) {
+    return (
+      `Host port ${hostPort} is already bound, and Docker could not be asked ` +
+      `what holds it.`
+    );
+  }
   if (holders) {
     return (
       `Host port ${hostPort} is already published by: ` +
@@ -292,6 +299,21 @@ export async function describeHostPortConflict(
   return (
     `Host port ${hostPort} is already bound, and no container publishes it — ` +
     `a process on this host is listening on it.`
+  );
+}
+
+export async function describeHostPortConflict(
+  hostPort: number,
+): Promise<string> {
+  return formatHostPortConflict(
+    hostPort,
+    await dockerCapture([
+      'ps',
+      '--filter',
+      `publish=${hostPort}`,
+      '--format',
+      '{{.Names}} ({{.Image}})',
+    ]),
   );
 }
 
@@ -320,7 +342,7 @@ async function removeAbandonedTestSynapseContainers(
   hostPort: number,
 ): Promise<void> {
   let ids = await dockerCapture(abandonedSynapseQuery(hostPort));
-  let containerIds = ids.split(/\s+/).filter(Boolean);
+  let containerIds = (ids ?? '').split(/\s+/).filter(Boolean);
   if (containerIds.length === 0) {
     return;
   }

--- a/packages/matrix/support/synapse/index.ts
+++ b/packages/matrix/support/synapse/index.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
 import * as net from 'net';
+import * as childProcess from 'child_process';
 import fse from 'fs-extra';
 import { request } from '@playwright/test';
 import {
@@ -20,8 +21,11 @@ import {
   registerSynapseWithTraefik,
 } from '../environment-config.ts';
 
-export const SYNAPSE_IP_ADDRESS = '172.20.0.5';
 export const SYNAPSE_PORT = 8008;
+
+// Synapse containers are named after the temp config directory they are given,
+// which `cfgDirFromTemplate` creates with this prefix.
+const TEST_SYNAPSE_CONTAINER_PREFIX = 'sf-test-synapse-';
 
 // Synapse's listeners bind to "::" (IPv6 dual-stack) by default. Hosts whose
 // kernel lacks IPv6 (some minimal cloud VMs / containers) can't bind it and
@@ -165,7 +169,7 @@ export async function cfgDirFromTemplate(
   const macaroonSecret = randB64Bytes(16);
   const formSecret = randB64Bytes(16);
 
-  const host = options?.host ?? SYNAPSE_IP_ADDRESS;
+  const host = options?.host ?? '127.0.0.1';
   const port = options?.port ?? SYNAPSE_PORT;
   const baseUrl = options?.publicBaseUrl ?? `http://${host}:${port}`;
 
@@ -219,6 +223,97 @@ interface StartOptions {
   dynamicHostPort?: true;
 }
 
+// Build the `docker run` flags for a Synapse container.
+//
+// The container joins the shared `boxel` network without asking for an address
+// on it. Everything that reaches Synapse addresses it either from the host
+// through the published port, or — for containers on the same network, such as
+// a local Prometheus scraping `boxel-synapse:9001` — by container name through
+// Docker's embedded DNS. Requesting a fixed address instead would make startup
+// depend on how many other containers already hold the low addresses in the
+// range, since Docker hands those out in the order containers join.
+export function synapseDockerParams(args: {
+  configDir: string;
+  hostPort: number;
+  runAsRoot?: boolean;
+}): string[] {
+  return [
+    '--rm',
+    '-v',
+    `${args.configDir}:/data`,
+    '-v',
+    `${path.join(import.meta.dirname, 'templates')}:/custom/templates/`,
+    '-v',
+    `${path.join(import.meta.dirname, 'modules')}:/custom/modules/`,
+    '-e',
+    'PYTHONPATH=/custom/modules',
+    // When the host runs as root (e.g. the Claude-web cloud VM), the synapse
+    // image would otherwise drop privileges to its default uid 991, which
+    // cannot write the root-owned config dir mounted at /data. Telling the
+    // image to stay as root (UID/GID=0) keeps it able to create media_store.
+    ...(args.runAsRoot ? ['-e', 'UID=0', '-e', 'GID=0'] : []),
+    '-p',
+    `${args.hostPort}:8008/tcp`,
+    '--network=boxel',
+  ];
+}
+
+function dockerCapture(params: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    childProcess.execFile(
+      'docker',
+      params,
+      { encoding: 'utf8' },
+      (err, stdout) => resolve(err ? '' : stdout.trim()),
+    );
+  });
+}
+
+// Docker reports a refused bind as "Address already in use" without saying
+// which address it means, which reads equally like the published host port and
+// like the container's address on the network. Name the port and whatever
+// already publishes it, so the message points at something actionable.
+export async function describeHostPortConflict(
+  hostPort: number,
+): Promise<string> {
+  let holders = await dockerCapture([
+    'ps',
+    '--filter',
+    `publish=${hostPort}`,
+    '--format',
+    '{{.Names}} ({{.Image}})',
+  ]);
+  if (holders) {
+    return (
+      `Host port ${hostPort} is already published by: ` +
+      `${holders.split('\n').join(', ')}.`
+    );
+  }
+  return (
+    `Host port ${hostPort} is already bound, and no container publishes it — ` +
+    `a process on this host is listening on it.`
+  );
+}
+
+// Synapse containers are named after the temp config directory they are given,
+// so a run killed before its teardown leaves one behind under a name no later
+// run can predict. Such a container keeps holding the host port the next run
+// needs, so clearing the way means sweeping by name prefix rather than by an
+// individual name.
+async function removeAbandonedTestSynapseContainers(): Promise<void> {
+  let ids = await dockerCapture([
+    'ps',
+    '-aq',
+    '--filter',
+    `name=${TEST_SYNAPSE_CONTAINER_PREFIX}`,
+  ]);
+  let containerIds = ids.split(/\s+/).filter(Boolean);
+  if (containerIds.length === 0) {
+    return;
+  }
+  await dockerCapture(['rm', '-f', ...containerIds]);
+}
+
 async function resolveHostPort(synapseId: string): Promise<number> {
   let { execSync } = await import('child_process');
   let portOutput = execSync(`docker port ${synapseId} 8008/tcp`, {
@@ -241,6 +336,10 @@ export async function synapseStart(
       stopPromises.push(synapseStop(id));
     }
     await Promise.allSettled(stopPromises);
+    // `stopExisting` means this Synapse is to be the only one on the host, so
+    // it also covers containers abandoned by a run that never reached its
+    // teardown. Callers that share the host with other harnesses pass false.
+    await removeAbandonedTestSynapseContainers();
   }
   let useDynamicHostPort = Boolean(
     isEnvironmentMode() || opts?.dynamicHostPort,
@@ -256,7 +355,6 @@ export async function synapseStart(
   for (let attempt = 1; attempt <= attempts; attempt++) {
     hostPort = useDynamicHostPort ? await findAvailablePort() : SYNAPSE_PORT;
     synCfg = await cfgDirFromTemplate(opts?.template ?? 'test', opts?.dataDir, {
-      host: useDynamicHostPort ? '127.0.0.1' : SYNAPSE_IP_ADDRESS,
       port: hostPort,
       publicBaseUrl: `http://localhost:${hostPort}`,
     });
@@ -284,36 +382,11 @@ export async function synapseStart(
       `Starting synapse with config dir ${synCfg.configDir} in container ${containerName}...`,
     );
 
-    let dockerParams: string[] = [
-      '--rm',
-      '-v',
-      `${synCfg.configDir}:/data`,
-      '-v',
-      `${path.join(import.meta.dirname, 'templates')}:/custom/templates/`,
-      '-v',
-      `${path.join(import.meta.dirname, 'modules')}:/custom/modules/`,
-      '-e',
-      'PYTHONPATH=/custom/modules',
-    ];
-    // When the host runs as root (e.g. the Claude-web cloud VM), the synapse
-    // image would otherwise drop privileges to its default uid 991, which
-    // cannot write the root-owned config dir mounted at /data. Telling the
-    // image to stay as root (UID/GID=0) keeps it able to create media_store.
-    if (process.getuid?.() === 0) {
-      dockerParams.push('-e', 'UID=0', '-e', 'GID=0');
-    }
-    if (useDynamicHostPort) {
-      // In dynamic-host-port mode multiple harnesses may run concurrently, so
-      // we must not claim the shared fixed Synapse container IP.
-      dockerParams.push('-p', `${hostPort}:8008/tcp`, '--network=boxel');
-    } else {
-      dockerParams.push(
-        `--ip=${synCfg.host}`,
-        '-p',
-        `${synCfg.port}:8008/tcp`,
-        '--network=boxel',
-      );
-    }
+    let dockerParams = synapseDockerParams({
+      configDir: synCfg.configDir,
+      hostPort,
+      runAsRoot: process.getuid?.() === 0,
+    });
 
     try {
       synapseId = await dockerRun({
@@ -334,7 +407,12 @@ export async function synapseStart(
         !isPortBindError(error) ||
         attempt === attempts
       ) {
-        throw error;
+        throw isPortBindError(error)
+          ? new Error(
+              `Could not start Synapse: ${await describeHostPortConflict(hostPort)} ` +
+                `Docker reported: ${error instanceof Error ? error.message : String(error)}`,
+            )
+          : error;
       }
       console.warn(
         `Synapse host port ${hostPort} was claimed before Docker bound it; retrying (${attempt}/${attempts})...`,

--- a/packages/matrix/tests/synapse-container-networking.spec.ts
+++ b/packages/matrix/tests/synapse-container-networking.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+import {
+  describeHostPortConflict,
+  synapseDockerParams,
+} from '../support/synapse/index.ts';
+
+test.describe('Synapse container networking', () => {
+  test('joins the shared network without requesting an address on it', async () => {
+    const params = synapseDockerParams({
+      configDir: '/tmp/sf-test-synapse-abc123',
+      hostPort: 8008,
+    });
+
+    expect(params).toContain('--network=boxel');
+    // Docker allocates addresses on a network in the order containers join it,
+    // so a container that asks for a specific one starts only while every
+    // lower address happens to be free. Nothing reaches Synapse by address —
+    // the host uses the published port, peers on the network use its container
+    // name — so nothing may ask for one.
+    expect(params.filter((p) => p.startsWith('--ip'))).toEqual([]);
+  });
+
+  test('publishes the requested host port', async () => {
+    const params = synapseDockerParams({
+      configDir: '/tmp/sf-test-synapse-abc123',
+      hostPort: 34567,
+    });
+
+    expect(params).toContain('34567:8008/tcp');
+    expect(params[params.indexOf('34567:8008/tcp') - 1]).toBe('-p');
+  });
+
+  test('mounts the config dir and keeps the default container user', async () => {
+    const params = synapseDockerParams({
+      configDir: '/tmp/sf-test-synapse-abc123',
+      hostPort: 8008,
+    });
+
+    expect(params).toContain('/tmp/sf-test-synapse-abc123:/data');
+    expect(params).not.toContain('UID=0');
+  });
+
+  test('stays root in the container when the host runs as root', async () => {
+    const params = synapseDockerParams({
+      configDir: '/tmp/sf-test-synapse-abc123',
+      hostPort: 8008,
+      runAsRoot: true,
+    });
+
+    expect(params).toContain('UID=0');
+    expect(params).toContain('GID=0');
+  });
+
+  test('names the port in a bind conflict rather than leaving it unstated', async () => {
+    // The port no container publishes is the case a reader is most likely to
+    // misread as a Docker-internal problem, so the message has to be explicit
+    // that a host process holds it.
+    const message = await describeHostPortConflict(8008);
+
+    expect(message).toContain('8008');
+  });
+});

--- a/packages/matrix/tests/synapse-container-networking.spec.ts
+++ b/packages/matrix/tests/synapse-container-networking.spec.ts
@@ -11,6 +11,7 @@ test.describe('Synapse container networking', () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
       ownerPid: 4242,
+      ownerHost: 'build-box',
       hostPort: 8008,
     });
 
@@ -27,6 +28,7 @@ test.describe('Synapse container networking', () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
       ownerPid: 4242,
+      ownerHost: 'build-box',
       hostPort: 34567,
     });
 
@@ -38,6 +40,7 @@ test.describe('Synapse container networking', () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
       ownerPid: 4242,
+      ownerHost: 'build-box',
       hostPort: 8008,
     });
 
@@ -49,6 +52,7 @@ test.describe('Synapse container networking', () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
       ownerPid: 4242,
+      ownerHost: 'build-box',
       hostPort: 8008,
       runAsRoot: true,
     });
@@ -61,25 +65,30 @@ test.describe('Synapse container networking', () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
       ownerPid: 4242,
+      ownerHost: 'build-box',
       hostPort: 8008,
     });
 
     // Debris and a live tenant are indistinguishable from the outside — both
     // are running, healthy, and named alike — so the owning process is what a
-    // later run reads to tell them apart.
+    // later run reads to tell them apart. The pid travels with its host,
+    // because it means nothing on any other one.
     expect(params).toContain('boxel.synapse-owner-pid=4242');
+    expect(params).toContain('boxel.synapse-owner-host=build-box');
   });
 
-  test('the sweep asks only about this harness own containers', () => {
+  test('the sweep asks only about containers this harness started', () => {
     const query = abandonedSynapseQuery();
 
     expect(query).toContain('name=sf-test-synapse-');
     expect(query).toContain('label=boxel.synapse-owner-pid');
+    expect(query).toContain('label=boxel.synapse-owner-host');
   });
 
   test('sweeps containers whose owner has exited', () => {
     const ids = abandonedContainerIds(
-      'aaa111 4242\nbbb222 9999',
+      'aaa111 4242 build-box\nbbb222 9999 build-box',
+      'build-box',
       (pid) => pid === 9999,
     );
 
@@ -90,14 +99,32 @@ test.describe('Synapse container networking', () => {
     // The case that matters most: a suite mid-run looks exactly like debris,
     // and removing it kills someone's test run rather than costing them a
     // legible error.
-    const ids = abandonedContainerIds('aaa111 4242', () => true);
+    const ids = abandonedContainerIds(
+      'aaa111 4242 build-box',
+      'build-box',
+      () => true,
+    );
+
+    expect(ids).toEqual([]);
+  });
+
+  test('spares a container owned from another pid namespace', () => {
+    // A pid issued on another host — a container sharing this Docker daemon
+    // through a mounted socket — numbers its processes independently, so
+    // asking about it here answers for an unrelated process, or none.
+    const ids = abandonedContainerIds(
+      'aaa111 4242 devcontainer\nbbb222 4242',
+      'build-box',
+      () => false,
+    );
 
     expect(ids).toEqual([]);
   });
 
   test('spares a container whose owner cannot be read', () => {
     const ids = abandonedContainerIds(
-      'aaa111 not-a-pid\nbbb222 -1\nccc333',
+      'aaa111 not-a-pid build-box\nbbb222 -1 build-box\nccc333',
+      'build-box',
       () => false,
     );
 
@@ -105,8 +132,10 @@ test.describe('Synapse container networking', () => {
   });
 
   test('reads no containers out of an unavailable listing', () => {
-    expect(abandonedContainerIds(undefined, () => false)).toEqual([]);
-    expect(abandonedContainerIds('', () => false)).toEqual([]);
+    expect(abandonedContainerIds(undefined, 'build-box', () => false)).toEqual(
+      [],
+    );
+    expect(abandonedContainerIds('', 'build-box', () => false)).toEqual([]);
   });
 
   test('a bind conflict names the port and the containers holding it', () => {

--- a/packages/matrix/tests/synapse-container-networking.spec.ts
+++ b/packages/matrix/tests/synapse-container-networking.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+  abandonedSynapseQuery,
   describeHostPortConflict,
   synapseDockerParams,
 } from '../support/synapse/index.ts';
@@ -49,6 +50,19 @@ test.describe('Synapse container networking', () => {
 
     expect(params).toContain('UID=0');
     expect(params).toContain('GID=0');
+  });
+
+  test('sweeps abandoned containers only on the port being claimed', () => {
+    const query = abandonedSynapseQuery(8008);
+
+    // A container carrying this harness's name prefix is debris only while it
+    // holds the port this launch is about to claim. A harness that published a
+    // dynamically chosen port is a live tenant sharing the host, so the name
+    // prefix alone must never be enough to select a container for removal.
+    expect(query).toContain('name=sf-test-synapse-');
+    expect(query).toContain('publish=8008');
+    // `-a` would also list exited containers, which hold no port at all.
+    expect(query).not.toContain('-aq');
   });
 
   test('names the port in a bind conflict rather than leaving it unstated', async () => {

--- a/packages/matrix/tests/synapse-container-networking.spec.ts
+++ b/packages/matrix/tests/synapse-container-networking.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+  abandonedContainerIds,
   abandonedSynapseQuery,
   formatHostPortConflict,
   synapseDockerParams,
@@ -9,6 +10,7 @@ test.describe('Synapse container networking', () => {
   test('joins the shared network without requesting an address on it', async () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
+      ownerPid: 4242,
       hostPort: 8008,
     });
 
@@ -24,6 +26,7 @@ test.describe('Synapse container networking', () => {
   test('publishes the requested host port', async () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
+      ownerPid: 4242,
       hostPort: 34567,
     });
 
@@ -34,6 +37,7 @@ test.describe('Synapse container networking', () => {
   test('mounts the config dir and keeps the default container user', async () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
+      ownerPid: 4242,
       hostPort: 8008,
     });
 
@@ -44,6 +48,7 @@ test.describe('Synapse container networking', () => {
   test('stays root in the container when the host runs as root', async () => {
     const params = synapseDockerParams({
       configDir: '/tmp/sf-test-synapse-abc123',
+      ownerPid: 4242,
       hostPort: 8008,
       runAsRoot: true,
     });
@@ -52,17 +57,56 @@ test.describe('Synapse container networking', () => {
     expect(params).toContain('GID=0');
   });
 
-  test('sweeps abandoned containers only on the port being claimed', () => {
-    const query = abandonedSynapseQuery(8008);
+  test('labels each container with the process that started it', () => {
+    const params = synapseDockerParams({
+      configDir: '/tmp/sf-test-synapse-abc123',
+      ownerPid: 4242,
+      hostPort: 8008,
+    });
 
-    // A container carrying this harness's name prefix is debris only while it
-    // holds the port this launch is about to claim. A harness that published a
-    // dynamically chosen port is a live tenant sharing the host, so the name
-    // prefix alone must never be enough to select a container for removal.
+    // Debris and a live tenant are indistinguishable from the outside — both
+    // are running, healthy, and named alike — so the owning process is what a
+    // later run reads to tell them apart.
+    expect(params).toContain('boxel.synapse-owner-pid=4242');
+  });
+
+  test('the sweep asks only about this harness own containers', () => {
+    const query = abandonedSynapseQuery();
+
     expect(query).toContain('name=sf-test-synapse-');
-    expect(query).toContain('publish=8008');
-    // `-a` would also list exited containers, which hold no port at all.
-    expect(query).not.toContain('-aq');
+    expect(query).toContain('label=boxel.synapse-owner-pid');
+  });
+
+  test('sweeps containers whose owner has exited', () => {
+    const ids = abandonedContainerIds(
+      'aaa111 4242\nbbb222 9999',
+      (pid) => pid === 9999,
+    );
+
+    expect(ids).toEqual(['aaa111']);
+  });
+
+  test('spares a container whose owning run is still going', () => {
+    // The case that matters most: a suite mid-run looks exactly like debris,
+    // and removing it kills someone's test run rather than costing them a
+    // legible error.
+    const ids = abandonedContainerIds('aaa111 4242', () => true);
+
+    expect(ids).toEqual([]);
+  });
+
+  test('spares a container whose owner cannot be read', () => {
+    const ids = abandonedContainerIds(
+      'aaa111 not-a-pid\nbbb222 -1\nccc333',
+      () => false,
+    );
+
+    expect(ids).toEqual([]);
+  });
+
+  test('reads no containers out of an unavailable listing', () => {
+    expect(abandonedContainerIds(undefined, () => false)).toEqual([]);
+    expect(abandonedContainerIds('', () => false)).toEqual([]);
   });
 
   test('a bind conflict names the port and the containers holding it', () => {

--- a/packages/matrix/tests/synapse-container-networking.spec.ts
+++ b/packages/matrix/tests/synapse-container-networking.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
   abandonedSynapseQuery,
-  describeHostPortConflict,
+  formatHostPortConflict,
   synapseDockerParams,
 } from '../support/synapse/index.ts';
 
@@ -65,12 +65,32 @@ test.describe('Synapse container networking', () => {
     expect(query).not.toContain('-aq');
   });
 
-  test('names the port in a bind conflict rather than leaving it unstated', async () => {
-    // The port no container publishes is the case a reader is most likely to
-    // misread as a Docker-internal problem, so the message has to be explicit
-    // that a host process holds it.
-    const message = await describeHostPortConflict(8008);
+  test('a bind conflict names the port and the containers holding it', () => {
+    const message = formatHostPortConflict(
+      8008,
+      'boxel-synapse (matrixdotorg/synapse:v1.126.0)\nother (alpine:3)',
+    );
 
     expect(message).toContain('8008');
+    expect(message).toContain('boxel-synapse (matrixdotorg/synapse:v1.126.0)');
+    expect(message).toContain('other (alpine:3)');
+  });
+
+  test('a bind conflict no container explains points at a host process', () => {
+    const message = formatHostPortConflict(8008, '');
+
+    expect(message).toContain('8008');
+    expect(message).toContain('a process on this host');
+  });
+
+  test('a bind conflict Docker could not be asked about says so', () => {
+    // An unavailable daemon and a port no container publishes are different
+    // answers. Reporting the first as the second sends a reader looking for a
+    // host process that does not exist.
+    const message = formatHostPortConflict(8008, undefined);
+
+    expect(message).toContain('8008');
+    expect(message).toContain('Docker could not be asked');
+    expect(message).not.toContain('a process on this host');
   });
 });

--- a/packages/realm-test-harness/src/shared.ts
+++ b/packages/realm-test-harness/src/shared.ts
@@ -792,38 +792,6 @@ export function runCommand(command: string, args: string[], cwd: string) {
   }
 }
 
-export function cleanupStaleSynapseContainers() {
-  // Only clean up test harness Synapse containers (sf-test-synapse-* prefix).
-  // Do NOT touch boxel-synapse* containers — those belong to the dev
-  // environment (mise run dev-all) and killing them breaks the dev server.
-  let result = spawnSync(
-    'docker',
-    ['ps', '-aq', '--filter', 'name=sf-test-synapse-'],
-    {
-      cwd: workspaceRoot,
-      encoding: 'utf8',
-    },
-  );
-
-  if (result.status !== 0) {
-    return;
-  }
-
-  let containerIds = result.stdout
-    .split(/\s+/)
-    .map((id) => id.trim())
-    .filter(Boolean);
-
-  if (containerIds.length === 0) {
-    return;
-  }
-
-  spawnSync('docker', ['rm', '-f', ...containerIds], {
-    cwd: workspaceRoot,
-    stdio: 'ignore',
-  });
-}
-
 export function maybeRequire(specifier: string) {
   if (typeof require === 'function') {
     return require(specifier);

--- a/packages/realm-test-harness/src/support-services.ts
+++ b/packages/realm-test-harness/src/support-services.ts
@@ -9,7 +9,6 @@ import { logger } from './logger.ts';
 import {
   boxelIconsDir,
   browserPassword,
-  cleanupStaleSynapseContainers,
   DEFAULT_ICONS_PROBE_URL,
   DEFAULT_MATRIX_BROWSER_USERNAME,
   DEFAULT_MATRIX_SERVER_USERNAME,
@@ -144,6 +143,7 @@ async function loadSynapseModule() {
       admin?: boolean,
       displayName?: string,
     ) => Promise<unknown>;
+    removeAbandonedTestSynapseContainers: () => Promise<void>;
     synapseStart: (
       opts?: {
         suppressRegistrationSecretFile?: true;
@@ -993,9 +993,14 @@ export async function startFactorySupportServices(): Promise<{
 }> {
   return await logTimed(supportLog, 'startFactorySupportServices', async () => {
     await ensurePgReady();
-    cleanupStaleSynapseContainers();
-    let { synapseStart, synapseStop } = await loadSynapseModule();
+    let { removeAbandonedTestSynapseContainers, synapseStart, synapseStop } =
+      await loadSynapseModule();
     let { getSynapseURL } = await loadMatrixEnvironmentConfigModule();
+
+    // Clear Synapse containers left by harness runs that never reached their
+    // teardown. Containers whose owning process is still alive are a live run,
+    // not debris, and are left alone.
+    await removeAbandonedTestSynapseContainers();
 
     // stopExisting: false — the test harness uses a dynamic port, so it
     // doesn't conflict with the dev Synapse (boxel-synapse on port 8008).


### PR DESCRIPTION
The matrix Playwright suite runs four containers on a shared Docker network called `boxel`: smtp4dev, the mock OIDC upstream, a Caddy proxy in front of it, and Synapse. Global setup starts them in that order, and only Synapse asked for a specific address on the network — `172.20.0.5`. The other three took whatever Docker handed out.

Docker allocates addresses on a user-defined network in the order containers join it. On an otherwise empty network that works out exactly: smtp `.2`, upstream `.3`, proxy `.4`, and `.5` is still free when Synapse asks for it. One more tenant anywhere on that network shifts every allocation up by one, the Caddy proxy takes `.5`, and Synapse cannot start:

```
docker: Error response from daemon: failed to set up container networking: Address already in use
```

That reads like a host port conflict. It is the container's address, and the suite dies before a single test runs.

The observability stack is what makes this routine locally — its Prometheus joins `boxel` to scrape Synapse's metrics, sits at `172.20.0.2`, and restarts on its own, so a reboot does not clear it. The same mechanism hits `mise run start-synapse`, which takes the same fixed-address path as the suite.

## The shape of the fix

Nothing reaches Synapse by address. The host reaches it through the published port (`localhost:8008`); containers on the same network reach it by container name through Docker's embedded DNS, which is exactly how the Prometheus config above names its scrape target — `boxel-synapse:9001`. The pinned address bought nothing and cost the suite its independence from whatever else was on the network, so the request is gone.

With it goes the last difference between the two start paths. The fixed-port path and the dynamic-host-port path (used where several harnesses share a host) now build identical flags — publish the port, join the network, let Docker allocate — so the branch collapses into one `synapseDockerParams` function.

The network's `--subnet=172.20.0.0/16` was pinned to make `172.20.0.5` meaningful and goes with it. Requesting a subnet is not free: Docker refuses to create a network whose range another network already holds (`Pool overlaps with other one on this address space`), and a `boxel` network created any other way — `docker network create boxel`, which `packages/observability/docker-compose.yml` tells you to run when bringing that stack up first — gets a different range, in which the pinned address is not merely taken but invalid.

## Two adjacent repairs

Both are part of the same reported reproduction.

**An abandoned container no longer poisons the next run.** Synapse containers are named after the temp config directory they are given, so a run killed before its teardown leaves one behind under a name no later run can predict — still holding the host port the next run needs.

Nothing about the container itself identifies it as debris. An abandoned Synapse is running and healthy, on the same port and under the same name shape as one whose suite is mid-run — and both the software-factory harness and the Playwright suite start containers under that shape. Neither name nor port can tell them apart.

The owning process can. Each container carries its owner's pid and the host that issued it, and only those whose owner has exited are swept. The host travels with the pid because a pid is only answerable from the machine that issued it — two processes in different namespaces against the same Docker daemon number theirs independently, so a foreign pid read locally names an unrelated process or none. Every unreadable answer leaves the container alone — an owner that does not parse, or a pid that is alive only because it was reused — because declining to sweep costs a legible port-conflict message on the next start, while sweeping a live run destroys it. The dev Synapse is excluded by name: it outlives the process that starts it, and callers meaning to replace it stop it explicitly.

The realm test harness kept a second sweep of its own — every `sf-test-synapse-*` container, removed by name with no liveness test — so starting the factory support services destroyed a running Playwright suite's homeserver, and a concurrent harness's, over containers neither contended for. It now calls the same function rather than carrying a second definition that can drift from this one.

**A refused bind now names what it collided with.** Docker's message declines to say which address is in use. A bind failure is now reported as the host port and whatever publishes it:

```
Could not start Synapse: Host port 8008 is already published by: boxel-synapse (matrixdotorg/synapse:v1.126.0). Docker reported: ...
```

The three answers stay distinct: containers holding it, nobody holding it (so a host process is), and Docker not answerable at all — a failed query is never reported as a host process.

## Verification

Reproduced and re-checked against the real containers with Prometheus holding `172.20.0.2`, running the container-startup half of global setup:

- Before: `RESULT: FAILED — ... failed to set up container networking: Address already in use`
- After: Synapse starts at `172.20.0.3`, passes its health check, and serves `http://localhost:8008`

And the three behaviors the change rests on, checked directly:

- A peer container on `boxel` resolves the Synapse container by name and gets `OK` from `/health` on port 8008 — the path Prometheus uses.
- With a suite mid-run holding port 8008 and debris from a killed run alongside it, a dev-stack Synapse start sweeps the debris, leaves the live suite running, and fails with `Host port 8008 is already published by: sf-test-synapse-… (matrixdotorg/synapse:v1.126.0)` — the loud failure that path has always had, now naming what it collided with.
- A squatter on host port 8008 produces the message above instead of the unattributed one.

`packages/matrix/tests/synapse-container-networking.spec.ts` covers the flag construction directly, so a reintroduced address pin fails a test rather than waiting for a machine that happens to have a neighbour on the network. `pnpm lint` and the shard-assignment test pass.

## Scope

The ticket asks whether this is also behind the Synapse container flakes seen in CI shards. It does not appear to be: no workflow puts anything else on the `boxel` network, so a fresh runner allocates the addresses in exactly the order the pinned one assumed. This removes the dependency regardless, but it should not be expected to move those shards.
