### PR TITLE
Retry a prerender command only when it provably never ran

### DIFF
--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -21,6 +21,7 @@ import {
   retryPolicyForPath,
   sanitizePrerenderJobId,
   sanitizePrerenderRequestId,
+  type PrerenderEndpoint,
 } from './prerender-constants.ts';
 import { randomUUID } from 'crypto';
 import { fromAffinityKey, toAffinityKey } from './affinity.ts';
@@ -975,7 +976,7 @@ export function buildPrerenderManagerApp(options?: {
 
   async function proxyPrerenderRequest(
     ctxt: Koa.Context,
-    pathSuffix: string,
+    pathSuffix: PrerenderEndpoint,
     label: string,
   ) {
     // Same source as the client's own retry loop: the two enforce different
@@ -1198,8 +1199,18 @@ export function buildPrerenderManagerApp(options?: {
           return;
         }
         const timer = setTimeout(() => ac.abort(), proxyTimeoutMs).unref?.();
+        // Only a request that can still be retried somewhere is worth
+        // abandoning to shorten a drain. A dispatched command has no retry
+        // left on either layer, so aborting it here would not defer the work —
+        // it would cancel a command that may already be creating cards and
+        // hand the caller a failure nothing will pick up. The proxy timeout
+        // still bounds how long this can hold the drain open, and the manager
+        // keeps its listener alive after the signal rather than racing to
+        // close (see `shutdown` in manager-server.ts).
         const drainPoll =
-          options?.isDraining && proxyTimeoutMs > 50
+          retryPolicy === 'any-failure' &&
+          options?.isDraining &&
+          proxyTimeoutMs > 50
             ? setInterval(
                 () => {
                   if (options.isDraining!()) {

--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -18,9 +18,9 @@ import {
   PRERENDER_SERVER_STATUS_DRAINING,
   PRERENDER_SERVER_STATUS_HEADER,
   resolvePrerenderServerProxyTimeoutMs,
+  retryPolicyForPath,
   sanitizePrerenderJobId,
   sanitizePrerenderRequestId,
-  type PrerenderRetryPolicy,
 } from './prerender-constants.ts';
 import { randomUUID } from 'crypto';
 import { fromAffinityKey, toAffinityKey } from './affinity.ts';
@@ -977,8 +977,10 @@ export function buildPrerenderManagerApp(options?: {
     ctxt: Koa.Context,
     pathSuffix: string,
     label: string,
-    retryPolicy: PrerenderRetryPolicy = 'any-failure',
   ) {
+    // Same source as the client's own retry loop: the two enforce different
+    // halves of one guarantee and must not disagree about an endpoint.
+    let retryPolicy = retryPolicyForPath(pathSuffix);
     // CS-10872: honor caller-supplied correlation ID; mint one if
     // absent (direct curl, test harnesses). Echo on every subsequent
     // log line so a single grep surfaces the full proxy story.
@@ -1173,6 +1175,28 @@ export function buildPrerenderManagerApp(options?: {
           ac.abort();
           return;
         }
+        // Answer a drain that began since the check at the top of the handler
+        // before dispatching rather than by aborting mid-flight. Both produce
+        // the same status, but only this one can still say no prerender server
+        // received the request: once the fetch is out, an abort cannot
+        // distinguish a connection that was never made from one whose server
+        // had already read the request.
+        if (options?.isDraining?.()) {
+          ctxt.status = PRERENDER_SERVER_DRAINING_STATUS_CODE;
+          ctxt.set(
+            PRERENDER_SERVER_STATUS_HEADER,
+            PRERENDER_SERVER_STATUS_DRAINING,
+          );
+          ctxt.body = {
+            errors: [
+              {
+                status: PRERENDER_SERVER_DRAINING_STATUS_CODE,
+                message: 'Prerender manager draining',
+              },
+            ],
+          };
+          return;
+        }
         const timer = setTimeout(() => ac.abort(), proxyTimeoutMs).unref?.();
         const drainPoll =
           options?.isDraining && proxyTimeoutMs > 50
@@ -1219,9 +1243,11 @@ export function buildPrerenderManagerApp(options?: {
         clearTimeout(timer as any);
         if (drainPoll) clearInterval(drainPoll as any);
         // Whether this target can be ruled out as having acted on the request.
-        // Only a connection that was never established rules it out: a
-        // response of any status, and an abort of a connected request alike,
-        // leave the server free to have read the request and run it.
+        // Only an error code confined to connection setup rules it out. A
+        // response of any status leaves the server free to have read the
+        // request and run it, and so does an abort — it carries no code, and
+        // nothing here can tell one raised before the connect from one raised
+        // with the request already in the server's hands.
         let undeliveredToTarget =
           !res && isUndeliveredRequestError(upstreamError);
         if (!undeliveredToTarget) {
@@ -1348,16 +1374,8 @@ export function buildPrerenderManagerApp(options?: {
   router.post('/prerender-visit', (ctxt) =>
     proxyPrerenderRequest(ctxt, 'prerender-visit', 'visit'),
   );
-  // A command is not idempotent — it creates cards, matrix rooms and outbound
-  // calls, and the queue declines to collapse two identical invocations — so
-  // it never fails over to a second server once a server may have received it.
   router.post('/run-command', (ctxt) =>
-    proxyPrerenderRequest(
-      ctxt,
-      'run-command',
-      'command',
-      'only-when-undelivered',
-    ),
+    proxyPrerenderRequest(ctxt, 'run-command', 'command'),
   );
   router.post('/prerender-screenshot', (ctxt) =>
     proxyPrerenderRequest(ctxt, 'prerender-screenshot', 'screenshot'),

--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -7,6 +7,10 @@ import {
 } from '../middleware/index.ts';
 import { format } from 'date-fns';
 import {
+  isUndeliveredRequestError,
+  PRERENDER_DISPATCH_DELIVERED,
+  PRERENDER_DISPATCH_HEADER,
+  PRERENDER_DISPATCH_NONE,
   PRERENDER_JOB_ID_HEADER,
   PRERENDER_HOST_SHELL_HASH_HEADER,
   PRERENDER_REQUEST_ID_HEADER,
@@ -16,6 +20,7 @@ import {
   resolvePrerenderServerProxyTimeoutMs,
   sanitizePrerenderJobId,
   sanitizePrerenderRequestId,
+  type PrerenderRetryPolicy,
 } from './prerender-constants.ts';
 import { randomUUID } from 'crypto';
 import { fromAffinityKey, toAffinityKey } from './affinity.ts';
@@ -972,6 +977,7 @@ export function buildPrerenderManagerApp(options?: {
     ctxt: Koa.Context,
     pathSuffix: string,
     label: string,
+    retryPolicy: PrerenderRetryPolicy = 'any-failure',
   ) {
     // CS-10872: honor caller-supplied correlation ID; mint one if
     // absent (direct curl, test harnesses). Echo on every subsequent
@@ -983,6 +989,12 @@ export function buildPrerenderManagerApp(options?: {
       sanitizePrerenderRequestId(ctxt.get(PRERENDER_REQUEST_ID_HEADER)) ??
       randomUUID();
     ctxt.set(PRERENDER_REQUEST_ID_HEADER, requestId);
+    // Tells the caller whether any prerender server received this request, so
+    // that a caller retrying a request which must not run twice can tell a
+    // failure that landed before dispatch from one that may have lost the
+    // response to work already done. Starts at `none` and is upgraded the
+    // moment an upstream fetch could have been read by a server.
+    ctxt.set(PRERENDER_DISPATCH_HEADER, PRERENDER_DISPATCH_NONE);
     // Optional indexing-job correlator threaded from the worker. When
     // present, gets stamped onto every proxying/proxied log line as
     // `[job: J.R]` and forwarded upstream so the prerender-server can
@@ -1148,6 +1160,7 @@ export function buildPrerenderManagerApp(options?: {
           `proxying ${label} prerender request for ${logTarget} to ${targetURL} requestId=${requestId} affinity=${affinityKey} attempt=${attempts.size} queueMs=${queueMs}${jobTag}`,
         );
         let abortedDueToDrain = false;
+        let upstreamError: unknown;
         const ac = new AbortController();
         // Expose this attempt's controller so the ctxt.res 'close'
         // listener can abort the current upstream fetch
@@ -1184,6 +1197,7 @@ export function buildPrerenderManagerApp(options?: {
           body: raw,
           signal: ac.signal,
         }).catch((e) => {
+          upstreamError = e;
           if (e?.name === 'AbortError' && clientAborted) {
             // Client gave up — not our fault, not the upstream's
             // fault. Don't prune, don't mark drain. The outer
@@ -1204,6 +1218,15 @@ export function buildPrerenderManagerApp(options?: {
         });
         clearTimeout(timer as any);
         if (drainPoll) clearInterval(drainPoll as any);
+        // Whether this target can be ruled out as having acted on the request.
+        // Only a connection that was never established rules it out: a
+        // response of any status, and an abort of a connected request alike,
+        // leave the server free to have read the request and run it.
+        let undeliveredToTarget =
+          !res && isUndeliveredRequestError(upstreamError);
+        if (!undeliveredToTarget) {
+          ctxt.set(PRERENDER_DISPATCH_HEADER, PRERENDER_DISPATCH_DELIVERED);
+        }
         // If the client aborted at any point during this attempt,
         // stop here — we've already told the upstream to bail via
         // `currentAc.abort()` and the response socket is already
@@ -1232,9 +1255,20 @@ export function buildPrerenderManagerApp(options?: {
           if (draining) {
             markDraining(target);
           }
-          // try next server if available
-          if (attempts.size < registry.servers.size) {
+          // Move on to the next server, unless this request must not run
+          // twice and the failed target may already have carried it out —
+          // failing over then is a second execution the caller never asked
+          // for, and it sees only one call.
+          let mayTryAnotherServer =
+            retryPolicy === 'any-failure' || undeliveredToTarget;
+          if (mayTryAnotherServer && attempts.size < registry.servers.size) {
             continue;
+          }
+          if (!mayTryAnotherServer && attempts.size < registry.servers.size) {
+            log.warn(
+              `not failing over ${label} requestId=${requestId} affinity=${affinityKey} target=${target}: ` +
+                `the request may already have been carried out there${jobTag}`,
+            );
           }
           if (draining) {
             ctxt.status = PRERENDER_SERVER_DRAINING_STATUS_CODE;
@@ -1286,6 +1320,7 @@ export function buildPrerenderManagerApp(options?: {
         // Re-echo after res.headers iteration so the manager's ID
         // wins over any header passthrough from the prerender-server.
         ctxt.set(PRERENDER_REQUEST_ID_HEADER, requestId);
+        ctxt.set(PRERENDER_DISPATCH_HEADER, PRERENDER_DISPATCH_DELIVERED);
         const buf = Buffer.from(await res.arrayBuffer());
         ctxt.body = buf;
         let proxyMs = now() - proxyStart;
@@ -1313,8 +1348,16 @@ export function buildPrerenderManagerApp(options?: {
   router.post('/prerender-visit', (ctxt) =>
     proxyPrerenderRequest(ctxt, 'prerender-visit', 'visit'),
   );
+  // A command is not idempotent — it creates cards, matrix rooms and outbound
+  // calls, and the queue declines to collapse two identical invocations — so
+  // it never fails over to a second server once a server may have received it.
   router.post('/run-command', (ctxt) =>
-    proxyPrerenderRequest(ctxt, 'run-command', 'command'),
+    proxyPrerenderRequest(
+      ctxt,
+      'run-command',
+      'command',
+      'only-when-undelivered',
+    ),
   );
   router.post('/prerender-screenshot', (ctxt) =>
     proxyPrerenderRequest(ctxt, 'prerender-screenshot', 'screenshot'),

--- a/packages/realm-server/prerender/prerender-constants.ts
+++ b/packages/realm-server/prerender/prerender-constants.ts
@@ -164,6 +164,20 @@ export const PRERENDER_DISPATCH_DELIVERED = 'delivered';
 // never reached a prerender server.
 export type PrerenderRetryPolicy = 'any-failure' | 'only-when-undelivered';
 
+// The policy for each prerender endpoint, read by both layers that retry —
+// the client's per-request loop and the manager's failover across servers.
+// They enforce different halves of the same guarantee, so a request type
+// listed on one side and forgotten on the other would keep retrying through
+// the other half in silence; naming it once is what makes that impossible.
+// An endpoint absent here is a pure read.
+const RETRY_POLICY_BY_PATH: Record<string, PrerenderRetryPolicy> = {
+  'run-command': 'only-when-undelivered',
+};
+
+export function retryPolicyForPath(path: string): PrerenderRetryPolicy {
+  return RETRY_POLICY_BY_PATH[path] ?? 'any-failure';
+}
+
 // Network error codes that mean no connection to the peer was ever
 // established, so the request cannot have been received, let alone acted on.
 // A reset or a timeout proves nothing: either can land after the peer read the

--- a/packages/realm-server/prerender/prerender-constants.ts
+++ b/packages/realm-server/prerender/prerender-constants.ts
@@ -141,3 +141,44 @@ export function resolvePrerenderServerProxyTimeoutMs(): number {
     prerenderRequestTimeoutMs,
   );
 }
+
+// Whether any prerender server received this request before the manager
+// answered it. The manager stamps this on every response it produces itself.
+// `none` is the manager's guarantee that no prerender server saw the request,
+// which is what makes the failure safe to retry even for a request that must
+// not run twice; `delivered` — and an absent header, which reads the same way —
+// means a server may have received it and acted on it.
+export const PRERENDER_DISPATCH_HEADER = 'x-boxel-prerender-dispatch';
+export const PRERENDER_DISPATCH_NONE = 'none';
+export const PRERENDER_DISPATCH_DELIVERED = 'delivered';
+
+// How far a failed prerender request may be retried.
+//
+// A render is a pure read of a card: repeating it costs time and nothing else,
+// so any failure is worth another attempt. Running a command is not — it
+// creates cards, matrix rooms and outbound calls, and the queue deliberately
+// declines to collapse two identical invocations (see `dedupeKey` in
+// runtime-common's `tasks/run-command.ts`), so a retry of an invocation whose
+// outcome is unknown executes it a second time while the caller still sees a
+// single call. Such a request is retried only on a failure that proves it
+// never reached a prerender server.
+export type PrerenderRetryPolicy = 'any-failure' | 'only-when-undelivered';
+
+// Network error codes that mean no connection to the peer was ever
+// established, so the request cannot have been received, let alone acted on.
+// A reset or a timeout proves nothing: either can land after the peer read the
+// request and started work on it.
+const UNDELIVERED_ERROR_CODES = new Set([
+  'ECONNREFUSED', // the peer refused the connection
+  'ENOTFOUND', // DNS resolved to nothing
+  'EAI_AGAIN', // DNS resolution failed
+]);
+
+// Node's fetch wraps network errors in a TypeError carrying the underlying
+// error in `cause`, so the code sits at either level.
+export function isUndeliveredRequestError(err: unknown): boolean {
+  let code =
+    (err as { code?: unknown; cause?: { code?: unknown } })?.code ??
+    (err as { cause?: { code?: unknown } })?.cause?.code;
+  return typeof code === 'string' && UNDELIVERED_ERROR_CODES.has(code);
+}

--- a/packages/realm-server/prerender/prerender-constants.ts
+++ b/packages/realm-server/prerender/prerender-constants.ts
@@ -164,18 +164,33 @@ export const PRERENDER_DISPATCH_DELIVERED = 'delivered';
 // never reached a prerender server.
 export type PrerenderRetryPolicy = 'any-failure' | 'only-when-undelivered';
 
-// The policy for each prerender endpoint, read by both layers that retry —
-// the client's per-request loop and the manager's failover across servers.
-// They enforce different halves of the same guarantee, so a request type
-// listed on one side and forgotten on the other would keep retrying through
-// the other half in silence; naming it once is what makes that impossible.
-// An endpoint absent here is a pure read.
-const RETRY_POLICY_BY_PATH: Record<string, PrerenderRetryPolicy> = {
+// Every endpoint that either retrying layer can address. Both take this as
+// their path parameter, so the map below is exhaustive over it and a new
+// endpoint does not compile until it has declared a policy — the alternative,
+// defaulting an unlisted endpoint, makes forgetting to list one mean "retry
+// everything", which is the single outcome this table exists to prevent.
+export type PrerenderEndpoint =
+  | 'prerender-module'
+  | 'prerender-visit'
+  | 'prerender-screenshot'
+  | 'run-command';
+
+// The policy for each endpoint, read by both layers that retry — the client's
+// per-request loop and the manager's failover across servers. They enforce
+// different halves of the same guarantee, so an endpoint given one policy on
+// one side and another on the other would keep retrying through the remaining
+// half in silence; naming it once is what makes that impossible.
+const RETRY_POLICY_BY_PATH: Record<PrerenderEndpoint, PrerenderRetryPolicy> = {
+  'prerender-module': 'any-failure',
+  'prerender-visit': 'any-failure',
+  'prerender-screenshot': 'any-failure',
   'run-command': 'only-when-undelivered',
 };
 
-export function retryPolicyForPath(path: string): PrerenderRetryPolicy {
-  return RETRY_POLICY_BY_PATH[path] ?? 'any-failure';
+export function retryPolicyForPath(
+  path: PrerenderEndpoint,
+): PrerenderRetryPolicy {
+  return RETRY_POLICY_BY_PATH[path];
 }
 
 // Network error codes that mean no connection to the peer was ever

--- a/packages/realm-server/prerender/prerender-constants.ts
+++ b/packages/realm-server/prerender/prerender-constants.ts
@@ -168,10 +168,21 @@ export type PrerenderRetryPolicy = 'any-failure' | 'only-when-undelivered';
 // established, so the request cannot have been received, let alone acted on.
 // A reset or a timeout proves nothing: either can land after the peer read the
 // request and started work on it.
+//
+// Membership turns on the phase an error can be raised in, not on how it
+// reads. Routing failures (`EHOSTUNREACH`, `ENETUNREACH`) are deliberately
+// absent even though they usually do come from a failed `connect`: undici
+// forwards a socket error raw from an established connection too, so a route
+// that dies while the request is in flight surfaces under the same code as one
+// that died before the SYN. `UND_ERR_CONNECT_TIMEOUT` is included because it
+// carries the distinction itself — undici raises it only from the timer it
+// clears once the socket connects, so it cannot describe a request that was
+// already written.
 const UNDELIVERED_ERROR_CODES = new Set([
   'ECONNREFUSED', // the peer refused the connection
   'ENOTFOUND', // DNS resolved to nothing
   'EAI_AGAIN', // DNS resolution failed
+  'UND_ERR_CONNECT_TIMEOUT', // the connection was never established
 ]);
 
 // Node's fetch wraps network errors in a TypeError carrying the underlying

--- a/packages/realm-server/prerender/remote-prerenderer.ts
+++ b/packages/realm-server/prerender/remote-prerenderer.ts
@@ -10,6 +10,9 @@ import {
   logger,
 } from '@cardstack/runtime-common';
 import {
+  isUndeliveredRequestError,
+  PRERENDER_DISPATCH_HEADER,
+  PRERENDER_DISPATCH_NONE,
   PRERENDER_JOB_ID_HEADER,
   PRERENDER_JOB_PRIORITY_HEADER,
   PRERENDER_REQUEST_ID_HEADER,
@@ -18,6 +21,7 @@ import {
   PRERENDER_SERVER_STATUS_HEADER,
   resolvePrerenderManagerRequestTimeoutMs,
   sanitizePrerenderJobId,
+  type PrerenderRetryPolicy,
 } from './prerender-constants.ts';
 import { randomUUID } from 'crypto';
 
@@ -29,9 +33,18 @@ const jsonApiHeaders = {
 
 class RetryablePrerenderError extends Error {
   status?: number;
-  constructor(message: string, status?: number) {
+  // Whether the manager answered without any prerender server having received
+  // the request. Only such a failure is safe to retry under
+  // `only-when-undelivered`.
+  undelivered: boolean;
+  constructor(
+    message: string,
+    status?: number,
+    opts?: { undelivered?: boolean },
+  ) {
     super(message);
     this.status = status;
+    this.undelivered = opts?.undelivered ?? false;
   }
 }
 
@@ -69,6 +82,7 @@ export function createRemotePrerenderer(
       renderOptions?: RenderRouteOptions;
       [key: string]: any;
     },
+    retryPolicy: PrerenderRetryPolicy = 'any-failure',
   ): Promise<T> {
     validatePrerenderAttributes(type, attributes);
 
@@ -151,7 +165,11 @@ export function createRemotePrerenderer(
             message += `: ${text}`;
           }
           if (response.status === 503 || draining || serverError) {
-            throw new RetryablePrerenderError(message, response.status);
+            throw new RetryablePrerenderError(message, response.status, {
+              undelivered:
+                response.headers.get(PRERENDER_DISPATCH_HEADER) ===
+                PRERENDER_DISPATCH_NONE,
+            });
           }
           throw new Error(message);
         }
@@ -189,13 +207,35 @@ export function createRemotePrerenderer(
         // underlying error (ECONNREFUSED, ECONNRESET, etc.) in e.cause.
         // Check both e.code and e.cause.code to catch these.
         let code = e?.code ?? e?.cause?.code;
-        let retryable =
+        let transportFailure =
           e instanceof RetryablePrerenderError ||
           code === 'ECONNREFUSED' ||
           code === 'ETIMEDOUT' ||
           code === 'ECONNRESET' ||
           (e instanceof TypeError && e.message === 'fetch failed');
+        // A request that must not run twice is retried only when the failure
+        // proves no prerender server received it: the manager saying it never
+        // dispatched, or a connection that was never established. A timeout, a
+        // reset, or a 5xx from a server that may have run the request is a
+        // completed side effect whose response was lost, and repeating it
+        // would perform that side effect a second time.
+        let undelivered =
+          e instanceof RetryablePrerenderError
+            ? e.undelivered
+            : isUndeliveredRequestError(e);
+        let retryable =
+          retryPolicy === 'only-when-undelivered'
+            ? undelivered
+            : transportFailure;
         if (!retryable || attempts >= maxAttempts) {
+          if (transportFailure && !retryable && attempts < maxAttempts) {
+            log.warn(
+              `Prerender request to ${endpoint.href} failed and is not retryable ` +
+                `(requestId=${requestId}, affinity=${affinityTag}): the request may ` +
+                `already have been carried out, so a retry could repeat its side ` +
+                `effects: ${e.message}`,
+            );
+          }
           throw e;
         }
         let delayMs = Math.min(
@@ -264,6 +304,11 @@ export function createRemotePrerenderer(
         },
       );
     },
+    // Commands are not idempotent — they create cards, matrix rooms and
+    // outbound calls, and the queue declines to collapse two identical
+    // invocations — so this request is retried only on a failure that proves
+    // no prerender server ever received it. Every other prerender call is a
+    // pure read and keeps the full retry budget.
     async runCommand({ userId, auth, command, commandInput, priority }) {
       return await requestWithRetry<RunCommandResponse>(
         'run-command',
@@ -276,6 +321,7 @@ export function createRemotePrerenderer(
           commandInput,
           ...(priority !== undefined ? { priority } : {}),
         },
+        'only-when-undelivered',
       );
     },
     async prerenderScreenshot({

--- a/packages/realm-server/prerender/remote-prerenderer.ts
+++ b/packages/realm-server/prerender/remote-prerenderer.ts
@@ -22,6 +22,7 @@ import {
   resolvePrerenderManagerRequestTimeoutMs,
   retryPolicyForPath,
   sanitizePrerenderJobId,
+  type PrerenderEndpoint,
 } from './prerender-constants.ts';
 import { randomUUID } from 'crypto';
 
@@ -71,7 +72,7 @@ export function createRemotePrerenderer(
   const requestTimeoutMs = resolvePrerenderManagerRequestTimeoutMs();
 
   async function requestWithRetry<T>(
-    path: string,
+    path: PrerenderEndpoint,
     type: string,
     attributes: {
       affinityType: AffinityType;

--- a/packages/realm-server/prerender/remote-prerenderer.ts
+++ b/packages/realm-server/prerender/remote-prerenderer.ts
@@ -207,7 +207,7 @@ export function createRemotePrerenderer(
         // underlying error (ECONNREFUSED, ECONNRESET, etc.) in e.cause.
         // Check both e.code and e.cause.code to catch these.
         let code = e?.code ?? e?.cause?.code;
-        let transportFailure =
+        let retryableUnderAnyFailure =
           e instanceof RetryablePrerenderError ||
           code === 'ECONNREFUSED' ||
           code === 'ETIMEDOUT' ||
@@ -226,9 +226,13 @@ export function createRemotePrerenderer(
         let retryable =
           retryPolicy === 'only-when-undelivered'
             ? undelivered
-            : transportFailure;
+            : retryableUnderAnyFailure;
         if (!retryable || attempts >= maxAttempts) {
-          if (transportFailure && !retryable && attempts < maxAttempts) {
+          if (
+            retryableUnderAnyFailure &&
+            !retryable &&
+            attempts < maxAttempts
+          ) {
             log.warn(
               `Prerender request to ${endpoint.href} failed and is not retryable ` +
                 `(requestId=${requestId}, affinity=${affinityTag}): the request may ` +

--- a/packages/realm-server/prerender/remote-prerenderer.ts
+++ b/packages/realm-server/prerender/remote-prerenderer.ts
@@ -20,8 +20,8 @@ import {
   PRERENDER_SERVER_STATUS_DRAINING,
   PRERENDER_SERVER_STATUS_HEADER,
   resolvePrerenderManagerRequestTimeoutMs,
+  retryPolicyForPath,
   sanitizePrerenderJobId,
-  type PrerenderRetryPolicy,
 } from './prerender-constants.ts';
 import { randomUUID } from 'crypto';
 
@@ -82,9 +82,9 @@ export function createRemotePrerenderer(
       renderOptions?: RenderRouteOptions;
       [key: string]: any;
     },
-    retryPolicy: PrerenderRetryPolicy = 'any-failure',
   ): Promise<T> {
     validatePrerenderAttributes(type, attributes);
+    let retryPolicy = retryPolicyForPath(path);
 
     let endpoint = new URL(path, prerenderURL);
     // jobId is request metadata, not part of the validated body — strip
@@ -308,11 +308,6 @@ export function createRemotePrerenderer(
         },
       );
     },
-    // Commands are not idempotent — they create cards, matrix rooms and
-    // outbound calls, and the queue declines to collapse two identical
-    // invocations — so this request is retried only on a failure that proves
-    // no prerender server ever received it. Every other prerender call is a
-    // pure read and keeps the full retry budget.
     async runCommand({ userId, auth, command, commandInput, priority }) {
       return await requestWithRetry<RunCommandResponse>(
         'run-command',
@@ -325,7 +320,6 @@ export function createRemotePrerenderer(
           commandInput,
           ...(priority !== undefined ? { priority } : {}),
         },
-        'only-when-undelivered',
       );
     },
     async prerenderScreenshot({

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -18,6 +18,7 @@ import {
   PRERENDER_SERVER_STATUS_HEADER,
 } from '../prerender/prerender-constants.ts';
 import { toAffinityKey } from '../prerender/affinity.ts';
+import { createRemotePrerenderer } from '../prerender/remote-prerenderer.ts';
 import { Deferred } from '@cardstack/runtime-common';
 import { testCreatePrerenderAuth } from './helpers/index.ts';
 
@@ -2380,6 +2381,95 @@ module(basename(import.meta.filename), function () {
       assert.strictEqual(renders, 2, 'both servers were tried');
     });
 
+    test('does not fail over a command to a second server on a drain', async function (assert) {
+      // A prerender server reaches its `/run-command` handler while draining
+      // and can only report the drain from inside the race, by which time the
+      // command is running. So a drain is no more evidence than a 500 that the
+      // command did not run.
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlA },
+        },
+      });
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlB },
+        },
+      });
+
+      let runs = 0;
+      let drainAfterRunning = (ctxt: Koa.Context) => {
+        runs++;
+        ctxt.status = PRERENDER_SERVER_DRAINING_STATUS_CODE;
+        ctxt.set(
+          PRERENDER_SERVER_STATUS_HEADER,
+          PRERENDER_SERVER_STATUS_DRAINING,
+        );
+        ctxt.body = JSON.stringify({
+          errors: [
+            {
+              status: PRERENDER_SERVER_DRAINING_STATUS_CODE,
+              message: 'draining',
+            },
+          ],
+        });
+      };
+      mockPrerenderA?.setResponder(drainAfterRunning);
+      mockPrerenderB?.setResponder(drainAfterRunning);
+
+      let res = await request
+        .post('/run-command')
+        .send(makeCommandBody('https://realm.example/cmd', 'create-card'));
+
+      assert.strictEqual(
+        res.status,
+        PRERENDER_SERVER_DRAINING_STATUS_CODE,
+        'reports the drain to the caller',
+      );
+      assert.strictEqual(runs, 1, 'only one server received the command');
+      assert.strictEqual(
+        res.headers[PRERENDER_DISPATCH_HEADER],
+        PRERENDER_DISPATCH_DELIVERED,
+        'tells the caller a server may have run the command',
+      );
+    });
+
+    test('keeps the undispatched report across refused connections', async function (assert) {
+      // The upgrade to `delivered` is one-way, so a request that never reached
+      // any of several dead servers must still come back retryable.
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlA },
+        },
+      });
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlB },
+        },
+      });
+      await mockPrerenderA?.stop();
+      await mockPrerenderB?.stop();
+
+      let res = await request
+        .post('/run-command')
+        .send(makeCommandBody('https://realm.example/cmd', 'create-card'));
+
+      assert.strictEqual(res.status, 503, 'reports the failure to the caller');
+      assert.strictEqual(
+        res.headers[PRERENDER_DISPATCH_HEADER],
+        PRERENDER_DISPATCH_NONE,
+        'a command no server received stays retryable',
+      );
+    });
+
     test('reports whether a failed request reached a prerender server', async function (assert) {
       process.env.PRERENDER_SERVER_DISCOVERY_WAIT_MS = '0';
       let { app } = buildPrerenderManagerApp();
@@ -2410,6 +2500,113 @@ module(basename(import.meta.filename), function () {
         PRERENDER_DISPATCH_DELIVERED,
         'a proxied request is reported as delivered',
       );
+    });
+
+    // The manager's failover and the client's retry loop enforce different
+    // halves of the same guarantee. These wire the two together, since each
+    // half looks correct in isolation while the pair still repeats a command.
+    module('client and manager together', function (hooks) {
+      let managerServer: http.Server | undefined;
+      let managerRequests = 0;
+
+      hooks.beforeEach(function () {
+        process.env.PRERENDER_MANAGER_RETRY_ATTEMPTS = '2';
+        process.env.PRERENDER_MANAGER_RETRY_DELAY_MS = '1';
+        managerRequests = 0;
+      });
+      hooks.afterEach(async function () {
+        delete process.env.PRERENDER_MANAGER_RETRY_ATTEMPTS;
+        delete process.env.PRERENDER_MANAGER_RETRY_DELAY_MS;
+        if (managerServer) {
+          let server = managerServer;
+          managerServer = undefined;
+          await new Promise<void>((resolve) => server.close(() => resolve()));
+        }
+      });
+
+      // Serves the manager over a real port so the client reaches it the way
+      // it does in production, and counts what arrives so a client-side retry
+      // is visible even when the manager answers identically each time.
+      function listenManager(
+        app: ReturnType<typeof buildPrerenderManagerApp>['app'],
+      ) {
+        let handler = app.callback();
+        managerServer = createServer((req, res) => {
+          managerRequests++;
+          handler(req, res);
+        }).listen(0);
+        return `http://127.0.0.1:${(managerServer.address() as any).port}`;
+      }
+
+      test('runs a command once when every server fails after running it', async function (assert) {
+        let { app } = buildPrerenderManagerApp();
+        let request: SuperTest<Test> = supertest(app.callback());
+        await request.post('/prerender-servers').send({
+          data: {
+            type: 'prerender-server',
+            attributes: { capacity: 1, url: serverUrlA },
+          },
+        });
+        await request.post('/prerender-servers').send({
+          data: {
+            type: 'prerender-server',
+            attributes: { capacity: 1, url: serverUrlB },
+          },
+        });
+
+        let runs = 0;
+        let failAfterRunning = (ctxt: Koa.Context) => {
+          runs++;
+          ctxt.status = 500;
+          ctxt.body = JSON.stringify({
+            errors: [
+              { status: 500, message: 'Protocol error (Target closed)' },
+            ],
+          });
+        };
+        mockPrerenderA?.setResponder(failAfterRunning);
+        mockPrerenderB?.setResponder(failAfterRunning);
+
+        let prerenderer = createRemotePrerenderer(listenManager(app));
+        await assert.rejects(
+          prerenderer.runCommand({
+            userId: '@user:localhost',
+            auth: makeAuth('https://realm.example/cmd'),
+            command: 'create-card',
+            commandInput: null,
+          }),
+          /status 503/,
+          'the caller is told the command failed',
+        );
+
+        assert.strictEqual(runs, 1, 'the command ran exactly once');
+        assert.strictEqual(managerRequests, 1, 'the client did not retry');
+      });
+
+      test('retries a command the manager never dispatched', async function (assert) {
+        // No servers registered, so the manager turns the request away without
+        // dispatching and the client is free to try again.
+        process.env.PRERENDER_SERVER_DISCOVERY_WAIT_MS = '0';
+        let { app } = buildPrerenderManagerApp();
+
+        let prerenderer = createRemotePrerenderer(listenManager(app));
+        await assert.rejects(
+          prerenderer.runCommand({
+            userId: '@user:localhost',
+            auth: makeAuth('https://realm.example/cmd'),
+            command: 'create-card',
+            commandInput: null,
+          }),
+          /status 503/,
+          'the caller is told the command failed',
+        );
+
+        assert.strictEqual(
+          managerRequests,
+          2,
+          'the client spent its retry budget',
+        );
+      });
     });
 
     test('maintenance reset clears realm assignments', async function (assert) {

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -9,6 +9,9 @@ import type { RealmHttpServer as Server } from '../server.ts';
 import http, { createServer } from 'http';
 import { buildPrerenderManagerApp } from '../prerender/manager-app.ts';
 import {
+  PRERENDER_DISPATCH_DELIVERED,
+  PRERENDER_DISPATCH_HEADER,
+  PRERENDER_DISPATCH_NONE,
   PRERENDER_HOST_SHELL_HASH_HEADER,
   PRERENDER_SERVER_DRAINING_STATUS_CODE,
   PRERENDER_SERVER_STATUS_DRAINING,
@@ -2246,6 +2249,166 @@ module(basename(import.meta.filename), function () {
       assert.false(
         registry.servers.has(serverUrlA!),
         'unhealthy server pruned from registry',
+      );
+    });
+
+    // A command is not idempotent: it creates cards, matrix rooms and outbound
+    // calls. Handing it to a second server after the first may already have
+    // run it is a second execution the caller never asked for and cannot see.
+    test('does not fail over a command to a second server after a 500', async function (assert) {
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlA },
+        },
+      });
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlB },
+        },
+      });
+
+      // Both servers answer the same way, so the count is the number of
+      // servers that received the command regardless of which is chosen first.
+      let runs = 0;
+      let failAfterRunning = (ctxt: Koa.Context) => {
+        runs++;
+        ctxt.status = 500;
+        ctxt.body = JSON.stringify({
+          errors: [{ status: 500, message: 'Protocol error (Target closed)' }],
+        });
+      };
+      mockPrerenderA?.setResponder(failAfterRunning);
+      mockPrerenderB?.setResponder(failAfterRunning);
+
+      let res = await request
+        .post('/run-command')
+        .send(makeCommandBody('https://realm.example/cmd', 'create-card'));
+
+      assert.strictEqual(res.status, 503, 'reports the failure to the caller');
+      assert.strictEqual(runs, 1, 'only one server received the command');
+      assert.strictEqual(
+        res.headers[PRERENDER_DISPATCH_HEADER],
+        PRERENDER_DISPATCH_DELIVERED,
+        'tells the caller a server may have run the command',
+      );
+    });
+
+    test('fails a command over when the first server is unreachable', async function (assert) {
+      // A refused connection is the one failure that proves the command never
+      // reached the server, so the useful part of the failover survives.
+      let { app, registry } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlA },
+        },
+      });
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlB },
+        },
+      });
+      await mockPrerenderA?.stop();
+
+      let runs = 0;
+      mockPrerenderB?.setResponder((ctxt) => {
+        runs++;
+        ctxt.status = 201;
+        ctxt.set('Content-Type', 'application/vnd.api+json');
+        ctxt.body = JSON.stringify({
+          data: { attributes: { status: 'ready' } },
+        });
+      });
+
+      let res = await request
+        .post('/run-command')
+        .send(makeCommandBody('https://realm.example/cmd', 'create-card'));
+
+      assert.strictEqual(res.status, 201, 'the command runs');
+      assert.strictEqual(runs, 1, 'the reachable server ran it once');
+      assert.false(
+        registry.servers.has(serverUrlA!),
+        'unreachable server pruned from registry',
+      );
+    });
+
+    test('renders still fail over to a second server after a 500', async function (assert) {
+      // Confining the rule to commands: a render is a pure read, so a second
+      // server repeating it costs time and nothing else.
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlA },
+        },
+      });
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlB },
+        },
+      });
+
+      let renders = 0;
+      let failAfterRendering = (ctxt: Koa.Context) => {
+        renders++;
+        ctxt.status = 500;
+        ctxt.body = JSON.stringify({
+          errors: [{ status: 500, message: 'Protocol error (Target closed)' }],
+        });
+      };
+      mockPrerenderA?.setResponder(failAfterRendering);
+      mockPrerenderB?.setResponder(failAfterRendering);
+
+      let res = await request
+        .post('/prerender-visit')
+        .send(
+          makeBody(
+            'https://realm.example/render-failover',
+            'https://realm.example/render-failover/1',
+          ),
+        );
+
+      assert.strictEqual(res.status, 503, 'reports the failure to the caller');
+      assert.strictEqual(renders, 2, 'both servers were tried');
+    });
+
+    test('reports whether a failed request reached a prerender server', async function (assert) {
+      process.env.PRERENDER_SERVER_DISCOVERY_WAIT_MS = '0';
+      let { app } = buildPrerenderManagerApp();
+      let request: SuperTest<Test> = supertest(app.callback());
+
+      let undispatched = await request
+        .post('/run-command')
+        .send(makeCommandBody('https://realm.example/cmd', 'create-card'));
+      assert.strictEqual(undispatched.status, 503, '503 when no servers');
+      assert.strictEqual(
+        undispatched.headers[PRERENDER_DISPATCH_HEADER],
+        PRERENDER_DISPATCH_NONE,
+        'a request that never left the manager is safe to retry',
+      );
+
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlA },
+        },
+      });
+      let dispatched = await request
+        .post('/run-command')
+        .send(makeCommandBody('https://realm.example/cmd', 'create-card'));
+      assert.strictEqual(dispatched.status, 201, 'the command runs');
+      assert.strictEqual(
+        dispatched.headers[PRERENDER_DISPATCH_HEADER],
+        PRERENDER_DISPATCH_DELIVERED,
+        'a proxied request is reported as delivered',
       );
     });
 

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -2120,6 +2120,56 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('lets a dispatched command finish when draining begins mid-flight', async function (assert) {
+      // The counterpart of the render case below. A render aborted at drain is
+      // deferred — some layer retries it. A dispatched command is not: neither
+      // layer will retry it, so abandoning it cancels work that may already
+      // have created cards and hands the caller a failure nobody picks up.
+      let draining = false;
+      let { app } = buildPrerenderManagerApp({ isDraining: () => draining });
+      let request: SuperTest<Test> = supertest(app.callback());
+      // Handshake rather than sleeps: the command must provably be running on
+      // the server before draining starts, or the request is turned away
+      // before dispatch and the test proves nothing about the in-flight case.
+      let started = new Deferred<void>();
+      let release = new Deferred<void>();
+      let completed = 0;
+      mockPrerenderA?.setResponder(async (ctxt) => {
+        started.fulfill();
+        await release.promise;
+        completed++;
+        ctxt.status = 201;
+        ctxt.set('Content-Type', 'application/vnd.api+json');
+        ctxt.body = JSON.stringify({
+          data: { attributes: { status: 'ready' } },
+        });
+      });
+
+      await request.post('/prerender-servers').send({
+        data: {
+          type: 'prerender-server',
+          attributes: { capacity: 1, url: serverUrlA },
+        },
+      });
+
+      // `.then` is what dispatches a supertest request.
+      let resPromise = request
+        .post('/run-command')
+        .send(makeCommandBody('https://realm.example/cmd', 'create-card'))
+        .then((r) => r);
+
+      await started.promise;
+      draining = true;
+      // Long enough that a drain poll, were it armed, would have aborted this
+      // several times over at its <=100ms interval.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      release.fulfill();
+
+      let res = await resPromise;
+      assert.strictEqual(res.status, 201, 'the caller gets the result');
+      assert.strictEqual(completed, 1, 'the command ran to completion');
+    });
+
     test('returns draining when manager starts draining during an in-flight proxy', async function (assert) {
       let draining = false;
       let { app } = buildPrerenderManagerApp({ isDraining: () => draining });

--- a/packages/realm-server/tests/remote-prerenderer-test.ts
+++ b/packages/realm-server/tests/remote-prerenderer-test.ts
@@ -4,6 +4,7 @@ import { basename } from 'path';
 import { createServer, type ServerResponse } from 'http';
 import { createRemotePrerenderer } from '../prerender/remote-prerenderer.ts';
 import {
+  PRERENDER_DISPATCH_DELIVERED,
   PRERENDER_DISPATCH_HEADER,
   PRERENDER_DISPATCH_NONE,
   PRERENDER_SERVER_DRAINING_STATUS_CODE,
@@ -581,8 +582,9 @@ module(basename(import.meta.filename), function (hooks) {
     }
 
     test('does not retry a 5xx that may be a lost response', async function (assert) {
-      // The manager answers 502 for a request whose command already ran to
-      // completion — the response is what was lost, not the work.
+      // A proxy in front of the manager answers 502 for a request whose
+      // command already ran to completion — the response is what was lost,
+      // not the work.
       let manager = makeCommandServer((res) => {
         res.statusCode = 502;
         res.end('Upstream error');
@@ -767,6 +769,28 @@ module(basename(import.meta.filename), function (hooks) {
         assert.strictEqual(attempts, 1, 'made a single attempt');
       } finally {
         (globalThis as any).fetch = originalFetch;
+      }
+    });
+
+    test('does not retry a 5xx that reports itself as delivered', async function (assert) {
+      // The header is what the client reads; a failure naming itself
+      // `delivered` is refused as firmly as one that says nothing.
+      let manager = makeCommandServer((res) => {
+        res.statusCode = 500;
+        res.setHeader(PRERENDER_DISPATCH_HEADER, PRERENDER_DISPATCH_DELIVERED);
+        res.end('Upstream error');
+      });
+
+      try {
+        let prerenderer = createRemotePrerenderer(manager.url());
+        await assert.rejects(
+          prerenderer.runCommand(commandArgs),
+          /status 500/,
+          'surfaces the failure to the caller',
+        );
+        assert.strictEqual(manager.requests(), 1, 'the command ran once');
+      } finally {
+        await manager.stop();
       }
     });
 

--- a/packages/realm-server/tests/remote-prerenderer-test.ts
+++ b/packages/realm-server/tests/remote-prerenderer-test.ts
@@ -1,9 +1,11 @@
 import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
-import { createServer } from 'http';
+import { createServer, type ServerResponse } from 'http';
 import { createRemotePrerenderer } from '../prerender/remote-prerenderer.ts';
 import {
+  PRERENDER_DISPATCH_HEADER,
+  PRERENDER_DISPATCH_NONE,
   PRERENDER_SERVER_DRAINING_STATUS_CODE,
   PRERENDER_SERVER_STATUS_DRAINING,
   PRERENDER_SERVER_STATUS_HEADER,
@@ -525,6 +527,210 @@ module(basename(import.meta.filename), function (hooks) {
         assert.ok(attempts >= 2, 'retried after 500');
       } finally {
         await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+  });
+
+  // A command is not idempotent: it creates cards, matrix rooms and outbound
+  // calls, and nothing downstream collapses two identical invocations. So a
+  // retry is only ever safe on a failure that proves no prerender server
+  // received the request — a manager that says it never dispatched, or a
+  // connection that was never established. Every other failure leaves open
+  // that the command ran and only its response was lost.
+  module('run-command retries', function (hooks) {
+    hooks.beforeEach(function () {
+      process.env.PRERENDER_MANAGER_RETRY_ATTEMPTS = '3';
+      process.env.PRERENDER_MANAGER_RETRY_DELAY_MS = '1';
+    });
+
+    let commandArgs = {
+      userId: '@user:localhost',
+      auth: '{}',
+      command: 'create-card',
+      commandInput: null,
+    } as const;
+
+    // Stands in for the manager: `runs` counts the invocations that reached a
+    // prerender server, which is the number the command's side effects would
+    // be repeated by.
+    function makeCommandServer(
+      respond: (res: ServerResponse, runs: number) => void | 'ran',
+    ) {
+      let runs = 0;
+      let server = createServer((_req, res) => {
+        runs++;
+        respond(res, runs);
+      }).listen(0);
+      return {
+        url: () => `http://127.0.0.1:${(server.address() as any).port}`,
+        runs: () => runs,
+        stop: () =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      };
+    }
+
+    function succeed(res: ServerResponse) {
+      res.statusCode = 201;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          data: { attributes: { status: 'ready', cardResultString: null } },
+        }),
+      );
+    }
+
+    test('does not retry a 5xx that may be a lost response', async function (assert) {
+      // The manager answers 502 for a request whose command already ran to
+      // completion — the response is what was lost, not the work.
+      let manager = makeCommandServer((res) => {
+        res.statusCode = 502;
+        res.end('Upstream error');
+      });
+
+      try {
+        let prerenderer = createRemotePrerenderer(manager.url());
+        await assert.rejects(
+          prerenderer.runCommand(commandArgs),
+          /status 502/,
+          'surfaces the failure to the caller',
+        );
+        assert.strictEqual(manager.runs(), 1, 'the command ran once');
+      } finally {
+        await manager.stop();
+      }
+    });
+
+    test('does not retry a 503 from a manager that may have dispatched', async function (assert) {
+      // 503 with no dispatch header: the manager gives no assurance that the
+      // request stopped short of a prerender server.
+      let manager = makeCommandServer((res) => {
+        res.statusCode = 503;
+        res.end('No servers');
+      });
+
+      try {
+        let prerenderer = createRemotePrerenderer(manager.url());
+        await assert.rejects(
+          prerenderer.runCommand(commandArgs),
+          /status 503/,
+          'surfaces the failure to the caller',
+        );
+        assert.strictEqual(manager.runs(), 1, 'the command ran at most once');
+      } finally {
+        await manager.stop();
+      }
+    });
+
+    test('retries a failure the manager reports as never dispatched', async function (assert) {
+      let manager = makeCommandServer((res, runs) => {
+        if (runs === 1) {
+          res.statusCode = 503;
+          res.setHeader(PRERENDER_DISPATCH_HEADER, PRERENDER_DISPATCH_NONE);
+          res.end('No servers');
+          return;
+        }
+        succeed(res);
+      });
+
+      try {
+        let prerenderer = createRemotePrerenderer(manager.url());
+        let result = await prerenderer.runCommand(commandArgs);
+        assert.strictEqual(result.status, 'ready', 'the caller gets a result');
+        assert.strictEqual(
+          manager.runs(),
+          2,
+          'retried the request the manager never handed to a server',
+        );
+      } finally {
+        await manager.stop();
+      }
+    });
+
+    test('retries when the connection was never established', async function (assert) {
+      let manager = makeCommandServer((res) => succeed(res));
+      let originalFetch = globalThis.fetch;
+      let refusedOnce = false;
+
+      try {
+        (globalThis as any).fetch = (...args: Parameters<typeof fetch>) => {
+          if (!refusedOnce) {
+            refusedOnce = true;
+            let err: any = new TypeError('fetch failed');
+            err.cause = Object.assign(new Error('connect ECONNREFUSED'), {
+              code: 'ECONNREFUSED',
+            });
+            return Promise.reject(err);
+          }
+          return originalFetch(...args);
+        };
+
+        let prerenderer = createRemotePrerenderer(manager.url());
+        let result = await prerenderer.runCommand(commandArgs);
+
+        assert.strictEqual(result.status, 'ready', 'the caller gets a result');
+        assert.true(refusedOnce, 'the first attempt was refused');
+        assert.strictEqual(manager.runs(), 1, 'the command ran once');
+      } finally {
+        (globalThis as any).fetch = originalFetch;
+        await manager.stop();
+      }
+    });
+
+    test('does not retry a connection reset', async function (assert) {
+      // A reset can land after the server read the request and started the
+      // command, so it proves nothing about whether the command ran.
+      let originalFetch = globalThis.fetch;
+      let attempts = 0;
+
+      try {
+        (globalThis as any).fetch = () => {
+          attempts++;
+          let err: any = new TypeError('fetch failed');
+          err.cause = Object.assign(new Error('socket hang up'), {
+            code: 'ECONNRESET',
+          });
+          return Promise.reject(err);
+        };
+
+        let prerenderer = createRemotePrerenderer('http://127.0.0.1:1');
+        await assert.rejects(
+          prerenderer.runCommand(commandArgs),
+          /fetch failed/,
+          'surfaces the failure to the caller',
+        );
+        assert.strictEqual(attempts, 1, 'made a single attempt');
+      } finally {
+        (globalThis as any).fetch = originalFetch;
+      }
+    });
+
+    test('renders still retry a 5xx', async function (assert) {
+      // The narrow policy is scoped to commands: a render is a pure read, so
+      // repeating it costs time and nothing else.
+      let manager = makeCommandServer((res, runs) => {
+        if (runs === 1) {
+          res.statusCode = 502;
+          res.end('Upstream error');
+          return;
+        }
+        res.statusCode = 201;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ data: { attributes: { ok: true } } }));
+      });
+
+      try {
+        let prerenderer = createRemotePrerenderer(manager.url());
+        let result = await prerenderer.prerenderVisit({
+          affinityType: 'realm',
+          affinityValue: 'realm',
+          realm: 'realm',
+          url: 'https://example.com/card',
+          auth: '{}',
+        });
+        assert.true((result as any).ok, 'succeeds on the retry');
+        assert.strictEqual(manager.runs(), 2, 'retried the render');
+      } finally {
+        await manager.stop();
       }
     });
   });

--- a/packages/realm-server/tests/remote-prerenderer-test.ts
+++ b/packages/realm-server/tests/remote-prerenderer-test.ts
@@ -550,20 +550,21 @@ module(basename(import.meta.filename), function (hooks) {
       commandInput: null,
     } as const;
 
-    // Stands in for the manager: `runs` counts the invocations that reached a
-    // prerender server, which is the number the command's side effects would
-    // be repeated by.
+    // Stands in for the manager: `requests` counts what it received. What a
+    // request stands for is the responder's to say — a 5xx answered after the
+    // command ran to completion, or a rejection that never reached a prerender
+    // server — so each assertion reads the count against its own responder.
     function makeCommandServer(
-      respond: (res: ServerResponse, runs: number) => void | 'ran',
+      respond: (res: ServerResponse, requestCount: number) => void,
     ) {
-      let runs = 0;
+      let requests = 0;
       let server = createServer((_req, res) => {
-        runs++;
-        respond(res, runs);
+        requests++;
+        respond(res, requests);
       }).listen(0);
       return {
         url: () => `http://127.0.0.1:${(server.address() as any).port}`,
-        runs: () => runs,
+        requests: () => requests,
         stop: () =>
           new Promise<void>((resolve) => server.close(() => resolve())),
       };
@@ -594,7 +595,7 @@ module(basename(import.meta.filename), function (hooks) {
           /status 502/,
           'surfaces the failure to the caller',
         );
-        assert.strictEqual(manager.runs(), 1, 'the command ran once');
+        assert.strictEqual(manager.requests(), 1, 'the command ran once');
       } finally {
         await manager.stop();
       }
@@ -615,7 +616,11 @@ module(basename(import.meta.filename), function (hooks) {
           /status 503/,
           'surfaces the failure to the caller',
         );
-        assert.strictEqual(manager.runs(), 1, 'the command ran at most once');
+        assert.strictEqual(
+          manager.requests(),
+          1,
+          'the command ran at most once',
+        );
       } finally {
         await manager.stop();
       }
@@ -637,7 +642,7 @@ module(basename(import.meta.filename), function (hooks) {
         let result = await prerenderer.runCommand(commandArgs);
         assert.strictEqual(result.status, 'ready', 'the caller gets a result');
         assert.strictEqual(
-          manager.runs(),
+          manager.requests(),
           2,
           'retried the request the manager never handed to a server',
         );
@@ -669,7 +674,7 @@ module(basename(import.meta.filename), function (hooks) {
 
         assert.strictEqual(result.status, 'ready', 'the caller gets a result');
         assert.true(refusedOnce, 'the first attempt was refused');
-        assert.strictEqual(manager.runs(), 1, 'the command ran once');
+        assert.strictEqual(manager.requests(), 1, 'the command ran once');
       } finally {
         (globalThis as any).fetch = originalFetch;
         await manager.stop();
@@ -701,7 +706,7 @@ module(basename(import.meta.filename), function (hooks) {
         let result = await prerenderer.runCommand(commandArgs);
 
         assert.strictEqual(result.status, 'ready', 'the caller gets a result');
-        assert.strictEqual(manager.runs(), 1, 'the command ran once');
+        assert.strictEqual(manager.requests(), 1, 'the command ran once');
       } finally {
         (globalThis as any).fetch = originalFetch;
         await manager.stop();
@@ -789,7 +794,7 @@ module(basename(import.meta.filename), function (hooks) {
           auth: '{}',
         });
         assert.true((result as any).ok, 'succeeds on the retry');
-        assert.strictEqual(manager.runs(), 2, 'retried the render');
+        assert.strictEqual(manager.requests(), 2, 'retried the render');
       } finally {
         await manager.stop();
       }

--- a/packages/realm-server/tests/remote-prerenderer-test.ts
+++ b/packages/realm-server/tests/remote-prerenderer-test.ts
@@ -676,6 +676,67 @@ module(basename(import.meta.filename), function (hooks) {
       }
     });
 
+    test('retries a connect-phase timeout', async function (assert) {
+      // undici raises this only from the timer it clears once the socket
+      // connects, so it cannot describe a request that was already written.
+      let manager = makeCommandServer((res) => succeed(res));
+      let originalFetch = globalThis.fetch;
+      let timedOutOnce = false;
+
+      try {
+        (globalThis as any).fetch = (...args: Parameters<typeof fetch>) => {
+          if (!timedOutOnce) {
+            timedOutOnce = true;
+            let err: any = new TypeError('fetch failed');
+            err.cause = Object.assign(new Error('Connect Timeout Error'), {
+              name: 'ConnectTimeoutError',
+              code: 'UND_ERR_CONNECT_TIMEOUT',
+            });
+            return Promise.reject(err);
+          }
+          return originalFetch(...args);
+        };
+
+        let prerenderer = createRemotePrerenderer(manager.url());
+        let result = await prerenderer.runCommand(commandArgs);
+
+        assert.strictEqual(result.status, 'ready', 'the caller gets a result');
+        assert.strictEqual(manager.runs(), 1, 'the command ran once');
+      } finally {
+        (globalThis as any).fetch = originalFetch;
+        await manager.stop();
+      }
+    });
+
+    test('does not retry a routing failure', async function (assert) {
+      // A route can die while the request is in flight, and undici forwards
+      // the socket error raw, so the code alone cannot tell that case from a
+      // `connect` that never left the host.
+      let originalFetch = globalThis.fetch;
+      let attempts = 0;
+
+      try {
+        (globalThis as any).fetch = () => {
+          attempts++;
+          let err: any = new TypeError('fetch failed');
+          err.cause = Object.assign(new Error('connect EHOSTUNREACH'), {
+            code: 'EHOSTUNREACH',
+          });
+          return Promise.reject(err);
+        };
+
+        let prerenderer = createRemotePrerenderer('http://127.0.0.1:1');
+        await assert.rejects(
+          prerenderer.runCommand(commandArgs),
+          /fetch failed/,
+          'surfaces the failure to the caller',
+        );
+        assert.strictEqual(attempts, 1, 'made a single attempt');
+      } finally {
+        (globalThis as any).fetch = originalFetch;
+      }
+    });
+
     test('does not retry a connection reset', async function (assert) {
       // A reset can land after the server read the request and started the
       // command, so it proves nothing about whether the command ran.


### PR DESCRIPTION
## What this changes

Prerender calls are retried at two layers — `requestWithRetry` in
`remote-prerenderer.ts` retries the whole request against the manager, and the
manager's proxy fails a request over to a second prerender server. Both treated
`run-command` like a render.

A command is not idempotent. It creates cards, matrix rooms and outbound calls,
and the queue deliberately declines to collapse two identical invocations
(`dedupeKey` is opt-in in `runtime-common/tasks/run-command.ts`). The
lost-response window is real: the manager applies its own proxy abort and can
answer for a request whose command already ran to completion. Retrying then runs
the command a second time while the caller sees a single invocation, so the
duplicate card or room is invisible until someone looks at the realm — a command
that reports the id it created reports only the last one.

Both layers now separate a failure that landed **before any prerender server
received the request** from one that may have lost the response to work already
done, and retry a command only in the first case.

### The signal

The manager stamps `x-boxel-prerender-dispatch` on every response it produces
itself: `none` is its guarantee that no prerender server saw the request,
`delivered` (and an absent header, which reads the same way) means one may have
received it and acted on it. The header starts at `none` and is upgraded, once
and one-way, the moment an upstream fetch could have been read by a server.

That distinction did not exist on the wire before: a `503 No servers` from an
empty registry and a `503` after an upstream failure were byte-identical, so a
caller could not tell "never dispatched" from "may have run".

`retryPolicyForPath` in `prerender-constants.ts` is the single source for which
endpoints are non-idempotent. Both layers read it, because they enforce
different halves of one guarantee — an endpoint given one policy on one side
and another on the other would keep retrying through the remaining half in
silence. The map is exhaustive over a `PrerenderEndpoint` union that both
layers take as their path parameter, so an endpoint that has not declared a
policy does not compile.

### What each layer does with it

- **Manager** (`manager-app.ts`) — `/run-command` stops its cross-server
  failover at the first target that may have received the request. Only an
  error code confined to connection setup rules a target out: a response of any
  status leaves the server free to have read the request and run it, and so
  does an abort, which carries no code at all. A drain that begins mid-request
  is therefore answered *before* the fetch goes out, where the manager can still
  report truthfully that nothing was dispatched — and once a command is
  dispatched, the drain poll no longer aborts it, since no layer would retry
  that work and cancelling it leaves the side effects half-done.
- **Client** (`remote-prerenderer.ts`) — `runCommand` retries only on the
  `none` header or on a connection that was never established. A timeout, a
  reset, or a 5xx from a server that may have run the command ends the call,
  with a log line naming the request it declined to retry. Every other
  prerender call is a pure read and keeps the full retry budget.

### Which network errors count as undelivered

Membership turns on the phase undici can raise an error in, not on how it reads:

- `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN` and `UND_ERR_CONNECT_TIMEOUT` are
  confined to connection setup. The last one carries the distinction itself:
  undici raises it only from the timer it clears on `connect`/`secureConnect`,
  before any request bytes are written.
- Routing codes (`EHOSTUNREACH`, `ENETUNREACH`) are deliberately out.
  `onHttpSocketError` is attached to the *established* socket and forwards the
  system error raw, so a route that dies with the request in flight arrives
  under the same code as a `connect` that never left the host.

## What this does not fix

**The queue can still re-deliver the job.** `run-command` jobs are subject to
the reservation cap in `pg-queue.ts`, which counts only reservations closed
`completed` or still open. A worker SIGKILLed mid-command has its reservation
finalized `interrupted`, which is excluded by design so a transient crash gets
its retry — so a deploy that kills a worker mid-command re-delivers the job and
runs the command again, entirely above the two layers this PR hardens. That is
pre-existing and orthogonal to the transport bug, but it means this PR narrows
the duplicate window rather than closing it; the queue path needs its own
change.

## Topology notes

- Deploy order already holds: `deploy-release.yml` puts both `deploy-worker`
  and `deploy-realm-server` downstream of `deploy-prerender-manager`, so the
  manager is always upgraded first. That matters here because an older manager
  stamps no header, and an absent header reads as `delivered` — a new client
  against an old manager could not retry that manager's `503 No servers`.
- The integration harness points the realm-server straight at a
  prerender-server with no manager in between (`realm-test-harness`,
  `packages/matrix/support`). No header is stamped there, so `run-command` has
  no retries in that topology. That is the correct reading — any response from
  the server that runs the command means it was delivered — but it is a
  behavior change for CI. Dev, staging and production all go through the
  manager.

## Scope

`prerenderVisit`, `prerenderModule` and `prerenderScreenshot` are unchanged:
repeating a pure read costs time and nothing else.

## Test plan

`packages/realm-server/tests/remote-prerenderer-test.ts` — a stub manager whose
`requests` counter is read against each test's own responder, since what a
request stands for is the responder's to decide:

- a 5xx answered after the command ran, with the header absent or an explicit
  `delivered` → the caller gets the failure, the command ran once
- a 503 carrying `x-boxel-prerender-dispatch: none` → retried, the caller gets a
  result
- `ECONNREFUSED` on attempt 1, success on attempt 2 → the command ran once and
  the caller got the result
- a connect-phase timeout → retried, the command ran once
- `ECONNRESET`, and a routing failure → a single attempt each
- a render still retries a 5xx

`packages/realm-server/tests/prerender-manager-test.ts`:

- two servers, both failing after running the command — with a 500, and with a
  drain, which a prerender server can only report from inside the race → exactly
  one server received it, response carries `delivered`
- several refused connections → 503 that still reports `none`, pinning the
  one-way upgrade
- first server unreachable → the command fails over and runs once on the second
- a drain beginning while a command is executing → the command finishes and the
  caller gets its result, pinned with a handshake rather than sleeps so the
  command is provably in flight before draining starts
- a render still fails over after a 500, and is still aborted by a mid-flight
  drain
- client and manager wired together: every server failing after running the
  command yields exactly one execution and no client retry, while a manager
  with nothing to dispatch to still spends the client's retry budget

Reverting any of the three policy expressions fails the tests that pin it. Both
files pass in full (89 tests), along with lint, prettier and types for the
touched package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpzgLn8JAvscDXLEdNWtM5