### PR TITLE
Let a newer card document refresh a resolved query-backed field

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -536,6 +536,12 @@ export interface StoreSearchResource<T extends CardDef | FileDef = CardDef> {
   // carries. Optional: a store whose resources hold no state worth superseding
   // implements no supersession.
   reseed?(seed: StoreSearchSeed<T>): void;
+  // The identity of the seeded result set the resource holds, and `undefined`
+  // once a search has re-derived that set for itself. Read it to decide whether
+  // a seed is worth handing over: a remembered "last seed applied" would go on
+  // claiming a set the resource has since replaced, and would then skip a
+  // document restoring the earlier one.
+  readonly appliedSeedIdentity?: string;
 }
 
 // A result set a producer already resolved, handed to a search resource in
@@ -543,6 +549,13 @@ export interface StoreSearchResource<T extends CardDef | FileDef = CardDef> {
 // seeds with file-meta rows rather than being narrowed to `CardDef`.
 export type StoreSearchSeed<T extends CardDef | FileDef = CardDef> = {
   cards: T[];
+  // What this result set is, as against any other the same query could
+  // produce: two seeds sharing an identity assert the same thing, so a
+  // resource already holding one ignores the other. It has to cover
+  // everything the seed asserts and not just its rows — a page-clamped
+  // field whose match count moved holds the same row and a different
+  // answer.
+  identity?: string;
   searchURL?: string;
   realms?: string[];
   queryErrors?: Array<{

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -556,6 +556,13 @@ export type StoreSearchSeed<T extends CardDef | FileDef = CardDef> = {
   // field whose match count moved holds the same row and a different
   // answer.
   identity?: string;
+  // The index generation this set was resolved at. Separate from the identity
+  // and doing a different job: the identity says whether two sets differ, this
+  // says which of them is newer. Keeping the generation out of the identity is
+  // deliberate — a realm generation moves on every write anywhere in the realm,
+  // so folding it in would make every set look different from every other and
+  // re-apply answers that had not changed.
+  generation?: number;
   searchURL?: string;
   realms?: string[];
   queryErrors?: Array<{

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -532,37 +532,46 @@ export interface StoreSearchResource<T extends CardDef | FileDef = CardDef> {
   // the server's own result set rather than the reconciled one, so a locally
   // edited or created card can't be mistaken for a short page.
   readonly isPartial: boolean;
+  // Hand a running resource the result set a document fetched since it started
+  // carries. Optional: a store whose resources hold no state worth superseding
+  // implements no supersession.
+  reseed?(seed: StoreSearchSeed<T>): void;
 }
+
+// A result set a producer already resolved, handed to a search resource in
+// place of running the query. Generic in the row type so a `FileDef` search
+// seeds with file-meta rows rather than being narrowed to `CardDef`.
+export type StoreSearchSeed<T extends CardDef | FileDef = CardDef> = {
+  cards: T[];
+  searchURL?: string;
+  realms?: string[];
+  queryErrors?: Array<{
+    realm: string;
+    type: string;
+    message: string;
+    status?: number;
+  }>;
+  // IDs the parent doc named in `relationships.{field}.data`. Used
+  // by the SearchResource when `cards` is empty and the parent
+  // skipped query-backed expansion — the resource loads each ID by
+  // URL instead of running a live re-query.
+  cardURLs?: string[];
+  // The result meta the seed was resolved under, chiefly `page.total` —
+  // the query's match count, which exceeds `cards.length` when the page
+  // ceiling clamped the expansion. Absent it, the resource takes the
+  // record count for the total and a truncated seed reads as complete.
+  meta?: QueryResultsMeta;
+  // The seed's match count is not knowable and must not be inferred from its
+  // rows — the producer resolved the field but deliberately reported no
+  // total, as a query-backed field does when one of its realms failed.
+  totalUnknown?: boolean;
+};
 
 export type GetSearchResourceFuncOpts = {
   isLive?: boolean;
   doWhileRefreshing?: (() => void) | undefined;
   dependencyTracking?: RuntimeDependencyTrackingContext;
-  seed?: {
-    cards: CardDef[];
-    searchURL?: string;
-    realms?: string[];
-    queryErrors?: Array<{
-      realm: string;
-      type: string;
-      message: string;
-      status?: number;
-    }>;
-    // IDs the parent doc named in `relationships.{field}.data`. Used
-    // by the SearchResource when `cards` is empty and the parent
-    // skipped query-backed expansion — the resource loads each ID by
-    // URL instead of running a live re-query.
-    cardURLs?: string[];
-    // The result meta the seed was resolved under, chiefly `page.total` —
-    // the query's match count, which exceeds `cards.length` when the page
-    // ceiling clamped the expansion. Absent it, the resource takes the
-    // record count for the total and a truncated seed reads as complete.
-    meta?: QueryResultsMeta;
-    // The seed's match count is not knowable and must not be inferred from its
-    // rows — the producer resolved the field but deliberately reported no
-    // total, as a query-backed field does when one of its realms failed.
-    totalUnknown?: boolean;
-  };
+  seed?: StoreSearchSeed;
 };
 export type GetSearchResourceFunc<T extends CardDef | FileDef = CardDef> = (
   parent: object,

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -580,17 +580,17 @@ export type StoreSearchSeed<T extends CardDef | FileDef = CardDef> = {
   totalUnknown?: boolean;
 };
 
-export type GetSearchResourceFuncOpts = {
+export type GetSearchResourceFuncOpts<T extends CardDef | FileDef = CardDef> = {
   isLive?: boolean;
   doWhileRefreshing?: (() => void) | undefined;
   dependencyTracking?: RuntimeDependencyTrackingContext;
-  seed?: StoreSearchSeed;
+  seed?: StoreSearchSeed<T>;
 };
 export type GetSearchResourceFunc<T extends CardDef | FileDef = CardDef> = (
   parent: object,
   getQuery: () => Query | undefined,
   getRealms?: () => string[] | undefined,
-  opts?: GetSearchResourceFuncOpts,
+  opts?: GetSearchResourceFuncOpts<T>,
 ) => StoreSearchResource<T>;
 
 export interface CardStore {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -556,13 +556,18 @@ export type StoreSearchSeed<T extends CardDef | FileDef = CardDef> = {
   // field whose match count moved holds the same row and a different
   // answer.
   identity?: string;
-  // The index generation this set was resolved at. Separate from the identity
-  // and doing a different job: the identity says whether two sets differ, this
-  // says which of them is newer. Keeping the generation out of the identity is
-  // deliberate — a realm generation moves on every write anywhere in the realm,
-  // so folding it in would make every set look different from every other and
-  // re-apply answers that had not changed.
+  // The index generation this set was resolved at, and the realm whose counter
+  // that generation belongs to. Separate from the identity and doing a
+  // different job: the identity says whether two sets differ, these say which
+  // of them is newer. A generation counts writes within one realm, so it orders
+  // nothing without the realm that issued it.
+  //
+  // Keeping the generation out of the identity is deliberate — a realm
+  // generation moves on every write anywhere in the realm, so folding it in
+  // would make every set look different from every other and re-apply answers
+  // that had not changed.
   generation?: number;
+  realm?: string;
   searchURL?: string;
   realms?: string[];
   queryErrors?: Array<{

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -62,13 +62,22 @@ interface QueryFieldState {
     message: string;
     status?: number;
   }>;
-  // Identity of the result set the owner's most recent document carried, and of
-  // the one the search resource holds. Only an indexer-resolved umbrella gets
-  // an identity — a raw source document carries no authoritative answer, so it
-  // can never supersede one — and the pair is what lets a document fetched
-  // after the resource started hand it a fresher result set.
+  // Identity of the result set the owner's most recent document carried. Only
+  // an indexer-resolved umbrella gets one — a raw source document carries no
+  // authoritative answer, so it can never supersede one — and comparing it
+  // against the identity the search resource holds is what lets a document
+  // fetched after the resource started hand it a fresher result set.
   seedIdentity?: string;
-  appliedSeedIdentity?: string;
+  // A document has been captured that no resource has been offered yet. Set by
+  // every capture and cleared the first time a read acts on it, so a running
+  // resource is offered a result set once per document fetched for the owner.
+  //
+  // This is what keeps the offer tied to a document arriving rather than to a
+  // field being read: a search re-derives the set for itself and reports no
+  // seeded identity afterwards, and without this gate the next read would hand
+  // the last document's answer straight back over the fresher one the search
+  // just produced.
+  seedHandoverPending?: boolean;
   searchResource?: StoreSearchResource;
   renderCycleBarrier?: Promise<void>;
   // The sentinel `surfaceSearchResourceErrorState` planted on the most
@@ -152,18 +161,31 @@ export function ensureQueryFieldSearchResource(
     // own refresh is driven by realm events for the realms its query targets,
     // so it is behind for a write it never heard about — a subscription gap, or
     // a query whose realms don't include the one the owner was written to.
-    // Handing the newer result set over costs nothing, because the document
-    // already paid for the resolution, and is skipped when the identity matches
-    // the one already applied, which is every steady-state read of the field.
-    let seedIdentity = fieldState.seedIdentity;
-    if (seedIdentity && seedIdentity !== fieldState.appliedSeedIdentity) {
-      let seed = queryFieldSeed(fieldState);
-      if (seed) {
-        log.info(
-          `ensureQueryFieldSearchResource: applying refreshed seed for field=${field.name}; count=${seed.cards.length}`,
-        );
-        fieldState.appliedSeedIdentity = seedIdentity;
-        searchResource.reseed?.(seed);
+    // Handing that result set over costs nothing, because the document already
+    // paid for the resolution.
+    //
+    // Two gates, and both are needed. The outer one spends the document: the
+    // offer belongs to a document arriving, so a plain read never hands an
+    // answer back over a search that has since produced a fresher one. The
+    // inner one declines an offer the resource is already holding, asking the
+    // resource rather than remembering the last identity handed over — a
+    // memory would go on claiming a set a search had replaced, and would then
+    // turn away the document that corrects it.
+    if (fieldState.seedHandoverPending) {
+      fieldState.seedHandoverPending = false;
+      let seedIdentity = fieldState.seedIdentity;
+      if (
+        seedIdentity &&
+        searchResource.reseed &&
+        seedIdentity !== searchResource.appliedSeedIdentity
+      ) {
+        let seed = queryFieldSeed(fieldState);
+        if (seed) {
+          log.info(
+            `ensureQueryFieldSearchResource: applying refreshed seed for field=${field.name}; count=${seed.cards.length}`,
+          );
+          searchResource.reseed(seed);
+        }
       }
     }
     surfaceSearchResourceErrorState(
@@ -233,7 +255,8 @@ export function ensureQueryFieldSearchResource(
     },
   );
   fieldState.searchResource = searchResource;
-  fieldState.appliedSeedIdentity = fieldState.seedIdentity;
+  // The document's result set went in with the resource, so it is spent.
+  fieldState.seedHandoverPending = false;
   trackQueryFieldLoads(store, field.name, fieldState);
   surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
   // Bridge `getRelationshipMembershipState(...).isLoading` to this freshly-created resource:
@@ -681,11 +704,19 @@ export function captureQueryFieldSeedData(
       ? seedTotal
       : undefined;
   fieldState.seedIdentity = seedIdentityFor(fieldState);
+  fieldState.seedHandoverPending = true;
 }
 
-// The identity of an authoritative result set: the query the indexer resolved,
-// plus the ids it resolved to. An unauthoritative one has no identity, so it
-// can never be mistaken for a fresher answer than the one a resource holds.
+// The identity of an authoritative result set. An unauthoritative one has no
+// identity, so it can never be mistaken for a fresher answer than the one a
+// resource holds.
+//
+// It covers every part of the answer `queryFieldSeed` builds, not just the
+// rows: a page-clamped field gains a match it cannot surface and reports the
+// same row against a higher count, and a realm that stops answering leaves the
+// rows it did contribute while turning the count into a floor. Identifying a
+// result set by its rows alone would call both of those the answer already in
+// hand and leave the field reporting a shortfall of none.
 function seedIdentityFor(fieldState: QueryFieldState): string | undefined {
   if (!fieldState.seedSearchURL) {
     return undefined;
@@ -695,7 +726,15 @@ function seedIdentityFor(fieldState: QueryFieldState): string | undefined {
     (fieldState.seedRecords ?? [])
       .map((card) => card.id)
       .filter((id) => Boolean(id));
-  return `${fieldState.seedSearchURL}\n${ids.join(',')}`;
+  let unreachableRealms = (fieldState.seedErrors ?? [])
+    .map((error) => error.realm)
+    .sort();
+  return [
+    fieldState.seedSearchURL,
+    ids.join(','),
+    fieldState.seedTotal ?? '',
+    unreachableRealms.join(','),
+  ].join('\n');
 }
 
 // The result set the owner's most recent document produced, in the shape the
@@ -714,6 +753,7 @@ function queryFieldSeed(fieldState: QueryFieldState) {
   let seedSearchURL = fieldState.seedSearchURL;
   return {
     cards: seedRecords,
+    identity: fieldState.seedIdentity,
     searchURL: seedSearchURL ?? undefined,
     realms: fieldState.seedRealms,
     queryErrors: fieldState.seedErrors,

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -62,6 +62,13 @@ interface QueryFieldState {
     message: string;
     status?: number;
   }>;
+  // Identity of the result set the owner's most recent document carried, and of
+  // the one the search resource holds. Only an indexer-resolved umbrella gets
+  // an identity — a raw source document carries no authoritative answer, so it
+  // can never supersede one — and the pair is what lets a document fetched
+  // after the resource started hand it a fresher result set.
+  seedIdentity?: string;
+  appliedSeedIdentity?: string;
   searchResource?: StoreSearchResource;
   renderCycleBarrier?: Promise<void>;
   // The sentinel `surfaceSearchResourceErrorState` planted on the most
@@ -140,6 +147,25 @@ export function ensureQueryFieldSearchResource(
     log.debug(
       `ensureQueryFieldSearchResource: reusing existing resource from fieldState for field=${field.name}`,
     );
+    // A document fetched after the resource started carries this field resolved
+    // as of that read, which supersedes what the resource holds: the resource's
+    // own refresh is driven by realm events for the realms its query targets,
+    // so it is behind for a write it never heard about — a subscription gap, or
+    // a query whose realms don't include the one the owner was written to.
+    // Handing the newer result set over costs nothing, because the document
+    // already paid for the resolution, and is skipped when the identity matches
+    // the one already applied, which is every steady-state read of the field.
+    let seedIdentity = fieldState.seedIdentity;
+    if (seedIdentity && seedIdentity !== fieldState.appliedSeedIdentity) {
+      let seed = queryFieldSeed(fieldState);
+      if (seed) {
+        log.info(
+          `ensureQueryFieldSearchResource: applying refreshed seed for field=${field.name}; count=${seed.cards.length}`,
+        );
+        fieldState.appliedSeedIdentity = seedIdentity;
+        searchResource.reseed?.(seed);
+      }
+    }
     surfaceSearchResourceErrorState(
       fieldState,
       instance,
@@ -149,8 +175,7 @@ export function ensureQueryFieldSearchResource(
     return searchResource;
   }
 
-  let seedRecords = fieldState?.seedRecords;
-  let seedSearchURL = fieldState?.seedSearchURL;
+  let seedRecords = fieldState.seedRecords;
   let args = () => {
     return resolveQueryAndRealm(store, instance, field, fieldDefinition);
   };
@@ -204,45 +229,11 @@ export function ensureQueryFieldSearchResource(
     {
       isLive,
       dependencyTracking: trackingContext,
-      seed: seedRecords
-        ? {
-            cards: seedRecords,
-            searchURL: seedSearchURL ?? undefined,
-            realms: fieldState?.seedRealms,
-            queryErrors: fieldState?.seedErrors,
-            cardURLs: fieldState?.seedCardURLs,
-            // What the resource is allowed to believe about the match count,
-            // in order of how much is known. A count the indexer reported
-            // passes through as the count. Where it reported none but recorded
-            // a realm failure, the rows in hand are labelled a floor — that
-            // says both that the count is unknown and why, which is what turns
-            // into the field's shortfall signal. Where it reported none and no
-            // realm failed, the count is simply unknowable and says so.
-            //
-            // The ordering matters because the fallback is inference: absent
-            // any of these the resource takes the total from the record count,
-            // and a set short by a realm nobody could count would read as the
-            // whole of it — a confident number over an incomplete set, which is
-            // the failure this field's status exists to report rather than
-            // reproduce. An ordinary seed reaches that inference legitimately,
-            // because there nothing was withheld.
-            ...(fieldState?.seedTotal != null
-              ? { meta: { page: { total: fieldState.seedTotal } } }
-              : fieldState?.seedErrors?.length
-                ? {
-                    meta: {
-                      page: { total: seedRecords.length },
-                      incomplete: true,
-                    },
-                  }
-                : seedSearchURL != null
-                  ? { totalUnknown: true }
-                  : {}),
-          }
-        : undefined,
+      seed: queryFieldSeed(fieldState),
     },
   );
   fieldState.searchResource = searchResource;
+  fieldState.appliedSeedIdentity = fieldState.seedIdentity;
   trackQueryFieldLoads(store, field.name, fieldState);
   surfaceSearchResourceErrorState(fieldState, instance, field, searchResource);
   // Bridge `getRelationshipMembershipState(...).isLoading` to this freshly-created resource:
@@ -689,6 +680,71 @@ export function captureQueryFieldSeedData(
     Number.isFinite(seedTotal)
       ? seedTotal
       : undefined;
+  fieldState.seedIdentity = seedIdentityFor(fieldState);
+}
+
+// The identity of an authoritative result set: the query the indexer resolved,
+// plus the ids it resolved to. An unauthoritative one has no identity, so it
+// can never be mistaken for a fresher answer than the one a resource holds.
+function seedIdentityFor(fieldState: QueryFieldState): string | undefined {
+  if (!fieldState.seedSearchURL) {
+    return undefined;
+  }
+  let ids =
+    fieldState.seedCardURLs ??
+    (fieldState.seedRecords ?? [])
+      .map((card) => card.id)
+      .filter((id) => Boolean(id));
+  return `${fieldState.seedSearchURL}\n${ids.join(',')}`;
+}
+
+// The result set the owner's most recent document produced, in the shape the
+// search resource consumes. `undefined` when the document resolved nothing for
+// this field, which is the resource's signal to answer from a live query.
+//
+// Shared by resource creation and supersession so both describe the same set
+// the same way: the count semantics below are what the field's shortfall signal
+// reads, and a supersession that inferred a different count would report a
+// shortfall the document never claimed.
+function queryFieldSeed(fieldState: QueryFieldState) {
+  let seedRecords = fieldState.seedRecords;
+  if (!seedRecords) {
+    return undefined;
+  }
+  let seedSearchURL = fieldState.seedSearchURL;
+  return {
+    cards: seedRecords,
+    searchURL: seedSearchURL ?? undefined,
+    realms: fieldState.seedRealms,
+    queryErrors: fieldState.seedErrors,
+    cardURLs: fieldState.seedCardURLs,
+    // What the resource is allowed to believe about the match count, in order
+    // of how much is known. A count the indexer reported passes through as the
+    // count. Where it reported none but recorded a realm failure, the rows in
+    // hand are labelled a floor — that says both that the count is unknown and
+    // why, which is what turns into the field's shortfall signal. Where it
+    // reported none and no realm failed, the count is simply unknowable and
+    // says so.
+    //
+    // The ordering matters because the fallback is inference: absent any of
+    // these the resource takes the total from the record count, and a set short
+    // by a realm nobody could count would read as the whole of it — a confident
+    // number over an incomplete set, which is the failure this field's status
+    // exists to report rather than reproduce. An ordinary seed reaches that
+    // inference legitimately, because there nothing was withheld.
+    ...(fieldState.seedTotal != null
+      ? { meta: { page: { total: fieldState.seedTotal } } }
+      : fieldState.seedErrors?.length
+        ? {
+            meta: {
+              page: { total: seedRecords.length },
+              incomplete: true,
+            },
+          }
+        : seedSearchURL != null
+          ? { totalUnknown: true }
+          : {}),
+  };
 }
 
 function resolveQueryAndRealm(

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -68,6 +68,11 @@ interface QueryFieldState {
   // against the identity the search resource holds is what lets a document
   // fetched after the resource started hand it a fresher result set.
   seedIdentity?: string;
+  // The index generation the owner's document was serialized at, off
+  // `meta.generation`. What the resource compares against its own result set to
+  // order the two, so a document read before a search that has since completed
+  // does not overwrite it.
+  seedGeneration?: number;
   // A document has been captured that no resource has been offered yet. Set by
   // every capture and cleared the first time a read acts on it, so a running
   // resource is offered a result set once per document fetched for the owner.
@@ -704,6 +709,14 @@ export function captureQueryFieldSeedData(
       ? seedTotal
       : undefined;
   fieldState.seedIdentity = seedIdentityFor(fieldState);
+  // The generation the row this document was serialized from was written at.
+  // Absent where the serialization did not come off the index — a freshly built
+  // resource that was never persisted — in which case the field's result set is
+  // ordered by identity alone, as it was before any generation was available.
+  let generation = (resource.meta as { generation?: unknown } | undefined)
+    ?.generation;
+  fieldState.seedGeneration =
+    typeof generation === 'number' ? generation : undefined;
   fieldState.seedHandoverPending = true;
 }
 
@@ -754,6 +767,7 @@ function queryFieldSeed(fieldState: QueryFieldState) {
   return {
     cards: seedRecords,
     identity: fieldState.seedIdentity,
+    generation: fieldState.seedGeneration,
     searchURL: seedSearchURL ?? undefined,
     realms: fieldState.seedRealms,
     queryErrors: fieldState.seedErrors,

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -69,10 +69,18 @@ interface QueryFieldState {
   // fetched after the resource started hand it a fresher result set.
   seedIdentity?: string;
   // The index generation the owner's document was serialized at, off
-  // `meta.generation`. What the resource compares against its own result set to
+  // `meta.generation`, and the realm that generation counts writes in, off
+  // `meta.realmURL`. What the resource compares against its own result set to
   // order the two, so a document read before a search that has since completed
   // does not overwrite it.
+  //
+  // A floor rather than the generation the field was resolved at: read-time
+  // resolution does not rewrite the owner's row, and a matching card changing
+  // never does either, since dependencies reached only through a query context
+  // are left out of that row's deps. It errs toward declining a document that
+  // is in fact fresh.
   seedGeneration?: number;
+  seedRealm?: string;
   // A document has been captured that no resource has been offered yet. Set by
   // every capture and cleared the first time a read acts on it, so a running
   // resource is offered a result set once per document fetched for the owner.
@@ -709,14 +717,17 @@ export function captureQueryFieldSeedData(
       ? seedTotal
       : undefined;
   fieldState.seedIdentity = seedIdentityFor(fieldState);
-  // The generation the row this document was serialized from was written at.
-  // Absent where the serialization did not come off the index — a freshly built
-  // resource that was never persisted — in which case the field's result set is
-  // ordered by identity alone, as it was before any generation was available.
-  let generation = (resource.meta as { generation?: unknown } | undefined)
-    ?.generation;
+  // The generation the row this document was serialized from was written at,
+  // and the realm that counter belongs to. Absent where the serialization did
+  // not come off the index — a freshly built resource that was never persisted
+  // — in which case the field's result set is ordered by identity alone.
+  let meta = resource.meta as
+    | { generation?: unknown; realmURL?: unknown }
+    | undefined;
   fieldState.seedGeneration =
-    typeof generation === 'number' ? generation : undefined;
+    typeof meta?.generation === 'number' ? meta.generation : undefined;
+  fieldState.seedRealm =
+    typeof meta?.realmURL === 'string' ? meta.realmURL : undefined;
   fieldState.seedHandoverPending = true;
 }
 
@@ -768,6 +779,7 @@ function queryFieldSeed(fieldState: QueryFieldState) {
     cards: seedRecords,
     identity: fieldState.seedIdentity,
     generation: fieldState.seedGeneration,
+    realm: fieldState.seedRealm,
     searchURL: seedSearchURL ?? undefined,
     realms: fieldState.seedRealms,
     queryErrors: fieldState.seedErrors,

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -98,6 +98,12 @@ type StoreHooks = {
             // so a hop that forwards the seed field by field rather than whole
             // would drop it and restore exactly the inference it prevents.
             totalUnknown?: boolean;
+            // Here for the same reason: the identity is what stops a result set
+            // being re-applied over one the resource already holds, and a hop
+            // that dropped it would put that back. The generation is what
+            // orders the two when they do differ.
+            identity?: string;
+            generation?: number;
           }
         | undefined;
     },

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -1457,7 +1457,7 @@ export default class CardStoreWithGarbageCollection implements CardStore {
     parent: object,
     getQuery: () => Query | undefined,
     getRealms?: () => string[] | undefined,
-    opts?: GetSearchResourceFuncOpts,
+    opts?: GetSearchResourceFuncOpts<T>,
   ) {
     if (!this.#storeHooks?.getSearchResource) {
       return {

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -104,6 +104,7 @@ type StoreHooks = {
             // orders the two when they do differ.
             identity?: string;
             generation?: number;
+            realm?: string;
           }
         | undefined;
     },

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -139,6 +139,10 @@ export interface Args<T extends CardDef | FileDef = CardDef> {
     seed?:
       | {
           cards: T[];
+          // What this result set is, as against any other the same query could
+          // produce. A resource already holding a seed with this identity
+          // ignores the seed rather than re-applying it.
+          identity?: string;
           searchURL?: string;
           realms?: string[];
           meta?: QueryResultsMeta;
@@ -216,6 +220,15 @@ export class SearchResource<
   #cardInitiated = false;
   #getDefaultRealm: (() => string | undefined) | undefined;
   #seedApplied = false;
+  // Identity of the seeded result set this resource holds, cleared once a
+  // search completes and re-derives that set for itself. Deliberately
+  // untracked: it is read
+  // from the query-field getter, which then hands over a seed that writes it in
+  // the same render, and a tracked write there would trip the backtracking
+  // assertion. The read is safe untracked because the getter also consumes
+  // `instances`, so a search that clears this has already dirtied what brought
+  // the reader here.
+  #appliedSeedIdentity: string | undefined;
   // No match count is known yet and one must not be inferred. Tracked, because
   // `totalMatchCount` is read during render and has to re-derive when a seed or
   // a live search supplies a real count.
@@ -466,6 +479,7 @@ export class SearchResource<
     if (seed && !this.#seedApplied) {
       this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
       this.#seedApplied = true;
+      this.#appliedSeedIdentity = seed.identity;
       let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
       if (seed.searchURL && !hasQueryErrors) {
         let { query: seedQuery } = parseSearchURL(seed.searchURL);
@@ -592,11 +606,20 @@ export class SearchResource<
   // events for the realms the query targets, so a session that never received
   // one — a dropped subscription, a tab resumed after a gap, or a write to a
   // realm outside the query's own set — is behind until something hands it a
-  // fresher answer. The search is suppressed the same way the initial seed
-  // suppresses it, which keeps this free: the document already paid for the
-  // resolution.
+  // fresher answer. A result set the producer resolved in full costs nothing to
+  // take: the query is suppressed the same way the initial seed suppresses it,
+  // because the document already paid for the resolution. Only a set a realm
+  // failure cut short sends the field back to a live query (below).
+  //
+  // A seed asserting what this resource already holds is dropped here rather
+  // than at the call site, so the comparison is against the resource's own
+  // state and not a caller's memory of it.
   reseed(seed: NonNullable<Args<T>['named']['seed']>): void {
+    if (seed.identity && seed.identity === this.#appliedSeedIdentity) {
+      return;
+    }
     this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
+    this.#appliedSeedIdentity = seed.identity;
     let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
     if (seed.searchURL && !hasQueryErrors) {
       let { query: seedQuery } = parseSearchURL(seed.searchURL);
@@ -605,6 +628,25 @@ export class SearchResource<
     if (seed.realms) {
       this.#previousRealms = seed.realms;
     }
+    // A producer that could not reach every realm resolved a set that is short
+    // by what the failure withheld, so its rows are a floor and not an answer.
+    // The initial seed reaches a live query for exactly this case by leaving
+    // the query signature unset and falling through to `modify`'s search; run
+    // that query directly here, because nothing brings a running resource back
+    // through that fall-through — its query and realms are unchanged, so the
+    // next `modify` skips, and the field would stay short until an unrelated
+    // event.
+    //
+    // Live only, matching the initial seed: a prerender treats the document's
+    // relationships as the authoritative cardinality and runs no query at all,
+    // and a query per field per loaded card is the cascade that rules out.
+    if (this.#isLive && hasQueryErrors && this.#previousQuery) {
+      this.trackStoreLoad(this.search.perform(this.#previousQuery), 'search');
+    }
+  }
+
+  get appliedSeedIdentity() {
+    return this.#appliedSeedIdentity;
   }
 
   // Both routes to a result set count as loading. A seeded resource commonly
@@ -978,6 +1020,11 @@ export class SearchResource<
         // A completed search reports its own count, which supersedes a seed
         // that had none.
         this.seedTotalUnknown = false;
+        // This set is the search's own, so no seed describes it any more.
+        // Keeping the last-applied identity here would go on claiming a set
+        // that has been replaced, and would then turn away a document
+        // restoring the very set the search moved off.
+        this.#appliedSeedIdentity = undefined;
         this._meta = meta;
         this._errors = undefined;
         await this.updateInstances(instances, dependencyTrackingContext);
@@ -1004,6 +1051,11 @@ export class SearchResource<
         // signal exists to prevent.
         this.seedTotalUnknown = true;
         this._meta = { page: { total: 0 }, incomplete: true };
+        // The applied seed identity deliberately survives a failure, unlike a
+        // completed search above. A failed search computed nothing, so what a
+        // document last asserted about this field is still the last thing
+        // anyone asserted; clearing it here would let the next read reinstate
+        // those rows and, with them, clear the error this failure is reporting.
         if (this._instances.length > 0) {
           try {
             await this.updateInstances([], dependencyTrackingContext);
@@ -1045,6 +1097,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
     seed?:
       | {
           cards: T[];
+          identity?: string;
           searchURL?: string;
           meta?: QueryResultsMeta;
           errors?: ErrorEntry[];

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -143,6 +143,9 @@ export interface Args<T extends CardDef | FileDef = CardDef> {
           // produce. A resource already holding a seed with this identity
           // ignores the seed rather than re-applying it.
           identity?: string;
+          // The index generation the producer resolved this set at, which is
+          // what orders it against a set the resource already holds.
+          generation?: number;
           searchURL?: string;
           realms?: string[];
           meta?: QueryResultsMeta;
@@ -220,15 +223,22 @@ export class SearchResource<
   #cardInitiated = false;
   #getDefaultRealm: (() => string | undefined) | undefined;
   #seedApplied = false;
-  // Identity of the seeded result set this resource holds, cleared once a
-  // search completes and re-derives that set for itself. Deliberately
-  // untracked: it is read
-  // from the query-field getter, which then hands over a seed that writes it in
-  // the same render, and a tracked write there would trip the backtracking
-  // assertion. The read is safe untracked because the getter also consumes
-  // `instances`, so a search that clears this has already dirtied what brought
+  // Identity of the seeded result set this resource holds, cleared once a search
+  // completes and re-derives that set for itself. Deliberately untracked: the
+  // query-field getter reads it and then hands over a seed that writes it in the
+  // same render, and a tracked write there would trip the backtracking
+  // assertion. Reading it untracked is safe because that getter also consumes
+  // `instances`, so a search that cleared this has already dirtied what brought
   // the reader here.
   #appliedSeedIdentity: string | undefined;
+  // The index generation this resource's result set is known to reflect, as a
+  // floor. It is what orders a document against a search: both name a
+  // generation, so the newer of the two wins rather than whichever arrived
+  // last. Raised and never lowered, so a set whose generation cannot be
+  // established keeps the last floor established rather than reverting to
+  // none — that refuses a fresh document at worst, where the other direction
+  // would let a stale one overwrite a newer answer.
+  #resultGeneration: number | undefined;
   // No match count is known yet and one must not be inferred. Tracked, because
   // `totalMatchCount` is read during render and has to re-derive when a seed or
   // a live search supplies a real count.
@@ -480,6 +490,7 @@ export class SearchResource<
       // Recorded before the application starts, because the application itself
       // reads it to confirm it is still the seed the resource reports holding.
       this.#appliedSeedIdentity = seed.identity;
+      this.#raiseResultGeneration(seed.generation);
       this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
       this.#seedApplied = true;
       let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
@@ -565,8 +576,15 @@ export class SearchResource<
             if (!isIncrementalIndex && event.eventName !== 'prerender_html') {
               return;
             }
+            // The generation the indexing pass committed. A search answering
+            // this event reads the index at or after it, so it stands as the
+            // floor for what the result set reflects.
+            let generation =
+              'generation' in event && typeof event.generation === 'number'
+                ? event.generation
+                : undefined;
             this.trackStoreLoad(
-              this.search.perform(this.#previousQuery),
+              this.search.perform(this.#previousQuery, generation),
               'live-refresh',
             );
           }),
@@ -615,15 +633,41 @@ export class SearchResource<
   //
   // A seed asserting what this resource already holds is dropped here rather
   // than at the call site, so the comparison is against the resource's own
-  // state and not a caller's memory of it.
+  // state and not a caller's memory of it. Supersession needs an identity to
+  // compare: a seed carrying none cannot be told apart from any other and is
+  // always applied.
+  //
+  // Both `perform`s below write ember-concurrency's tracked task state, and
+  // this runs from the query-field getter during a render. A consumer that
+  // reads `getRelationshipMembershipState(...).isLoading` for a query field
+  // *before* reading the field itself in the same render would see that write
+  // land after its own read.
   reseed(seed: NonNullable<Args<T>['named']['seed']>): void {
     if (seed.identity && seed.identity === this.#appliedSeedIdentity) {
+      return;
+    }
+    // Older than what this resource holds, so it is not news — it is a read
+    // that was already in flight when a later one landed. Without this the
+    // handover has no ordering at all and the last arrival wins, which loses a
+    // completed search to a document resolved before it. Both generations have
+    // to be known to compare: where either is absent the identity check above
+    // decides alone, which is what this did before any generation was
+    // available.
+    if (
+      seed.generation != null &&
+      this.#resultGeneration != null &&
+      seed.generation < this.#resultGeneration
+    ) {
+      this.#log.info(
+        `decline seed from generation ${seed.generation}; holding generation ${this.#resultGeneration}`,
+      );
       return;
     }
     // Before the application starts, for the reason the initial seed records it
     // first: the application confirms against this that it has not been
     // superseded.
     this.#appliedSeedIdentity = seed.identity;
+    this.#raiseResultGeneration(seed.generation);
     this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
     let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
     if (seed.searchURL && !hasQueryErrors) {
@@ -652,6 +696,18 @@ export class SearchResource<
 
   get appliedSeedIdentity() {
     return this.#appliedSeedIdentity;
+  }
+
+  // Move the floor up, never down. An unknown generation leaves it alone: it
+  // says nothing about what the set reflects, and lowering the floor to `none`
+  // would reopen the ordering the floor exists to close.
+  #raiseResultGeneration(generation: number | undefined): void {
+    if (generation == null) {
+      return;
+    }
+    if (this.#resultGeneration == null || generation > this.#resultGeneration) {
+      this.#resultGeneration = generation;
+    }
   }
 
   // Both routes to a result set count as loading. A seeded resource commonly
@@ -1004,91 +1060,95 @@ export class SearchResource<
     },
   );
 
-  private search = restartableTask(async (query: Query) => {
-    this.#log.info(
-      `search task start; realms=${this.realmsToSearch.join(',')}; query=${JSON.stringify(query)}`,
-    );
-    // we cannot use the `waitForPromise` test waiter helper as that will cast
-    // the Task instance to a promise which makes it uncancellable. When this is
-    // uncancellable it results in a flaky test.
-    let token = waiter.beginAsync();
-    try {
-      let dependencyTrackingContext = this.dependencyTrackingContext(
-        'search-resource:search',
+  private search = restartableTask(
+    async (query: Query, generation?: number) => {
+      this.#log.info(
+        `search task start; realms=${this.realmsToSearch.join(',')}; query=${JSON.stringify(query)}`,
       );
+      // we cannot use the `waitForPromise` test waiter helper as that will cast
+      // the Task instance to a promise which makes it uncancellable. When this is
+      // uncancellable it results in a flaky test.
+      let token = waiter.beginAsync();
       try {
-        // A card-`@context` search runs card-initiated — under the page,
-        // realms, and concurrency caps inside `store.search`. `realmsToSearch`
-        // has already resolved a no-realm card search to the current realm
-        // (see modify). Host-internal searches pass no flag and are unbounded.
-        let { instances, meta } = await this.runtimeStore.search<T>(
-          query,
-          this.realmsToSearch,
-          {
-            includeMeta: true,
-            dependencyTrackingContext,
-            cardInitiated: this.#cardInitiated,
-          },
+        let dependencyTrackingContext = this.dependencyTrackingContext(
+          'search-resource:search',
         );
-        this.#log.info(
-          `search task complete; total instances=${instances.length}; refs=${instances
-            .map((r) => r.id)
-            .join(',')}`,
-        );
-        // A completed search reports its own count, which supersedes a seed
-        // that had none.
-        this.seedTotalUnknown = false;
-        // This set is the search's own, so no seed describes it any more.
-        // Keeping the last-applied identity here would go on claiming a set
-        // that has been replaced, and would then turn away a document
-        // restoring the very set the search moved off.
-        this.#appliedSeedIdentity = undefined;
-        this._meta = meta;
-        this._errors = undefined;
-        await this.updateInstances(instances, dependencyTrackingContext);
-      } catch (err) {
-        if (didCancel(err)) {
-          throw err;
-        }
-        this.#log.error(`search task failed`, err);
-        this._errors = [searchErrorEntry(err)];
-        // Zero rows, and zero is not a count of anything: the search failed as
-        // a unit, so what the query matches was never computed. The zero is
-        // kept because the loading and rendering paths need the shape, and both
-        // markers beside it say it is not a count — a rollup reading it would
-        // otherwise settle on the one number no failure can justify, and it is
-        // the most believable wrong answer there is, an empty result set and an
-        // empty match set rendering identically.
-        //
-        // Both are needed, because they are read separately and answer
-        // different halves. `seedTotalUnknown` is what `totalMatchCount`
-        // consults, so it withholds the count. `incomplete` is what the field's
-        // probe consults for the shortfall, and without it the count comes back
-        // unknown while nothing reports rows missing — "how many is unknown,
-        // and you hold all of them", which is the contradiction the shortfall
-        // signal exists to prevent.
-        this.seedTotalUnknown = true;
-        this._meta = { page: { total: 0 }, incomplete: true };
-        // The applied seed identity deliberately survives a failure, unlike a
-        // completed search above. A failed search computed nothing, so what a
-        // document last asserted about this field is still the last thing
-        // anyone asserted; clearing it here would let the next read reinstate
-        // those rows and, with them, clear the error this failure is reporting.
-        if (this._instances.length > 0) {
-          try {
-            await this.updateInstances([], dependencyTrackingContext);
-          } catch (cleanupErr) {
-            if (didCancel(cleanupErr)) {
-              throw cleanupErr;
+        try {
+          // A card-`@context` search runs card-initiated — under the page,
+          // realms, and concurrency caps inside `store.search`. `realmsToSearch`
+          // has already resolved a no-realm card search to the current realm
+          // (see modify). Host-internal searches pass no flag and are unbounded.
+          let { instances, meta } = await this.runtimeStore.search<T>(
+            query,
+            this.realmsToSearch,
+            {
+              includeMeta: true,
+              dependencyTrackingContext,
+              cardInitiated: this.#cardInitiated,
+            },
+          );
+          this.#log.info(
+            `search task complete; total instances=${instances.length}; refs=${instances
+              .map((r) => r.id)
+              .join(',')}`,
+          );
+          // A completed search reports its own count, which supersedes a seed
+          // that had none.
+          this.seedTotalUnknown = false;
+          // This set is the search's own, so no seed describes it any more.
+          // Keeping the last-applied identity here would go on claiming a set
+          // that has been replaced, and would then turn away a document
+          // restoring the very set the search moved off. What orders this set
+          // against a later document is the generation instead.
+          this.#appliedSeedIdentity = undefined;
+          this.#raiseResultGeneration(generation);
+          this._meta = meta;
+          this._errors = undefined;
+          await this.updateInstances(instances, dependencyTrackingContext);
+        } catch (err) {
+          if (didCancel(err)) {
+            throw err;
+          }
+          this.#log.error(`search task failed`, err);
+          this._errors = [searchErrorEntry(err)];
+          // Zero rows, and zero is not a count of anything: the search failed as
+          // a unit, so what the query matches was never computed. The zero is
+          // kept because the loading and rendering paths need the shape, and both
+          // markers beside it say it is not a count — a rollup reading it would
+          // otherwise settle on the one number no failure can justify, and it is
+          // the most believable wrong answer there is, an empty result set and an
+          // empty match set rendering identically.
+          //
+          // Both are needed, because they are read separately and answer
+          // different halves. `seedTotalUnknown` is what `totalMatchCount`
+          // consults, so it withholds the count. `incomplete` is what the field's
+          // probe consults for the shortfall, and without it the count comes back
+          // unknown while nothing reports rows missing — "how many is unknown,
+          // and you hold all of them", which is the contradiction the shortfall
+          // signal exists to prevent.
+          this.seedTotalUnknown = true;
+          this._meta = { page: { total: 0 }, incomplete: true };
+          // The applied seed identity deliberately survives a failure, unlike a
+          // completed search above. A failed search computed nothing, so what a
+          // document last asserted about this field is still the last thing
+          // anyone asserted; clearing it here would let the next read reinstate
+          // those rows and, with them, clear the error this failure is reporting.
+          if (this._instances.length > 0) {
+            try {
+              await this.updateInstances([], dependencyTrackingContext);
+            } catch (cleanupErr) {
+              if (didCancel(cleanupErr)) {
+                throw cleanupErr;
+              }
+              this.#log.error(`search cleanup failed`, cleanupErr);
             }
-            this.#log.error(`search cleanup failed`, cleanupErr);
           }
         }
+      } finally {
+        waiter.endAsync(token);
       }
-    } finally {
-      waiter.endAsync(token);
-    }
-  });
+    },
+  );
 }
 
 // WARNING! please don't import this directly into your component's module.
@@ -1116,6 +1176,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
       | {
           cards: T[];
           identity?: string;
+          generation?: number;
           searchURL?: string;
           meta?: QueryResultsMeta;
           errors?: ErrorEntry[];

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -975,6 +975,19 @@ export class SearchResource<
           return type !== 'card-error';
         }) as unknown as T[];
       }
+      // Another seed has been handed over since this one, and it is the set the
+      // resource reports holding. This task runs unbounded — two documents
+      // arriving close together resolve their rows concurrently — so applying
+      // this one now would leave the resource holding the older answer under
+      // the newer identity, whichever of the two happens to finish last. The
+      // check is inert for a producer that supplies no identity, whose seeds
+      // are indistinguishable by design.
+      if (seed.identity !== this.#appliedSeedIdentity) {
+        this.#log.info(
+          `abandon seed superseded while resolving; searchURL=${seed.searchURL}`,
+        );
+        return;
+      }
       // The row count stands in for the total only when the seed didn't report
       // one AND didn't say the count is unknowable. A producer that withheld
       // the count deliberately sets `totalUnknown`, and inferring it from the

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -586,6 +586,27 @@ export class SearchResource<
     return canonicalQuerySignature(query, this.network.virtualNetwork);
   }
 
+  // Apply a result set to a resource that is already running. A document
+  // fetched for the owner carries this field resolved as of that read, which
+  // supersedes what the resource holds: the live subscription refreshes only on
+  // events for the realms the query targets, so a session that never received
+  // one — a dropped subscription, a tab resumed after a gap, or a write to a
+  // realm outside the query's own set — is behind until something hands it a
+  // fresher answer. The search is suppressed the same way the initial seed
+  // suppresses it, which keeps this free: the document already paid for the
+  // resolution.
+  reseed(seed: NonNullable<Args<T>['named']['seed']>): void {
+    this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
+    let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
+    if (seed.searchURL && !hasQueryErrors) {
+      let { query: seedQuery } = parseSearchURL(seed.searchURL);
+      this.#previousQueryString = this.querySignature(seedQuery);
+    }
+    if (seed.realms) {
+      this.#previousRealms = seed.realms;
+    }
+  }
+
   // Both routes to a result set count as loading. A seeded resource commonly
   // never performs a search at all — the seed's query signature suppresses it —
   // so reporting only the search task would leave a window where the resource

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -477,9 +477,11 @@ export class SearchResource<
       `modify: prepared realms for subscription=${this.realmsToSearch.join(',')}`,
     );
     if (seed && !this.#seedApplied) {
+      // Recorded before the application starts, because the application itself
+      // reads it to confirm it is still the seed the resource reports holding.
+      this.#appliedSeedIdentity = seed.identity;
       this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
       this.#seedApplied = true;
-      this.#appliedSeedIdentity = seed.identity;
       let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
       if (seed.searchURL && !hasQueryErrors) {
         let { query: seedQuery } = parseSearchURL(seed.searchURL);
@@ -618,8 +620,11 @@ export class SearchResource<
     if (seed.identity && seed.identity === this.#appliedSeedIdentity) {
       return;
     }
-    this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
+    // Before the application starts, for the reason the initial seed records it
+    // first: the application confirms against this that it has not been
+    // superseded.
     this.#appliedSeedIdentity = seed.identity;
+    this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
     let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
     if (seed.searchURL && !hasQueryErrors) {
       let { query: seedQuery } = parseSearchURL(seed.searchURL);

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -143,9 +143,13 @@ export interface Args<T extends CardDef | FileDef = CardDef> {
           // produce. A resource already holding a seed with this identity
           // ignores the seed rather than re-applying it.
           identity?: string;
-          // The index generation the producer resolved this set at, which is
-          // what orders it against a set the resource already holds.
+          // The index generation the producer resolved this set at, and the
+          // realm whose counter it belongs to. Together they order this set
+          // against one the resource already holds — a generation counts
+          // writes within a single realm, so it means nothing without the
+          // realm that issued it.
           generation?: number;
+          realm?: string;
           searchURL?: string;
           realms?: string[];
           meta?: QueryResultsMeta;
@@ -231,14 +235,31 @@ export class SearchResource<
   // `instances`, so a search that cleared this has already dirtied what brought
   // the reader here.
   #appliedSeedIdentity: string | undefined;
-  // The index generation this resource's result set is known to reflect, as a
-  // floor. It is what orders a document against a search: both name a
-  // generation, so the newer of the two wins rather than whichever arrived
-  // last. Raised and never lowered, so a set whose generation cannot be
-  // established keeps the last floor established rather than reverting to
-  // none — that refuses a fresh document at worst, where the other direction
-  // would let a stale one overwrite a newer answer.
-  #resultGeneration: number | undefined;
+  // Per realm, the index generation this resource's result set is known to
+  // reflect, as a floor. It is what orders a document against a search: both
+  // name a generation, so the newer of the two wins rather than whichever
+  // arrived last. Each entry is raised and never lowered, so a set whose
+  // generation cannot be established keeps the floor already established
+  // rather than reverting to none — that refuses a fresh document at worst,
+  // where the other direction would let a stale one overwrite a newer answer.
+  //
+  // Keyed by realm because a generation counts writes within one realm and
+  // nothing else: `realm_generations` is per `realm_url`, so a document's
+  // generation and a search's are the same scale only when they came from the
+  // same realm. A query whose realms differ from its owner's would otherwise
+  // compare two unrelated sequences, and whichever ran ahead would decide every
+  // handover for that field — either declining all of them or none.
+  //
+  // Both sides are floors rather than exact resolution generations. A search
+  // is stamped with the generation of the event that woke it, and the index it
+  // then reads is at or after that. A document is stamped with the generation
+  // its owner's row was written at, which a query field's own membership never
+  // advances: dependencies reached only through a query context are left out of
+  // the row's deps, so a matching card changing never rewrites the owner. Both
+  // err toward declining a document that is in fact fresh. Making the document
+  // side exact means stamping the resolution's own generation on the umbrella
+  // relationship where the indexer resolves it.
+  #resultGenerations = new Map<string, number>();
   // No match count is known yet and one must not be inferred. Tracked, because
   // `totalMatchCount` is read during render and has to re-derive when a seed or
   // a live search supplies a real count.
@@ -490,7 +511,7 @@ export class SearchResource<
       // Recorded before the application starts, because the application itself
       // reads it to confirm it is still the seed the resource reports holding.
       this.#appliedSeedIdentity = seed.identity;
-      this.#raiseResultGeneration(seed.generation);
+      this.#raiseResultGeneration(seed.realm, seed.generation);
       this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
       this.#seedApplied = true;
       let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
@@ -576,15 +597,16 @@ export class SearchResource<
             if (!isIncrementalIndex && event.eventName !== 'prerender_html') {
               return;
             }
-            // The generation the indexing pass committed. A search answering
-            // this event reads the index at or after it, so it stands as the
-            // floor for what the result set reflects.
+            // The generation the indexing pass committed, and the realm whose
+            // counter it belongs to. A search answering this event reads the
+            // index at or after it, so together they stand as the floor for
+            // what the result set reflects of that realm.
             let generation =
               'generation' in event && typeof event.generation === 'number'
                 ? event.generation
                 : undefined;
             this.trackStoreLoad(
-              this.search.perform(this.#previousQuery, generation),
+              this.search.perform(this.#previousQuery, generation, realm),
               'live-refresh',
             );
           }),
@@ -646,20 +668,21 @@ export class SearchResource<
     if (seed.identity && seed.identity === this.#appliedSeedIdentity) {
       return;
     }
-    // Older than what this resource holds, so it is not news — it is a read
-    // that was already in flight when a later one landed. Without this the
-    // handover has no ordering at all and the last arrival wins, which loses a
-    // completed search to a document resolved before it. Both generations have
-    // to be known to compare: where either is absent the identity check above
-    // decides alone, which is what this did before any generation was
-    // available.
+    // Older than what this resource holds for the realm the document came from,
+    // so it is not news — it is a read that was already in flight when a later
+    // one landed. Without this the handover has no ordering at all and the last
+    // arrival wins, which loses a completed search to a document resolved
+    // before it. The comparison needs a realm and a generation on both sides;
+    // absent any of them the identity check above decides alone.
+    let seedFloor =
+      seed.realm != null ? this.#resultGenerations.get(seed.realm) : undefined;
     if (
       seed.generation != null &&
-      this.#resultGeneration != null &&
-      seed.generation < this.#resultGeneration
+      seedFloor != null &&
+      seed.generation < seedFloor
     ) {
       this.#log.info(
-        `decline seed from generation ${seed.generation}; holding generation ${this.#resultGeneration}`,
+        `decline seed from generation ${seed.generation}; holding generation ${seedFloor} for realm ${seed.realm}`,
       );
       return;
     }
@@ -667,7 +690,7 @@ export class SearchResource<
     // first: the application confirms against this that it has not been
     // superseded.
     this.#appliedSeedIdentity = seed.identity;
-    this.#raiseResultGeneration(seed.generation);
+    this.#raiseResultGeneration(seed.realm, seed.generation);
     this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
     let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
     if (seed.searchURL && !hasQueryErrors) {
@@ -698,15 +721,20 @@ export class SearchResource<
     return this.#appliedSeedIdentity;
   }
 
-  // Move the floor up, never down. An unknown generation leaves it alone: it
-  // says nothing about what the set reflects, and lowering the floor to `none`
-  // would reopen the ordering the floor exists to close.
-  #raiseResultGeneration(generation: number | undefined): void {
-    if (generation == null) {
+  // Move one realm's floor up, never down. An unknown realm or generation
+  // leaves every floor alone: neither says anything about what the set
+  // reflects, and lowering a floor to `none` would reopen the ordering the
+  // floor exists to close.
+  #raiseResultGeneration(
+    realm: string | undefined,
+    generation: number | undefined,
+  ): void {
+    if (realm == null || generation == null) {
       return;
     }
-    if (this.#resultGeneration == null || generation > this.#resultGeneration) {
-      this.#resultGeneration = generation;
+    let current = this.#resultGenerations.get(realm);
+    if (current == null || generation > current) {
+      this.#resultGenerations.set(realm, generation);
     }
   }
 
@@ -1061,7 +1089,7 @@ export class SearchResource<
   );
 
   private search = restartableTask(
-    async (query: Query, generation?: number) => {
+    async (query: Query, generation?: number, realm?: string) => {
       this.#log.info(
         `search task start; realms=${this.realmsToSearch.join(',')}; query=${JSON.stringify(query)}`,
       );
@@ -1101,7 +1129,7 @@ export class SearchResource<
           // restoring the very set the search moved off. What orders this set
           // against a later document is the generation instead.
           this.#appliedSeedIdentity = undefined;
-          this.#raiseResultGeneration(generation);
+          this.#raiseResultGeneration(realm, generation);
           this._meta = meta;
           this._errors = undefined;
           await this.updateInstances(instances, dependencyTrackingContext);
@@ -1177,6 +1205,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
           cards: T[];
           identity?: string;
           generation?: number;
+          realm?: string;
           searchURL?: string;
           meta?: QueryResultsMeta;
           errors?: ErrorEntry[];

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1755,6 +1755,11 @@ export default class StoreService extends Service implements StoreInterface {
       getDefaultRealm?: () => string | undefined;
       seed?: {
         cards: T[];
+        // Declared on this hop too, for the reason `totalUnknown` is below:
+        // the identity is what stops a seed being re-applied over a set a
+        // search has since re-derived, and a field-by-field forward that
+        // dropped it would restore that re-application silently.
+        identity?: string;
         searchURL?: string;
         meta?: QueryResultsMeta;
         errors?: ErrorEntry[];

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1760,6 +1760,10 @@ export default class StoreService extends Service implements StoreInterface {
         // search has since re-derived, and a field-by-field forward that
         // dropped it would restore that re-application silently.
         identity?: string;
+        // Declared on this hop for the same reason as the identity: it is what
+        // orders a handed-over set against one the resource already holds, and
+        // a forward that dropped it would leave the handover with no ordering.
+        generation?: number;
         searchURL?: string;
         meta?: QueryResultsMeta;
         errors?: ErrorEntry[];

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1760,10 +1760,10 @@ export default class StoreService extends Service implements StoreInterface {
         // search has since re-derived, and a field-by-field forward that
         // dropped it would restore that re-application silently.
         identity?: string;
-        // Declared on this hop for the same reason as the identity: it is what
-        // orders a handed-over set against one the resource already holds, and
-        // a forward that dropped it would leave the handover with no ordering.
+        // What orders a handed-over set against one the resource already
+        // holds: the generation, and the realm whose counter it belongs to.
         generation?: number;
+        realm?: string;
         searchURL?: string;
         meta?: QueryResultsMeta;
         errors?: ErrorEntry[];

--- a/packages/host/tests/integration/components/query-field-membership-status-test.gts
+++ b/packages/host/tests/integration/components/query-field-membership-status-test.gts
@@ -88,6 +88,9 @@ module('Integration | query-field relationship status', function (hooks) {
         'test-cards.gts': { Person, Host },
         'Person/one.json': new Person({ name: 'Anchor' }),
         'Person/two.json': new Person({ name: 'Anchor' }),
+        // Deliberately outside the query. A live search can never return this
+        // card, so its presence in the field is proof a document put it there.
+        'Person/three.json': new Person({ name: 'Different' }),
         'Host/anchor.json': new Host({ cardTitle: 'Anchor' }),
       },
     });
@@ -103,6 +106,39 @@ module('Integration | query-field relationship status', function (hooks) {
     let host = (await getService('store').get(HOST_URL)) as CardDefType;
     await settled();
     return host;
+  }
+
+  // The document the realm serves for the host card, which carries every
+  // query-backed field resolved as of that read.
+  async function fetchHostDoc(): Promise<any> {
+    let response = await getService('network').authedFetch(HOST_URL, {
+      headers: { Accept: 'application/vnd.card+json' },
+    });
+    return await response.json();
+  }
+
+  // Add `Person/three` to the host document's `matches`, spelled the way the
+  // realm spells the members it already carries: the resolved instance in
+  // `included`, an id in the umbrella relationship's `data`, a per-member
+  // `matches.N` entry (which is what the deserializer reads), and a match total
+  // covering all three, so the document describes three matches rather than
+  // contradicting itself.
+  function spliceThirdMember(hostDoc: any): void {
+    let relationships = hostDoc.data.relationships;
+    let template = hostDoc.included.find((resource: { id: string }) =>
+      resource.id.endsWith('Person/one'),
+    );
+    let spliced = JSON.parse(JSON.stringify(template));
+    spliced.id = template.id.replace('Person/one', 'Person/three');
+    hostDoc.included.push(spliced);
+
+    let umbrella = relationships.matches;
+    umbrella.data.push({ type: 'card', id: spliced.id });
+    umbrella.meta = { ...umbrella.meta, total: umbrella.data.length };
+    relationships[`matches.${umbrella.data.length - 1}`] = {
+      links: { self: spliced.id },
+      data: { type: 'card', id: spliced.id },
+    };
   }
 
   test('a singular query-backed field reports the one slot it surfaces, not the whole result set', async function (this: RenderingTestContext, assert) {
@@ -260,6 +296,71 @@ module('Integration | query-field relationship status', function (hooks) {
     assert.strictEqual(status.membership?.length, 1);
     assert.strictEqual(status.totalMatchCount, undefined);
     assert.false(status.isPartial);
+  });
+
+  test('a document fetched after the field resolved hands it the fresher result set', async function (this: RenderingTestContext, assert) {
+    let { getRelationshipMembershipState, updateFromSerialized } = cardApi;
+    let host = await loadHost();
+
+    assert.strictEqual(
+      getRelationshipMembershipState(host, 'matches').membership?.length,
+      2,
+      'the field resolves to the two cards the query matches',
+    );
+
+    // Start from the document the realm actually serves — the server resolves
+    // query fields at read time, so this carries `matches` already resolved —
+    // and splice in a third member. The spliced card claims a name the query
+    // matches, while the copy the realm indexed does not, so a search can never
+    // return it: the field can only hold it if this document put it there. (It
+    // has to claim a matching name because the resource reconciles its result
+    // set against the filter and drops rows that fail it.)
+    let hostDoc = await fetchHostDoc();
+    spliceThirdMember(hostDoc);
+
+    await updateFromSerialized(host as any, hostDoc);
+    await settled();
+
+    let matches = getRelationshipMembershipState(host, 'matches');
+    assert.strictEqual(
+      matches.membership?.length,
+      3,
+      'the newer document supersedes the result set the resource was holding',
+    );
+    assert.true(
+      matches.membership?.some(
+        (member) =>
+          member.kind === 'present' &&
+          member.reference.endsWith('Person/three'),
+      ),
+      'including the card no live search for this query could return',
+    );
+  });
+
+  test('a document that did not resolve the field cannot displace a result set', async function (this: RenderingTestContext, assert) {
+    let { getRelationshipMembershipState, updateFromSerialized } = cardApi;
+    let host = await loadHost();
+
+    // `links.search` is written only where the indexer resolved the field, so
+    // its absence marks a relationship this document is not authoritative
+    // about — a raw source file's own `data`, say. Stripping it while narrowing
+    // the field to a single member makes displacement unmistakable: a field
+    // that took this document's word for its membership would drop to one.
+    let hostDoc = await fetchHostDoc();
+    let relationships = hostDoc.data.relationships;
+    delete relationships.matches.links.search;
+    relationships.matches.data = [relationships.matches.data[0]];
+    relationships.matches.meta = { total: 1 };
+    delete relationships['matches.1'];
+
+    await updateFromSerialized(host as any, hostDoc);
+    await settled();
+
+    assert.strictEqual(
+      getRelationshipMembershipState(host, 'matches').membership?.length,
+      2,
+      'the field keeps the result set the indexer resolved',
+    );
   });
 
   test('a declared linksToMany reports no match count', async function (this: RenderingTestContext, assert) {

--- a/packages/host/tests/integration/components/query-field-membership-status-test.gts
+++ b/packages/host/tests/integration/components/query-field-membership-status-test.gts
@@ -337,6 +337,46 @@ module('Integration | query-field relationship status', function (hooks) {
     );
   });
 
+  test('a document reporting a higher match count refreshes a page-clamped field', async function (this: RenderingTestContext, assert) {
+    let { getRelationshipMembershipState, updateFromSerialized } = cardApi;
+    let host = await loadHost();
+
+    let before = getRelationshipMembershipState(host, 'firstMatch');
+    assert.strictEqual(before.totalMatchCount, 2, 'two matches are reported');
+
+    // `firstMatch` holds one row whatever its query matches, so a match count
+    // that moves leaves its rows and its query URL untouched — the count is the
+    // only thing that changed, and it is what says the rows fall short.
+    let hostDoc = await fetchHostDoc();
+    hostDoc.data.relationships.firstMatch.meta = { total: 3 };
+
+    await updateFromSerialized(host as any, hostDoc);
+    await settled();
+
+    let after = getRelationshipMembershipState(host, 'firstMatch');
+    assert.strictEqual(
+      after.membership?.length,
+      1,
+      'the field still holds the one row its page allowed',
+    );
+    assert.strictEqual(
+      after.totalMatchCount,
+      3,
+      'against the count the newer document reports',
+    );
+    assert.true(after.isPartial, 'so the shortfall is still reported');
+
+    // The field tracks whichever document arrived last rather than latching on
+    // the identities it has seen, so a count that moves back is applied too.
+    await updateFromSerialized(host as any, await fetchHostDoc());
+    await settled();
+    assert.strictEqual(
+      getRelationshipMembershipState(host, 'firstMatch').totalMatchCount,
+      2,
+      'and a document restoring the earlier count is applied in turn',
+    );
+  });
+
   test('a document that did not resolve the field cannot displace a result set', async function (this: RenderingTestContext, assert) {
     let { getRelationshipMembershipState, updateFromSerialized } = cardApi;
     let host = await loadHost();
@@ -361,6 +401,56 @@ module('Integration | query-field relationship status', function (hooks) {
       2,
       'the field keeps the result set the indexer resolved',
     );
+  });
+
+  test('a document reporting an unreachable realm sends the field back to a live query', async function (this: RenderingTestContext, assert) {
+    let { getRelationshipMembershipState, updateFromSerialized } = cardApi;
+    let network = getService('network');
+    let host = await loadHost();
+    assert.strictEqual(
+      getRelationshipMembershipState(host, 'matches').membership?.length,
+      2,
+      'the field resolves from the document without querying',
+    );
+
+    let searchRequests: string[] = [];
+    let spy = async (request: Request) => {
+      if (new URL(request.url).pathname.endsWith('/_federated-search')) {
+        searchRequests.push(request.url);
+      }
+      // Fall through to the realm-server mock.
+      return null;
+    };
+    network.virtualNetwork.mount(spy, { prepend: true });
+    try {
+      // A realm that failed contributes its error and no rows, so what this
+      // document carries is a floor rather than an answer. Resolving from it
+      // and stopping there would leave the field short with nothing scheduled
+      // to correct it.
+      let hostDoc = await fetchHostDoc();
+      let matches = hostDoc.data.relationships.matches;
+      matches.meta = {
+        ...matches.meta,
+        errors: [
+          {
+            realm: 'http://unreachable-realm/test/',
+            type: 'realm-unreachable',
+            message: 'realm did not answer',
+          },
+        ],
+      };
+
+      await updateFromSerialized(host as any, hostDoc);
+      await settled();
+
+      assert.strictEqual(
+        searchRequests.length,
+        1,
+        'the field runs the query the failed realm left unanswered',
+      );
+    } finally {
+      network.virtualNetwork.unmount(spy);
+    }
   });
 
   test('a declared linksToMany reports no match count', async function (this: RenderingTestContext, assert) {

--- a/packages/host/tests/integration/components/query-field-membership-status-test.gts
+++ b/packages/host/tests/integration/components/query-field-membership-status-test.gts
@@ -315,24 +315,38 @@ module('Integration | query-field relationship status', function (hooks) {
       'the field resolves to the two cards the query matches',
     );
 
+    assert.strictEqual(
+      getRelationshipMembershipState(host, 'matches').totalMatchCount,
+      2,
+      'and reports the count the indexer resolved it under',
+    );
+
     // Start from the document the realm actually serves — the server resolves
     // query fields at read time, so this carries `matches` already resolved —
-    // and splice in a third member. The spliced card claims a name the query
-    // matches, while the copy the realm indexed does not, so a search can never
-    // return it: the field can only hold it if this document put it there. (It
-    // has to claim a matching name because the resource reconciles its result
-    // set against the filter and drops rows that fail it.)
+    // and splice in a third member.
     let hostDoc = await fetchHostDoc();
     spliceThirdMember(hostDoc);
 
     await updateFromSerialized(host as any, hostDoc);
     await settled();
 
+    // The count is what proves the document reached the resource. Membership
+    // cannot: deserializing the document deposits the spliced member in the
+    // store, and a live search's result set is reconciled against store
+    // residency, so the client-side merge adds a resident matching card to the
+    // displayed set whether or not anything superseded the result set. The
+    // match count comes off the resource's own meta, which only an applied
+    // result set moves.
     let matches = getRelationshipMembershipState(host, 'matches');
+    assert.strictEqual(
+      matches.totalMatchCount,
+      3,
+      'the newer document supersedes the result set the resource was holding',
+    );
     assert.strictEqual(
       matches.membership?.length,
       3,
-      'the newer document supersedes the result set the resource was holding',
+      'and the field surfaces all three members',
     );
     assert.true(
       matches.membership?.some(
@@ -340,7 +354,7 @@ module('Integration | query-field relationship status', function (hooks) {
           member.kind === 'present' &&
           member.reference.endsWith('Person/three'),
       ),
-      'including the card no live search for this query could return',
+      'including the one the document introduced',
     );
   });
 
@@ -384,6 +398,45 @@ module('Integration | query-field relationship status', function (hooks) {
     );
   });
 
+  test('a document resolved before the result set the field holds is declined', async function (this: RenderingTestContext, assert) {
+    let { getRelationshipMembershipState, updateFromSerialized } = cardApi;
+    let host = await loadHost();
+
+    // Derived from whatever the realm stamped, so the two documents order
+    // against each other and against the one the field already resolved from,
+    // whether or not this harness stamps a generation at all.
+    let hostDoc = await fetchHostDoc();
+    let newerGeneration = (hostDoc.data.meta.generation ?? 0) + 10;
+    hostDoc.data.meta.generation = newerGeneration;
+    spliceThirdMember(hostDoc);
+    await updateFromSerialized(host as any, hostDoc);
+    await settled();
+    assert.strictEqual(
+      getRelationshipMembershipState(host, 'matches').totalMatchCount,
+      3,
+      'the field holds the set that document resolved',
+    );
+
+    // A read that was already in flight when the newer one landed. It is not
+    // news, and taking it would walk the field backwards — the failure the
+    // handover has to avoid, because it has no other way to tell a document
+    // that arrived late from one that resolved late.
+    let staleDoc = await fetchHostDoc();
+    staleDoc.data.meta.generation = newerGeneration - 1;
+
+    await updateFromSerialized(host as any, staleDoc);
+    await settled();
+
+    assert.strictEqual(
+      getRelationshipMembershipState(host, 'matches').totalMatchCount,
+      3,
+      'the older document does not displace it',
+    );
+  });
+
+  // Guards the gate rather than the handover: it holds trivially where nothing
+  // is handed over at all, and its job is to catch a gate that stops requiring
+  // an indexer-resolved umbrella.
   test('a document that did not resolve the field cannot displace a result set', async function (this: RenderingTestContext, assert) {
     let { getRelationshipMembershipState, updateFromSerialized } = cardApi;
     let host = await loadHost();

--- a/packages/host/tests/integration/components/query-field-membership-status-test.gts
+++ b/packages/host/tests/integration/components/query-field-membership-status-test.gts
@@ -125,9 +125,16 @@ module('Integration | query-field relationship status', function (hooks) {
   // contradicting itself.
   function spliceThirdMember(hostDoc: any): void {
     let relationships = hostDoc.data.relationships;
-    let template = hostDoc.included.find((resource: { id: string }) =>
+    let template = hostDoc.included?.find((resource: { id: string }) =>
       resource.id.endsWith('Person/one'),
     );
+    if (!template) {
+      throw new Error(
+        `expected the host document to carry Person/one as a resolved member of 'matches'; included ids were ${JSON.stringify(
+          (hostDoc.included ?? []).map((r: { id: string }) => r.id),
+        )}`,
+      );
+    }
     let spliced = JSON.parse(JSON.stringify(template));
     spliced.id = template.id.replace('Person/one', 'Person/three');
     hostDoc.included.push(spliced);


### PR DESCRIPTION
## What this changes

A query-backed field's search resource is created once per (instance, field). `getSearch` captures its `seed` argument at creation and the resource latches after applying it, so a refetched owner — whose document carries the field resolved by the server at read time — updated `fieldState` and reached the resource with nothing.

A resolved result set now carries an identity and an index generation, and a document arriving for the owner offers that set to the running resource through a new `SearchResource.reseed`.

## Why this shape

**Two axes, two questions.** The identity says whether two result sets differ at all; the generation says which of them is newer. Keeping them separate is deliberate: a realm generation moves on every write anywhere in the realm, so folding it into the identity would make every set look different from every other and re-apply answers that had not changed.

**Ordering, not arrival.** Without it the last arrival wins, which loses a completed search to a document resolved before it: the owner is reindexed and its reload issued, a second write lands and the field's own search answers it, then the first document arrives carrying membership from before that write.

A generation counts writes within one realm — `realm_generations` is per `realm_url` — so the floor is kept per realm. A search raises the floor of the realm whose event woke it; a document carries `meta.generation` together with the `meta.realmURL` that generation counts writes in; the comparison happens within one realm. Keyed globally instead, a query whose realms differ from its owner's would compare two unrelated sequences, and whichever ran ahead would decide every handover for that field — declining all of them or none, the first of which would kill the handover for precisely the field that has no other refresh. Each floor only ever rises, so a set whose generation cannot be established keeps the floor already established: that refuses a fresh document at worst, where the other direction lets a stale one through. Where either the realm or the generation is absent, the identity decides alone.

Both sides are floors rather than exact resolution generations. A search reads the index at or after the event that woke it. A document is stamped with the generation its owner's row was written at, which the field's own membership never advances — dependencies reached only through a query context are left out of that row's deps, so a matching card changing never rewrites the owner. Both err toward declining a document that is in fact fresh, which costs a refresh rather than correctness. Making the document side exact means stamping the resolution's own generation on the umbrella relationship where the indexer resolves it. A search driven by a query change rather than an event has no generation to stamp and leaves the floors where they were.

**Two gates decide whether an offer is taken.** The outer one is the document: `captureQueryFieldSeedData` marks a handover pending and the first read that acts on it spends the mark, so the offer belongs to a document arriving rather than to a field being read — without it, a plain read would hand the last document's answer back over a fresher set. The inner one is the identity, read off the resource rather than remembered by the caller, because a remembered value would go on claiming a set a search had replaced and would then turn away the document that corrects it. It deliberately survives a *failed* search: a failure computed nothing, so what a document last asserted is still the last thing anyone asserted, and clearing it would let the next read reinstate those rows and with them clear the error the failure is reporting.

**The identity covers everything the seed asserts, not just its rows.** A page-clamped field gains a match it cannot surface and reports the same row against a higher total; a realm that stops answering leaves the rows it did contribute while turning the total into a floor. Identifying by rows alone calls both of those the answer already in hand, and leaves the field reporting a shortfall of none. So it is the resolved query, its ids, the reported total, and the realms that failed — and only an indexer-resolved umbrella (`links.search`, written nowhere else) gets one at all, so a raw source document can never displace a real answer.

**An offer a realm failure cut short sends the field back to a live query.** Its rows are a floor, not an answer. The initial seed reaches a query for this case by leaving the query signature unset and falling through to `modify`'s search, but nothing brings a *running* resource back through that fall-through — its query and realms are unchanged, so the next `modify` skips. `reseed` runs that query directly, and only when live, matching the initial seed's refusal to query inside a prerender.

**An in-flight application is bound to the identity it was handed over as.** `applySeed` runs unbounded, so two documents arriving close together resolve their rows concurrently and whichever finishes last wins; since the resource records the newest identity synchronously, the loser could leave it holding an older answer under a newer identity. Each run re-checks before mutating and abandons otherwise. Not by making the task restartable: `updateInstances` splices `_instances` synchronously and reconciles store references only after awaiting each row's hydration, so a cancellation between the two leaves rows nothing holds a reference for — and the next run diffs against that already-spliced array, so those rows never get one.

**One function builds the seed for both paths.** Resource creation and the handover share `queryFieldSeed`, so both describe the same set the same way. The count ladder in it (an indexer-reported total, else a floor labelled incomplete when a realm failed, else explicitly unknowable) is what the field's shortfall signal reads.

**Where this earns its keep.** For a same-realm query field the owner's index event refreshes the field by search anyway, and the handover is a free head start — the document already paid for the resolution. It is the *only* refresh when the resource never subscribed to the realm the write landed in (a query whose `realms` set excludes the owner's realm), or when the subscription missed the event.

The seed shape is an exported `StoreSearchSeed<T>`, generic in the row type and threaded through `GetSearchResourceFuncOpts<T>`, so a `FileDef` search seeds with file-meta rows instead of being pinned to `CardDef`.

## Scope

`displayedInstances` still reconciles a handed-over set against the filter and against store residency, exactly as it does a searched one. That reconciliation is also why the tests below assert on the match count rather than on membership — see the test plan.

Left as follow-ups: giving the seed shape one home (`StoreSearchSeed<T> & { errors?: ErrorEntry[] }`) instead of the four copies it is spelled in today, and the server-side stamp that would make the document's generation exact.

## Test plan

`packages/host/tests/integration/components/query-field-membership-status-test.gts`:

- **a document fetched after the field resolved hands it the fresher result set** — starts from the document the realm actually serves and splices in a third member, spelled the way the realm spells the others. The load-bearing assertion is `totalMatchCount` moving 2 → 3: membership cannot carry this test, because deserializing the document deposits the spliced member in the store (`setCardNonTracked` → `makeTracked`) and the client-side merge then adds a resident matching card to the displayed set whether or not anything was superseded. The count comes off the resource's own meta, which only an applied result set moves.
- **a document reporting a higher match count refreshes a page-clamped field** — `firstMatch` holds its one row while the count moves to the document's 3 and `isPartial` stays true, then back to 2 on a document restoring the earlier count. Bypasses the merge entirely (`total !== _instances.length` makes it ineligible). The second leg fails if the identity is treated as a one-way latch.
- **a document resolved before the result set the field holds is declined** — two documents with derived generations; the older one does not walk the count back.
- **a document reporting an unreachable realm sends the field back to a live query** — counts `_federated-search` requests across the handover: zero for a document that resolved cleanly, one for a document naming a realm that did not answer.
- **a document that did not resolve the field cannot displace a result set** — guards the gate rather than the handover: it holds trivially where nothing is handed over, and its job is to catch a gate that stops requiring an indexer-resolved umbrella.

Not covered: the cross-realm ordering case, which needs a second realm in the fixture — the ordering test above is same-realm, so what is untested is specifically that a different realm's floor no longer interferes. Nor the path where a completed search clears the applied identity and a later document restores the set the search moved off; reaching it needs realm-event delivery to move the resource mid-test, and every framing collided with the reconciliation above.

Isolating the handover end-to-end needs a shape the current specs don't have: owner in realm A, targets in realm B, the field's query scoped to B so the resource subscribes to B only; resolve the field, block the client's search endpoints, add a matching target in B, then write the owner in A. No event reaches B so no search fires, while the store still refetches the owner's document from A with the field resolved.

**Not run in this environment**: the host suite needs the realm servers, and this session's network policy blocks the container registry the dev stack's Postgres/Synapse come from. Verified here: `ember-tsc --noEmit` clean for `@cardstack/host` (which compiles the changed `packages/base` files), prettier and eslint clean on the changed files. CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FH1ee2ghdpunvh13cdtq9p
