### PR TITLE
Drop the prerender app's persistence block on the command route

### DIFF
--- a/packages/host/app/routes/command-runner.ts
+++ b/packages/host/app/routes/command-runner.ts
@@ -93,13 +93,23 @@ export default class CommandRunnerRoute extends Route<CommandRunnerModel> {
     // tests also raise around in-browser index renders that run alongside an
     // interactive app whose saves must keep their indexed echo.
     (globalThis as any).__boxelHeadlessCommand = true;
-    // A command writes, so the prerender app's blanket persistence block must
-    // not be in force on this route. The pool can retag a tab that has served
-    // a card render onto a command affinity, and the render route is left by
-    // an in-app transition whose exit hooks run *after* this hook — so this
-    // route drops the flag itself rather than relying on the departing route's
-    // teardown to have already run. Writes from here stay deadlock-safe
-    // through `__boxelHeadlessCommand`, which indexes them deferred.
+    // `__boxelPrerenderApp` marks the app as the dedicated prerender app for
+    // its whole lifetime, and blocks persistence on every store while it is
+    // raised (see `renderContextBlocksPersistence`). This route is the one
+    // exception: a command is expected to write, and its writes are
+    // deadlock-safe through the deferred indexing `__boxelHeadlessCommand`
+    // asks for. So drop the block here rather than leave it standing.
+    //
+    // It has to be dropped rather than merely never raised: a pool tab that
+    // has served a card render carries the flag, and the pool can retag that
+    // tab from its realm affinity onto the user affinity a command runs on.
+    // Under the block a command's save resolves to an instance with no id,
+    // which every caller reads as success.
+    //
+    // Deliberately not restored on teardown. The render route raises the flag
+    // itself in `beforeModel`, and that hook runs before the exit hooks of
+    // the route being left — so a restore of a never-raised value would lower
+    // the block for the whole of the next render's model hook.
     (globalThis as any).__boxelPrerenderApp = undefined;
     registerDestructor(this, () => {
       (globalThis as any).__boxelHeadlessCommand = undefined;

--- a/packages/host/app/routes/command-runner.ts
+++ b/packages/host/app/routes/command-runner.ts
@@ -93,6 +93,14 @@ export default class CommandRunnerRoute extends Route<CommandRunnerModel> {
     // tests also raise around in-browser index renders that run alongside an
     // interactive app whose saves must keep their indexed echo.
     (globalThis as any).__boxelHeadlessCommand = true;
+    // A command writes, so the prerender app's blanket persistence block must
+    // not be in force on this route. The pool can retag a tab that has served
+    // a card render onto a command affinity, and the render route is left by
+    // an in-app transition whose exit hooks run *after* this hook — so this
+    // route drops the flag itself rather than relying on the departing route's
+    // teardown to have already run. Writes from here stay deadlock-safe
+    // through `__boxelHeadlessCommand`, which indexes them deferred.
+    (globalThis as any).__boxelPrerenderApp = undefined;
     registerDestructor(this, () => {
       (globalThis as any).__boxelHeadlessCommand = undefined;
       if (isTesting()) {

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -199,6 +199,14 @@ export default class RenderRoute extends Route<Model> {
     (globalThis as any).__boxelRenderStageSetAt = undefined;
     (globalThis as any).__boxelRenderDiagnostics = undefined;
     (globalThis as any).__waitForRenderLoadStability = undefined;
+    // `__boxelPrerenderApp` lives exactly as long as this route is entered.
+    // `beforeModel` raises it again ahead of every visit's model work, so no
+    // render ever runs without the persistence block in force; bounding it
+    // here is what keeps a tab that leaves the render tree from carrying the
+    // block into work that must write. A prerender pool tab can be retagged
+    // from a realm affinity onto a command affinity, and a store still
+    // holding this flag discards every write it is handed.
+    (globalThis as any).__boxelPrerenderApp = undefined;
     this.#detachWindowErrorListeners();
     this.lastStoreResetKey = undefined;
     this.renderBaseParams = undefined;
@@ -986,6 +994,7 @@ export default class RenderRoute extends Route<Model> {
       (globalThis as any).__renderModel = undefined;
       (globalThis as any).__boxelRenderCapturedDeps = undefined;
       (globalThis as any).__docsInFlight = undefined;
+      (globalThis as any).__boxelPrerenderApp = undefined;
       (globalThis as any).__waitForRenderLoadStability = undefined;
       (globalThis as any).__boxelLastAttemptedRenderCardId = undefined;
     });

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -199,14 +199,6 @@ export default class RenderRoute extends Route<Model> {
     (globalThis as any).__boxelRenderStageSetAt = undefined;
     (globalThis as any).__boxelRenderDiagnostics = undefined;
     (globalThis as any).__waitForRenderLoadStability = undefined;
-    // `__boxelPrerenderApp` lives exactly as long as this route is entered.
-    // `beforeModel` raises it again ahead of every visit's model work, so no
-    // render ever runs without the persistence block in force; bounding it
-    // here is what keeps a tab that leaves the render tree from carrying the
-    // block into work that must write. A prerender pool tab can be retagged
-    // from a realm affinity onto a command affinity, and a store still
-    // holding this flag discards every write it is handed.
-    (globalThis as any).__boxelPrerenderApp = undefined;
     this.#detachWindowErrorListeners();
     this.lastStoreResetKey = undefined;
     this.renderBaseParams = undefined;
@@ -994,7 +986,6 @@ export default class RenderRoute extends Route<Model> {
       (globalThis as any).__renderModel = undefined;
       (globalThis as any).__boxelRenderCapturedDeps = undefined;
       (globalThis as any).__docsInFlight = undefined;
-      (globalThis as any).__boxelPrerenderApp = undefined;
       (globalThis as any).__waitForRenderLoadStability = undefined;
       (globalThis as any).__boxelLastAttemptedRenderCardId = undefined;
     });

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -242,6 +242,15 @@ export default class RenderRoute extends Route<Model> {
     // activate() doesn't run early enough for this to be set before the model()
     // hook is run
     (globalThis as any).__boxelRenderContext = true;
+    // A render is never a headless command. The command route raises
+    // `__boxelHeadlessCommand` and drops it in its own teardown, but a
+    // transition runs the entering route's model hooks before the departing
+    // route's exit hooks — so a tab arriving here from the command route
+    // still carries the flag through this render's model hook. Clearing it
+    // keeps a render's writes from being marked for deferred indexing, and
+    // keeps a card that writes while rendering on the store's drop path
+    // rather than its report-a-stuck-command path.
+    (globalThis as any).__boxelHeadlessCommand = undefined;
     this.#registerGlobalsDestructor();
     this.#authGuard.register();
     if (!isTesting()) {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -832,7 +832,6 @@ export default class StoreService extends Service implements StoreInterface {
       } as CardResourceMeta;
     }
 
-    // A caller that asked the prerender app to persist gets an error rather
     // A headless command running while the prerender app's persistence block
     // is still raised is an impossible state, and the only one this path
     // reports rather than absorbs. The command route drops the block on entry
@@ -840,8 +839,7 @@ export default class StoreService extends Service implements StoreInterface {
     // save resolves to an instance carrying no id, `SaveCardTool` returns it
     // as saved, and every caller downstream — `boxel run-command` included —
     // reads a card that does not exist as a success. `create` already throws
-    // on the same state. Raised before the instance is registered, so a
-    // failed `add` leaves nothing resident.
+    // on the same state.
     //
     // A card render is deliberately NOT an error. The prerenderer is not an
     // avenue for mutations, and a card whose template or computed writes to

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -339,6 +339,11 @@ export default class StoreService extends Service implements StoreInterface {
     // store on __boxelRenderContext alone breaks it: card-prerender sets that
     // global around every test-realm index render, silently dropping app saves
     // that coincide with one.
+    //
+    // The command-runner route is the one place in the prerender app that
+    // drops `__boxelPrerenderApp`, because a command is expected to write and
+    // its writes index deferred rather than waiting on the worker the tab is
+    // holding.
     if ((globalThis as any).__boxelPrerenderApp) {
       return true;
     }
@@ -827,6 +832,28 @@ export default class StoreService extends Service implements StoreInterface {
       } as CardResourceMeta;
     }
 
+    // A caller that asked the prerender app to persist gets an error rather
+    // than the unpersisted instance. An instance handed back with no id is
+    // indistinguishable from a saved one — `SaveCardTool` reports it as a
+    // success — so returning it makes a blocked write a wrong answer instead
+    // of a failure, which is what lets a mis-marked tab answer a card-saving
+    // command with a card that does not exist. `create` already throws on the
+    // same state; `patch` reports a blocked write as `undefined`, which its
+    // callers already branch on. Thrown before the instance is registered so
+    // a failed `add` leaves nothing resident.
+    //
+    // Scoped to the prerender app rather than to every blocked context: host
+    // tests and the interactive app run in-browser index renders whose render
+    // store is blocked too, and a card that writes while rendering there has
+    // always had that write dropped rather than failing its render.
+    if (!opts?.doNotPersist && (globalThis as any).__boxelPrerenderApp) {
+      throw new Error(
+        `cannot persist instance ${
+          instance.id ?? instance[localIdSymbol]
+        }: persistence is blocked in the prerender app`,
+      );
+    }
+
     let maybeOldInstance = instance.id
       ? this.store.getCard(instance.id)
       : undefined;
@@ -838,19 +865,6 @@ export default class StoreService extends Service implements StoreInterface {
     await this.startAutoSaving(instance);
 
     if (this.renderContextBlocksPersistence()) {
-      // A caller that asked for persistence gets an error rather than the
-      // unpersisted instance. An instance handed back with no id is
-      // indistinguishable from a saved one — `SaveCardTool` reports it as a
-      // success — so returning it turns a blocked write into a wrong answer
-      // instead of a failure. Only `doNotPersist` callers wanted the
-      // in-memory instance, and they still get it.
-      if (!opts?.doNotPersist) {
-        throw new Error(
-          `cannot persist instance ${
-            instance.id ?? instance[localIdSymbol]
-          }: persistence is blocked in this render context`,
-        );
-      }
       return instance;
     }
 
@@ -2067,6 +2081,10 @@ export default class StoreService extends Service implements StoreInterface {
   // deliberately not part of the test — card-prerender sets it around index
   // renders that run alongside an interactive app, whose own query fields must
   // keep resolving through those windows.
+  //
+  // A command runs with `__boxelPrerenderApp` dropped, so its query fields do
+  // resolve eagerly — matching what a command gets on a tab that has never
+  // served a render.
   protected resolvesQueryFieldsEagerly(): boolean {
     if ((globalThis as any).__boxelPrerenderApp) {
       return false;

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -833,24 +833,31 @@ export default class StoreService extends Service implements StoreInterface {
     }
 
     // A caller that asked the prerender app to persist gets an error rather
-    // than the unpersisted instance. An instance handed back with no id is
-    // indistinguishable from a saved one — `SaveCardTool` reports it as a
-    // success — so returning it makes a blocked write a wrong answer instead
-    // of a failure, which is what lets a mis-marked tab answer a card-saving
-    // command with a card that does not exist. `create` already throws on the
-    // same state; `patch` reports a blocked write as `undefined`, which its
-    // callers already branch on. Thrown before the instance is registered so
-    // a failed `add` leaves nothing resident.
+    // A headless command running while the prerender app's persistence block
+    // is still raised is an impossible state, and the only one this path
+    // reports rather than absorbs. The command route drops the block on entry
+    // precisely so a command's writes can land; with the block still up the
+    // save resolves to an instance carrying no id, `SaveCardTool` returns it
+    // as saved, and every caller downstream — `boxel run-command` included —
+    // reads a card that does not exist as a success. `create` already throws
+    // on the same state. Raised before the instance is registered, so a
+    // failed `add` leaves nothing resident.
     //
-    // Scoped to the prerender app rather than to every blocked context: host
-    // tests and the interactive app run in-browser index renders whose render
-    // store is blocked too, and a card that writes while rendering there has
-    // always had that write dropped rather than failing its render.
-    if (!opts?.doNotPersist && (globalThis as any).__boxelPrerenderApp) {
+    // A card render is deliberately NOT an error. The prerenderer is not an
+    // avenue for mutations, and a card whose template or computed writes to
+    // the store is doing what it was designed to do — it just cannot have
+    // that write here, because it would aim at a realm whose sole indexing
+    // worker this render is occupying. Dropping the write renders the card;
+    // throwing would fail the render and index the card as an error.
+    if (
+      !opts?.doNotPersist &&
+      (globalThis as any).__boxelPrerenderApp &&
+      (globalThis as any).__boxelHeadlessCommand
+    ) {
       throw new Error(
         `cannot persist instance ${
           instance.id ?? instance[localIdSymbol]
-        }: persistence is blocked in the prerender app`,
+        }: a headless command is running with the prerender app's persistence block still raised`,
       );
     }
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -838,6 +838,19 @@ export default class StoreService extends Service implements StoreInterface {
     await this.startAutoSaving(instance);
 
     if (this.renderContextBlocksPersistence()) {
+      // A caller that asked for persistence gets an error rather than the
+      // unpersisted instance. An instance handed back with no id is
+      // indistinguishable from a saved one — `SaveCardTool` reports it as a
+      // success — so returning it turns a blocked write into a wrong answer
+      // instead of a failure. Only `doNotPersist` callers wanted the
+      // in-memory instance, and they still get it.
+      if (!opts?.doNotPersist) {
+        throw new Error(
+          `cannot persist instance ${
+            instance.id ?? instance[localIdSymbol]
+          }: persistence is blocked in this render context`,
+        );
+      }
       return instance;
     }
 

--- a/packages/host/tests/acceptance/prerender-persistence-block-test.gts
+++ b/packages/host/tests/acceptance/prerender-persistence-block-test.gts
@@ -29,16 +29,18 @@ import {
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
 
-// `__boxelPrerenderApp` is the prerender app's blanket persistence block: while
-// it is raised, every store in the app drops writes rather than aiming them at
-// a realm whose sole indexing worker the render is occupying. The render route
-// raises it, and its lifetime is bounded by that route being entered.
+// `__boxelPrerenderApp` marks the dedicated prerender app for its whole
+// lifetime, and blocks persistence on every store in it: a write from a render
+// would aim at a realm whose sole indexing worker that render is occupying.
+// The command route is the one place that drops the block, because a command is
+// expected to write and its writes index deferred.
 //
-// A prerender pool tab can be retagged from a realm affinity onto a user
-// affinity, and it enters the command route through an in-app transition — so
-// the app carries across whatever globals the render left behind. Commands
-// write, which makes that hand-off the case worth pinning: a command running
-// under the block answers with a card that was never saved.
+// Dropping it matters — rather than simply never raising it — because a pool
+// tab that has served a card render carries the flag, and the pool can retag
+// that tab from its realm affinity onto the user affinity commands run on. The
+// tab then enters the command route through an in-app transition, so the app
+// keeps whatever globals the render left behind, and a command running under
+// the block answers with a card that was never saved.
 //
 // Outside tests the render route raises the flag itself. Here it is raised by
 // hand, because these tests also run an interactive app whose own saves the
@@ -58,20 +60,18 @@ module('Acceptance | prerender | persistence block', function (hooks) {
     JSON.stringify({ clearCache: true } as RenderRouteOptions),
   );
 
+  // The prerender driver always hands the render route the card's `.json` file
+  // URL, so render against that rather than the extensionless id.
   async function renderCard(id: string) {
     await visit(
       `/render/${encodeURIComponent(
-        id,
+        `${id}.json`,
       )}/0/${RENDER_OPTIONS_SEGMENT}/html/isolated/0`,
     );
     return await capturePrerenderResult('textContent');
   }
 
-  function setCommandRunnerRequest(
-    requestId: string,
-    nonce: string,
-    command: string,
-  ) {
+  function runCommand(requestId: string, nonce: string, command: string) {
     window.localStorage.setItem(
       `boxel-command-request:${requestId}`,
       JSON.stringify({
@@ -81,6 +81,7 @@ module('Acceptance | prerender | persistence block', function (hooks) {
         createdAt: Date.now(),
       }),
     );
+    return visit(`/command-runner/${requestId}/${nonce}`);
   }
 
   function raisePersistenceBlock() {
@@ -143,31 +144,31 @@ module('Acceptance | prerender | persistence block', function (hooks) {
     delete (globalThis as any).__boxelPrerenderApp;
   });
 
-  test('the block does not outlive the render route', async function (assert) {
+  test('entering the command route drops the block', async function (assert) {
     raisePersistenceBlock();
-    let { value } = await renderCard(`${testRealmURL}Pet/mango`);
-    assert.true(value.includes('Mango'), 'the card rendered');
+    await runCommand(
+      'prerender-persistence-block-drop',
+      '1',
+      `${testRealmURL}save-pet-command/default`,
+    );
 
-    await visit('/_standby');
     assert.strictEqual(
       (globalThis as any).__boxelPrerenderApp,
       undefined,
-      'leaving the render route drops the persistence block',
+      'the command route drops the persistence block on entry',
     );
   });
 
   test('a command saves a durable card on a tab that has served a card render', async function (assert) {
     raisePersistenceBlock();
-    await renderCard(`${testRealmURL}Pet/mango`);
+    let { value } = await renderCard(`${testRealmURL}Pet/mango`);
+    assert.true(value.includes('Mango'), 'the card rendered');
 
-    let requestId = 'prerender-persistence-block-save';
-    let nonce = '1';
-    setCommandRunnerRequest(
-      requestId,
-      nonce,
+    await runCommand(
+      'prerender-persistence-block-save',
+      '1',
       `${testRealmURL}save-pet-command/default`,
     );
-    await visit(`/command-runner/${requestId}/${nonce}`);
     await waitFor('[data-prerender][data-prerender-status="ready"]');
 
     let savedId =
@@ -177,16 +178,19 @@ module('Acceptance | prerender | persistence block', function (hooks) {
       savedId.startsWith(testRealmURL),
       `the save came back with a realm id: ${savedId || '<empty>'}`,
     );
-
     // Read the realm's own source rather than the store, so a card that only
-    // ever existed in memory cannot satisfy this.
-    let source = await getService('card-service').getSource(
-      new URL(`${savedId}.json`),
-    );
-    assert.strictEqual(source.status, 200, 'the saved card is durable');
-    assert.true(
-      source.content.includes('Ringo'),
-      'the durable document holds what the command wrote',
-    );
+    // ever existed in memory cannot satisfy this. Guarded on a non-empty id:
+    // a blocked save yields none, and the read would then fail on URL parsing
+    // instead of on the assertion above that explains why.
+    if (savedId) {
+      let source = await getService('card-service').getSource(
+        new URL(`${savedId}.json`),
+      );
+      assert.strictEqual(source.status, 200, 'the saved card is durable');
+      assert.true(
+        source.content.includes('Ringo'),
+        'the durable document holds what the command wrote',
+      );
+    }
   });
 });

--- a/packages/host/tests/acceptance/prerender-persistence-block-test.gts
+++ b/packages/host/tests/acceptance/prerender-persistence-block-test.gts
@@ -1,0 +1,192 @@
+import { visit, waitFor } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import { Command, type RenderRouteOptions } from '@cardstack/runtime-common';
+
+import SaveCardTool from '@cardstack/host/tools/save-card';
+
+import {
+  capturePrerenderResult,
+  setupLocalIndexing,
+  setupOnSave,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+} from '../helpers';
+
+import {
+  CardDef,
+  Component,
+  contains,
+  field,
+  setupBaseRealm,
+  StringField,
+} from '../helpers/base-realm';
+
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+// `__boxelPrerenderApp` is the prerender app's blanket persistence block: while
+// it is raised, every store in the app drops writes rather than aiming them at
+// a realm whose sole indexing worker the render is occupying. The render route
+// raises it, and its lifetime is bounded by that route being entered.
+//
+// A prerender pool tab can be retagged from a realm affinity onto a user
+// affinity, and it enters the command route through an in-app transition — so
+// the app carries across whatever globals the render left behind. Commands
+// write, which makes that hand-off the case worth pinning: a command running
+// under the block answers with a card that was never saved.
+//
+// Outside tests the render route raises the flag itself. Here it is raised by
+// hand, because these tests also run an interactive app whose own saves the
+// flag would swallow.
+module('Acceptance | prerender | persistence block', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+
+  setupBaseRealm(hooks);
+
+  const RENDER_OPTIONS_SEGMENT = encodeURIComponent(
+    JSON.stringify({ clearCache: true } as RenderRouteOptions),
+  );
+
+  async function renderCard(id: string) {
+    await visit(
+      `/render/${encodeURIComponent(
+        id,
+      )}/0/${RENDER_OPTIONS_SEGMENT}/html/isolated/0`,
+    );
+    return await capturePrerenderResult('textContent');
+  }
+
+  function setCommandRunnerRequest(
+    requestId: string,
+    nonce: string,
+    command: string,
+  ) {
+    window.localStorage.setItem(
+      `boxel-command-request:${requestId}`,
+      JSON.stringify({
+        command,
+        input: null,
+        nonce,
+        createdAt: Date.now(),
+      }),
+    );
+  }
+
+  function raisePersistenceBlock() {
+    (globalThis as any).__boxelPrerenderApp = true;
+  }
+
+  hooks.beforeEach(async function () {
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field name = contains(StringField);
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <h2 data-test-pet><@fields.name /></h2>
+        </template>
+      };
+    }
+
+    class SavePetResult extends CardDef {
+      static displayName = 'SavePetResult';
+      @field savedId = contains(StringField);
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <span data-test-saved-pet-id><@fields.savedId /></span>
+        </template>
+      };
+    }
+
+    // Reports the id its save came back with, so a dropped write is
+    // distinguishable from a durable one: an instance handed back from a
+    // blocked store carries no id, which reads as success to every caller.
+    class SavePetCommand extends Command<undefined, typeof SavePetResult> {
+      static displayName = 'SavePetCommand';
+      async getInputType() {
+        return undefined;
+      }
+      protected async run(): Promise<SavePetResult> {
+        let saved = await new SaveCardTool(this.toolContext).execute({
+          card: new Pet({ name: 'Ringo' }),
+          realm: testRealmURL,
+        });
+        return new SavePetResult({ savedId: saved?.id ?? '' });
+      }
+    }
+
+    await setupAcceptanceTestRealm({
+      mockMatrixUtils,
+      contents: {
+        ...SYSTEM_CARD_FIXTURE_CONTENTS,
+        'pet.gts': { Pet },
+        'Pet/mango.json': new Pet({ name: 'Mango' }),
+        'save-pet-command.gts': {
+          SavePetResult,
+          default: SavePetCommand,
+        },
+      },
+    });
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__boxelPrerenderApp;
+  });
+
+  test('the block does not outlive the render route', async function (assert) {
+    raisePersistenceBlock();
+    let { value } = await renderCard(`${testRealmURL}Pet/mango`);
+    assert.true(value.includes('Mango'), 'the card rendered');
+
+    await visit('/_standby');
+    assert.strictEqual(
+      (globalThis as any).__boxelPrerenderApp,
+      undefined,
+      'leaving the render route drops the persistence block',
+    );
+  });
+
+  test('a command saves a durable card on a tab that has served a card render', async function (assert) {
+    raisePersistenceBlock();
+    await renderCard(`${testRealmURL}Pet/mango`);
+
+    let requestId = 'prerender-persistence-block-save';
+    let nonce = '1';
+    setCommandRunnerRequest(
+      requestId,
+      nonce,
+      `${testRealmURL}save-pet-command/default`,
+    );
+    await visit(`/command-runner/${requestId}/${nonce}`);
+    await waitFor('[data-prerender][data-prerender-status="ready"]');
+
+    let savedId =
+      document.querySelector('[data-test-saved-pet-id]')?.textContent?.trim() ??
+      '';
+    assert.ok(
+      savedId.startsWith(testRealmURL),
+      `the save came back with a realm id: ${savedId || '<empty>'}`,
+    );
+
+    // Read the realm's own source rather than the store, so a card that only
+    // ever existed in memory cannot satisfy this.
+    let source = await getService('card-service').getSource(
+      new URL(`${savedId}.json`),
+    );
+    assert.strictEqual(source.status, 200, 'the saved card is durable');
+    assert.true(
+      source.content.includes('Ringo'),
+      'the durable document holds what the command wrote',
+    );
+  });
+});

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -607,6 +607,31 @@ module('Integration | Store', function (hooks) {
     }
   });
 
+  test('adding an instance for persistence errors while persistence is blocked', async function (assert) {
+    // The prerender app raises `__boxelPrerenderApp` to block every store's
+    // writes. An instance handed back from that block carries no id, which is
+    // indistinguishable from a saved one to every caller — so a caller that
+    // asked for persistence gets an error instead, and only a `doNotPersist`
+    // caller gets the in-memory instance it asked for.
+    (globalThis as any).__boxelPrerenderApp = true;
+    try {
+      await assert.rejects(
+        storeService.add(new PersonDef({ name: 'Andrea' })),
+        /persistence is blocked/,
+        'a persisting add reports the blocked write',
+      );
+
+      let instance = new PersonDef({ name: 'Mango' });
+      assert.strictEqual(
+        await storeService.add(instance, { doNotPersist: true }),
+        instance,
+        'a memory-only add is served as asked',
+      );
+    } finally {
+      delete (globalThis as any).__boxelPrerenderApp;
+    }
+  });
+
   test('restoring sessions from storage skips the re-walk when the session blob is unchanged', function (assert) {
     // `restoreSessionsFromStorage` is synchronous, so the walk-count delta
     // measured immediately around each call is exactly that call's work — other

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -607,27 +607,38 @@ module('Integration | Store', function (hooks) {
     }
   });
 
-  test('adding an instance for persistence errors while persistence is blocked', async function (assert) {
-    // The prerender app raises `__boxelPrerenderApp` to block every store's
-    // writes. An instance handed back from that block carries no id, which is
-    // indistinguishable from a saved one to every caller — so a caller that
-    // asked for persistence gets an error instead, and only a `doNotPersist`
-    // caller gets the in-memory instance it asked for.
+  test('a card render absorbs a blocked write, a headless command reports it', async function (assert) {
+    // `__boxelPrerenderApp` blocks every store's writes in the prerender app.
+    // A card render absorbs the block: the prerenderer is not an avenue for
+    // mutations, so a card that writes from a template or computed still
+    // renders, with the write dropped.
     (globalThis as any).__boxelPrerenderApp = true;
     try {
-      await assert.rejects(
-        storeService.add(new PersonDef({ name: 'Andrea' })),
-        /persistence is blocked/,
-        'a persisting add reports the blocked write',
+      let rendered = new PersonDef({ name: 'Andrea' });
+      assert.strictEqual(
+        await storeService.add(rendered),
+        rendered,
+        'a render keeps the instance rather than failing',
       );
 
-      let instance = new PersonDef({ name: 'Mango' });
+      // A command is the one caller whose write must land, so the block being
+      // up here means the command route did not drop it — and an instance
+      // with no id reads as a saved card to every caller.
+      (globalThis as any).__boxelHeadlessCommand = true;
+      await assert.rejects(
+        storeService.add(new PersonDef({ name: 'Van Gogh' })),
+        /persistence block still raised/,
+        'a command reports the blocked write',
+      );
+
+      let ephemeral = new PersonDef({ name: 'Mango' });
       assert.strictEqual(
-        await storeService.add(instance, { doNotPersist: true }),
-        instance,
+        await storeService.add(ephemeral, { doNotPersist: true }),
+        ephemeral,
         'a memory-only add is served as asked',
       );
     } finally {
+      delete (globalThis as any).__boxelHeadlessCommand;
       delete (globalThis as any).__boxelPrerenderApp;
     }
   });


### PR DESCRIPTION
`__boxelPrerenderApp` marks the dedicated prerender app for its whole lifetime and blocks persistence on every store in it: a write from a render would aim at a realm whose sole indexing worker that render is occupying, and the write would then wait on a job that needs the held worker.

Commands are the exception — they are expected to write — but the flag was never dropped for them. `PagePool#reassignAffinityTab` can retag a tab from the realm affinity a card render uses onto the user affinity a command uses (via the dormant-tab commandeer, or the cross-affinity steal when standby refill fails), and `render-runner.ts` enters the command route with an in-app `transitionTo` rather than a document load. So a tab that had served a card render ran commands with all persistence disabled: `store.add()` returned the unpersisted instance, `SaveCardTool` treated it as saved, and the command answered `status: "ready"` with a result carrying no card id.

## Changes

**`app/routes/command-runner.ts`** — drops `__boxelPrerenderApp` in `beforeModel`, making the command route the single explicit carve-out from the block. Writes from here stay deadlock-safe through `__boxelHeadlessCommand`, which marks them for deferred indexing.

It drops rather than restores the flag on teardown. The render route raises it in its own `beforeModel`, and a transition runs the entering route's model hooks before the exit hooks of the route being left — so restoring a never-raised value would lower the block for the whole of the next render's model hook.

**`app/routes/render.ts`** — clears `__boxelHeadlessCommand` in `beforeModel`, by the same ordering: a tab arriving from the command route would otherwise carry that flag through the render's whole model hook, marking a render's writes for deferred indexing and putting them on the command error path below.

**`app/services/store.ts`** — `add()` reports one state instead of absorbing it: a headless command running while the block is still raised. The command route drops the block on entry so a command's writes can land, so the block being up there means the drop did not happen, and the save resolves to an instance with no id that every caller — `boxel run-command` and the software-factory steps that wrap it included — reads as a saved card. `create()` already throws on the same state. Raised before the instance is registered, so a failed `add` leaves nothing resident.

**A card render stays silent.** The prerenderer is not an avenue for mutations, but a card whose template or computed writes to the store is doing what it was designed to do; that write is dropped as it always has been and the card renders. Erroring would fail the render and index the card as an error.

## Scope

**The flag keeps its app-lifetime scope.** Clearing it in the render route's teardown was considered and rejected: `deactivate()` fires when a transition leaves the `render` tree, and one of the routes it leaves for is `module`, on the same realm affinity within the same indexing job. `routes/module.ts` raises `__boxelRenderContext` but not `__boxelPrerenderApp`, and renders through the render store, so clearing the flag on the way out would leave the regular `StoreService` unblocked for the whole module render while the tab still holds the worker. No write is reachable there today, but that shape fails open for the next route that doesn't consider the flag, whereas leaving the flag up fails closed.

**Left alone:** `patch()` reports a blocked write as `undefined`, which its callers already branch on; `delete()` has no block guard at all and issues the realm `DELETE` regardless. The second is worth its own change and is not touched here.

## Tests

- `tests/acceptance/prerender-persistence-block-test.gts` — entering the command route drops the block; and a card-saving command run on a tab that has just served a card render produces a card that reads back 200 from the realm's own source.
- `tests/integration/store-test.gts` — a card render keeps its instance rather than failing, a headless command under the block reports it, and a `doNotPersist` caller still gets the in-memory instance.

Not included: a prerender-server test that forces a cross-affinity steal on a single-page pool. `PagePool` keeps one warm standby above its active ceiling — `#desiredStandbyCount()` returns 1 once `activeTabs >= maxPages`, and `#prepareSlotForStandby()` admits `maxPages + 1` contexts — so a command on a fresh affinity takes that standby and gets a fresh tab; the steal is unreachable from a single-page pool without a new test seam in `Prerenderer`. The acceptance test covers the same app-level hand-off deterministically.

Also uncovered: the *raise* side of the invariant. `render.ts` only raises `__boxelPrerenderApp` when `!isTesting()`, so no host test can observe it, and nothing fails if that line is removed.

## Verification

`pnpm lint:js`, `pnpm lint:hbs` and `pnpm lint:types` pass in `packages/host`. The host suites need the full stack (Synapse, realm servers, host dist), which this environment cannot provision, so CI is what runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JN9nUPZmHWKKL8KnwLmTs