### PR TITLE
Invalidate the definition cache where module bytes change

### DIFF
--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -199,12 +199,13 @@ export default class ModuleRoute extends Route<Model> {
   // definition cache stores that under the rewritten module's URL.
   //
   // On the route rather than in `buildModuleModel`, which the route shares
-  // with card-prerender.gts. That component renders in the app's own tab,
-  // where the loader and store belong to the session and are already kept
-  // current by the file resources and realm subscriptions the app runs;
-  // replacing them out from under it would discard live state on a schedule
-  // the app has no part in. A tab that reached this route exists to serve
-  // renders and holds nothing else worth keeping.
+  // with card-prerender.gts. That component mounts only under `isTesting()`,
+  // so its renders run inside the test harness's own tab, sharing the loader
+  // and store with the application under test — state the harness and the
+  // app's own file resources and realm subscriptions already keep current.
+  // Replacing it from here would discard live state on a schedule neither
+  // has a part in. A tab that reached this route exists to serve renders and
+  // holds nothing else worth keeping.
   //
   // Held under its own key rather than the one routes/render.ts uses. Visits
   // thread the epoch their indexing batch minted, which is not committed

--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -215,6 +215,42 @@ export async function buildModuleModel(
   let moduleURL = trimExecutableExtension(rri(id));
   registerBoxelTransitionTo(context.router, context.owner);
 
+  // Loader-epoch synchronization, the module route's half of what
+  // routes/render.ts does for visits: the realm's loader epoch is re-minted
+  // whenever its executable modules change (an index pass that invalidates
+  // one, or the write that changed the bytes), and a mismatch in either
+  // direction means this tab's loader belongs to a different module
+  // timeline. Without it a module render imports out of whatever this tab
+  // already evaluated, so a module rewritten since then reports its previous
+  // shape — with the current file metadata attached, since that is re-read
+  // per render — and the definition cache stores that under the rewritten
+  // module's URL.
+  //
+  // Held under its own key rather than the one routes/render.ts uses.
+  // Visits thread the epoch their indexing batch minted, which is not
+  // committed until the batch ends, while this route's callers read the
+  // committed column; a single key would read that lag as two timelines
+  // alternating and reset the loader on every render for the length of the
+  // batch. Separate keys cost a tab one extra reset per epoch — each series
+  // synchronizes independently — and a reset only ever leaves the loader
+  // fresher than the other series assumes.
+  if (parsedOptions.loaderEpoch !== undefined) {
+    let held = (globalThis as any).__boxelModuleLoaderEpoch as
+      | string
+      | undefined;
+    if (held !== parsedOptions.loaderEpoch) {
+      context.state.setTypesCache(
+        new WeakMap<typeof BaseDef, Promise<TypesWithErrors>>(),
+      );
+      context.loaderService.resetLoader({
+        clearFetchCache: true,
+        reason: 'module-route loader epoch changed',
+      });
+      context.store.resetCache();
+      (globalThis as any).__boxelModuleLoaderEpoch = parsedOptions.loaderEpoch;
+    }
+  }
+
   if (parsedOptions.clearCache) {
     context.state.setTypesCache(
       new WeakMap<typeof BaseDef, Promise<TypesWithErrors>>(),

--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -177,6 +177,7 @@ export default class ModuleRoute extends Route<Model> {
     options?: string;
   }) {
     let parsedOptions = parseRenderRouteOptions(options);
+    this.#synchronizeLoaderEpoch(parsedOptions.loaderEpoch);
     return await buildModuleModel(
       {
         id,
@@ -185,6 +186,51 @@ export default class ModuleRoute extends Route<Model> {
       },
       this.#moduleModelContext(),
     );
+  }
+
+  // Loader-epoch synchronization, this route's half of what routes/render.ts
+  // does for visits: the realm's loader epoch is re-minted whenever its
+  // executable modules change (an index pass that invalidates one, or the
+  // write that changed the bytes), and a mismatch in either direction means
+  // this tab's loader belongs to a different module timeline. Without it a
+  // module render imports out of whatever this tab already evaluated, so a
+  // module rewritten since then reports its previous shape — with the current
+  // file metadata attached, since that is re-read per render — and the
+  // definition cache stores that under the rewritten module's URL.
+  //
+  // On the route rather than in `buildModuleModel`, which the route shares
+  // with card-prerender.gts. That component renders in the app's own tab,
+  // where the loader and store belong to the session and are already kept
+  // current by the file resources and realm subscriptions the app runs;
+  // replacing them out from under it would discard live state on a schedule
+  // the app has no part in. A tab that reached this route exists to serve
+  // renders and holds nothing else worth keeping.
+  //
+  // Held under its own key rather than the one routes/render.ts uses. Visits
+  // thread the epoch their indexing batch minted, which is not committed
+  // until the batch ends, while this route's callers read the committed
+  // column; a single key would read that lag as two timelines alternating and
+  // reset the loader on every render for the length of the batch. Separate
+  // keys cost a tab one extra reset per epoch — each series synchronizes
+  // independently — and a reset only ever leaves the loader fresher than the
+  // other series assumes.
+  #synchronizeLoaderEpoch(loaderEpoch: string | undefined) {
+    if (loaderEpoch === undefined) {
+      return;
+    }
+    let held = (globalThis as any).__boxelModuleLoaderEpoch as
+      | string
+      | undefined;
+    if (held === loaderEpoch) {
+      return;
+    }
+    this.typesCache = new WeakMap<typeof BaseDef, Promise<TypesWithErrors>>();
+    this.loaderService.resetLoader({
+      clearFetchCache: true,
+      reason: 'module-route loader epoch changed',
+    });
+    this.store.resetCache();
+    (globalThis as any).__boxelModuleLoaderEpoch = loaderEpoch;
   }
 
   #moduleModelContext(): ModuleModelContext {
@@ -214,42 +260,6 @@ export async function buildModuleModel(
   let parsedOptions = renderOptions ?? {};
   let moduleURL = trimExecutableExtension(rri(id));
   registerBoxelTransitionTo(context.router, context.owner);
-
-  // Loader-epoch synchronization, the module route's half of what
-  // routes/render.ts does for visits: the realm's loader epoch is re-minted
-  // whenever its executable modules change (an index pass that invalidates
-  // one, or the write that changed the bytes), and a mismatch in either
-  // direction means this tab's loader belongs to a different module
-  // timeline. Without it a module render imports out of whatever this tab
-  // already evaluated, so a module rewritten since then reports its previous
-  // shape — with the current file metadata attached, since that is re-read
-  // per render — and the definition cache stores that under the rewritten
-  // module's URL.
-  //
-  // Held under its own key rather than the one routes/render.ts uses.
-  // Visits thread the epoch their indexing batch minted, which is not
-  // committed until the batch ends, while this route's callers read the
-  // committed column; a single key would read that lag as two timelines
-  // alternating and reset the loader on every render for the length of the
-  // batch. Separate keys cost a tab one extra reset per epoch — each series
-  // synchronizes independently — and a reset only ever leaves the loader
-  // fresher than the other series assumes.
-  if (parsedOptions.loaderEpoch !== undefined) {
-    let held = (globalThis as any).__boxelModuleLoaderEpoch as
-      | string
-      | undefined;
-    if (held !== parsedOptions.loaderEpoch) {
-      context.state.setTypesCache(
-        new WeakMap<typeof BaseDef, Promise<TypesWithErrors>>(),
-      );
-      context.loaderService.resetLoader({
-        clearFetchCache: true,
-        reason: 'module-route loader epoch changed',
-      });
-      context.store.resetCache();
-      (globalThis as any).__boxelModuleLoaderEpoch = parsedOptions.loaderEpoch;
-    }
-  }
 
   if (parsedOptions.clearCache) {
     context.state.setTypesCache(

--- a/packages/realm-server/tests/definition-cache-write-invalidation-test.ts
+++ b/packages/realm-server/tests/definition-cache-write-invalidation-test.ts
@@ -271,7 +271,7 @@ module(basename(import.meta.filename), function () {
         assert.strictEqual(
           response.status,
           200,
-          'the pre-rewrite schema serialized an instance, warming its definition',
+          `the pre-rewrite schema serialized an instance, warming its definition — ${JSON.stringify(response.body)}`,
         );
       }
 
@@ -307,7 +307,11 @@ module(basename(import.meta.filename), function () {
           })
           .set('Accept', 'application/vnd.card+json');
 
-        assert.strictEqual(response.status, 200, 'HTTP 200 status');
+        assert.strictEqual(
+          response.status,
+          200,
+          `HTTP 200 status — ${JSON.stringify(response.body)}`,
+        );
         assert.strictEqual(
           response.body.data.attributes?.lastName,
           'Tangle',
@@ -335,14 +339,24 @@ module(basename(import.meta.filename), function () {
               type: 'card',
               attributes: { firstName: 'Van Gogh', lastName: 'Tangle' },
               meta: {
-                adoptsFrom: { module: rri('./person'), name: 'Person' },
+                adoptsFrom: {
+                  // Absolute: `createCard` serializes relative to the new
+                  // instance's own directory, so a relative ref would resolve
+                  // under `Person/` rather than the realm root.
+                  module: rri(`${realmURL.href}person`),
+                  name: 'Person',
+                },
               },
             },
           })
           .set('Accept', 'application/vnd.card+json')
           .set(DURING_PRERENDER_HEADER, 'true');
 
-        assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        assert.strictEqual(
+          response.status,
+          201,
+          `HTTP 201 status — ${JSON.stringify(response.body)}`,
+        );
         // A prerender-originated write indexes deferred, so its response is
         // echoed straight from the serialization that lands on disk — the
         // same document the stale schema would have stripped the field from.
@@ -378,14 +392,21 @@ module(basename(import.meta.filename), function () {
               type: 'card',
               attributes: { nickname: 'Mango' },
               meta: {
-                adoptsFrom: { module: rri('./pet'), name: 'Pet' },
+                adoptsFrom: {
+                  module: rri(`${realmURL.href}pet`),
+                  name: 'Pet',
+                },
               },
             },
           })
           .set('Accept', 'application/vnd.card+json')
           .set(DURING_PRERENDER_HEADER, 'true');
 
-        assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        assert.strictEqual(
+          response.status,
+          201,
+          `HTTP 201 status — ${JSON.stringify(response.body)}`,
+        );
         assert.strictEqual(
           response.body.data.attributes?.nickname,
           'Mango',

--- a/packages/realm-server/tests/definition-cache-write-invalidation-test.ts
+++ b/packages/realm-server/tests/definition-cache-write-invalidation-test.ts
@@ -277,9 +277,11 @@ module(basename(import.meta.filename), function () {
 
       // Widen the schema on a deferred-indexing write, the shape the headless
       // command and prerender-originated paths take: the bytes land and the
-      // index job is enqueued, so the write's own definition-cache
-      // invalidation is the only thing that can carry the new field into the
-      // instance write that follows.
+      // index job is enqueued. This realm does run a worker, so that job's own
+      // `onInvalidation` would eventually clear the cached definition too —
+      // the write-time invalidation is what reliably wins the race, not the
+      // only thing that can. The determinism lives in the no-worker module
+      // above; these tests pin the user-visible outcome.
       async function widenPersonSchema() {
         await testRealm.write('person.gts', personV2, { waitForIndex: false });
       }

--- a/packages/realm-server/tests/definition-cache-write-invalidation-test.ts
+++ b/packages/realm-server/tests/definition-cache-write-invalidation-test.ts
@@ -1,0 +1,397 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename, join } from 'path';
+import fsExtra from 'fs-extra';
+const { ensureDirSync, readJSONSync, writeJSONSync } = fsExtra;
+import { dirSync, setGracefulCleanup } from 'tmp';
+import type { DirResult } from 'tmp';
+import type { SuperTest, Test } from 'supertest';
+import type {
+  DefinitionLookup,
+  QueuePublisher,
+  Realm,
+} from '@cardstack/runtime-common';
+import { DURING_PRERENDER_HEADER, rri } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import {
+  createRealm,
+  createVirtualNetwork,
+  setupDB,
+  setupPermissionedRealmCached,
+  withRealmPath,
+  type RealmRequest,
+} from './helpers/index.ts';
+
+// The DB definition cache is keyed by module URL and carries no freshness
+// check, so a cached definition for a module outlives the bytes it was
+// derived from until something deletes the row. `fileSerialization` resolves
+// an instance's type through that cache and `serializeCardResource` skips
+// every attribute whose field the resolved definition doesn't declare — so a
+// definition that outlives a schema-widening module rewrite makes the next
+// instance write drop the new field, silently and with a success response.
+//
+// `_batchWriteUnlocked` closes that by invalidating the definition cache for
+// every executable file it writes, at the point the bytes change rather than
+// at the point indexing lands.
+
+const personV1 = `
+  import { contains, field, CardDef } from "@cardstack/base/card-api";
+  import StringField from "@cardstack/base/string";
+
+  export class Person extends CardDef {
+    @field firstName = contains(StringField);
+  }
+`;
+
+// Same class, one more field. Serializing an instance that carries
+// `lastName` against the v1 definition drops the attribute.
+const personV2 = `
+  import { contains, field, CardDef } from "@cardstack/base/card-api";
+  import StringField from "@cardstack/base/string";
+
+  export class Person extends CardDef {
+    @field firstName = contains(StringField);
+    @field lastName = contains(StringField);
+  }
+`;
+
+module(basename(import.meta.filename), function () {
+  module('module write invalidates the definition cache', function (hooks) {
+    let realmURL = 'http://127.0.0.1:4448/write-invalidation/';
+    let realm: Realm;
+    let dbAdapter: PgAdapter;
+    let publisher: QueuePublisher;
+    let tmpDir: DirResult;
+    // Every module URL handed to DefinitionLookup#invalidate, in call order.
+    let invalidated: string[];
+
+    setGracefulCleanup();
+
+    // The realm runs without a worker, so the index jobs these writes enqueue
+    // are never claimed. That makes the indexing job's `onInvalidation` — the
+    // other caller of DefinitionLookup#invalidate — structurally unable to
+    // fire, so every recorded call came from the write path and no assertion
+    // below depends on how fast a worker drains. It also means writes must
+    // pass `waitForIndex: false`; a write that waits would block on a job
+    // nothing is going to run.
+    setupDB(hooks, {
+      beforeEach: async (_dbAdapter, _publisher) => {
+        dbAdapter = _dbAdapter;
+        publisher = _publisher;
+        invalidated = [];
+        // unsafeCleanup: the realm writes files into this dir, and the
+        // default cleanup only removes an empty one.
+        tmpDir = dirSync({ unsafeCleanup: true });
+        let realmDir = join(tmpDir.name, 'realm');
+        ensureDirSync(realmDir);
+        writeJSONSync(join(realmDir, 'realm.json'), {
+          data: {
+            type: 'card',
+            attributes: { cardInfo: { name: 'Write Invalidation Realm' } },
+            meta: {
+              adoptsFrom: {
+                module: '@cardstack/base/realm-config',
+                name: 'RealmConfig',
+              },
+            },
+          },
+        });
+        ({ realm } = await createRealm({
+          dir: realmDir,
+          // Only `invalidate` and `forRealm` are reachable from the write
+          // path: nothing here writes with `serializeFile`, so no lookup
+          // runs. A recorder is enough, and it keeps the assertions on the
+          // realm's behavior rather than on the cache implementation.
+          definitionLookup: {
+            forRealm() {
+              return this;
+            },
+            async invalidate(moduleURL: string) {
+              invalidated.push(moduleURL);
+              return [];
+            },
+          } as unknown as DefinitionLookup,
+          realmURL,
+          permissions: { '*': ['read', 'write'] },
+          virtualNetwork: createVirtualNetwork(),
+          publisher,
+          dbAdapter,
+        }));
+      },
+    });
+
+    hooks.afterEach(function () {
+      tmpDir?.removeCallback();
+    });
+
+    test('writing a module invalidates that module', async function (assert) {
+      await realm.write('person.gts', personV1, { waitForIndex: false });
+
+      assert.deepEqual(
+        invalidated,
+        [`${realmURL}person.gts`],
+        'the write invalidated the definition cache for the module it wrote',
+      );
+    });
+
+    test('a rewritten module is invalidated before the write resolves', async function (assert) {
+      await realm.write('person.gts', personV1, { waitForIndex: false });
+      invalidated = [];
+
+      await realm.write('person.gts', personV2, { waitForIndex: false });
+
+      // Asserted synchronously off the resolved write: an instance write
+      // arriving the moment this one returns must already miss the cache,
+      // which is the whole guarantee — a definition dropped "shortly after"
+      // still leaves the window the drop exists to close.
+      assert.deepEqual(
+        invalidated,
+        [`${realmURL}person.gts`],
+        'the rewrite invalidated the module before the write resolved',
+      );
+    });
+
+    test('writing a card instance invalidates nothing', async function (assert) {
+      await realm.write(
+        'person-1.json',
+        JSON.stringify({
+          data: {
+            type: 'card',
+            attributes: { firstName: 'Mango' },
+            meta: { adoptsFrom: { module: './person', name: 'Person' } },
+          },
+        }),
+        { waitForIndex: false },
+      );
+
+      assert.deepEqual(
+        invalidated,
+        [],
+        'an instance write leaves the definition cache alone — its bytes are not a schema',
+      );
+    });
+
+    test('a batch write invalidates every module it contains', async function (assert) {
+      // Modules only. A batch that mixes in an instance flushes the modules
+      // written so far to the index before serializing it, and that flush
+      // waits on a worker this realm deliberately does not have.
+      await realm.writeMany(
+        new Map([
+          ['person.gts', personV1],
+          ['employee.gts', personV1],
+        ]),
+        { waitForIndex: false },
+      );
+
+      assert.deepEqual(
+        invalidated.sort(),
+        [`${realmURL}employee.gts`, `${realmURL}person.gts`],
+        'every module in the batch was invalidated, not just the last one',
+      );
+    });
+
+    test('rewriting a module with identical bytes invalidates nothing', async function (assert) {
+      await realm.write('person.gts', personV1, { waitForIndex: false });
+      invalidated = [];
+
+      await realm.write('person.gts', personV1, { waitForIndex: false });
+
+      assert.deepEqual(
+        invalidated,
+        [],
+        'an unchanged rewrite short-circuits before the write, so the cached definition still matches the bytes',
+      );
+    });
+
+    test('writing a non-executable file invalidates nothing', async function (assert) {
+      await realm.write('notes.txt', 'hello', { waitForIndex: false });
+
+      assert.deepEqual(
+        invalidated,
+        [],
+        'a non-executable file has no definition to invalidate',
+      );
+    });
+  });
+
+  module(
+    'a schema-widening module rewrite is visible to the next instance write',
+    function (hooks) {
+      let realmURL = new URL('http://127.0.0.1:4444/test/');
+      let testRealm: Realm;
+      let testRealmPath: string;
+      let request: RealmRequest;
+
+      setupPermissionedRealmCached(hooks, {
+        realmURL,
+        permissions: {
+          '*': ['read', 'write'],
+          '@node-test_realm:localhost': ['read', 'realm-owner'],
+        },
+        fileSystem: {
+          'person.gts': personV1,
+          'person-1.json': {
+            data: {
+              type: 'card',
+              attributes: { firstName: 'Mango' },
+              meta: {
+                adoptsFrom: { module: rri('./person'), name: 'Person' },
+              },
+            },
+          },
+        },
+        onRealmSetup(args: {
+          testRealm: Realm;
+          testRealmPath: string;
+          request: SuperTest<Test>;
+        }) {
+          testRealm = args.testRealm;
+          testRealmPath = args.testRealmPath;
+          request = withRealmPath(args.request, realmURL);
+        },
+      });
+
+      // Serializing an instance through the endpoint is what populates the
+      // definition cache in production, so this both warms the cache with the
+      // pre-rewrite schema and pins that the instance round-trips before the
+      // rewrite the test is actually about.
+      async function primeDefinitionCache(assert: Assert) {
+        let response = await request
+          .patch('/person-1')
+          .send({
+            data: {
+              type: 'card',
+              attributes: { firstName: 'Mango' },
+              meta: {
+                adoptsFrom: { module: rri('./person'), name: 'Person' },
+              },
+            },
+          })
+          .set('Accept', 'application/vnd.card+json');
+        assert.strictEqual(
+          response.status,
+          200,
+          'the pre-rewrite schema serialized an instance, warming its definition',
+        );
+      }
+
+      // Widen the schema on a deferred-indexing write, the shape the headless
+      // command and prerender-originated paths take: the bytes land and the
+      // index job is enqueued, so the write's own definition-cache
+      // invalidation is the only thing that can carry the new field into the
+      // instance write that follows.
+      async function widenPersonSchema() {
+        await testRealm.write('person.gts', personV2, { waitForIndex: false });
+      }
+
+      function storedInstance(path: string): any {
+        return readJSONSync(join(testRealmPath, path));
+      }
+
+      test('PATCH persists a field the rewrite added', async function (assert) {
+        // `patchCardInstance` serializes before `_batchWriteUnlocked` drains
+        // indexing, so nothing on this path waits for the rewrite's index job.
+        await primeDefinitionCache(assert);
+        await widenPersonSchema();
+
+        let response = await request
+          .patch('/person-1')
+          .send({
+            data: {
+              type: 'card',
+              attributes: { firstName: 'Mango', lastName: 'Tangle' },
+              meta: {
+                adoptsFrom: { module: rri('./person'), name: 'Person' },
+              },
+            },
+          })
+          .set('Accept', 'application/vnd.card+json');
+
+        assert.strictEqual(response.status, 200, 'HTTP 200 status');
+        assert.strictEqual(
+          response.body.data.attributes?.lastName,
+          'Tangle',
+          'the response echoes the field the rewrite added',
+        );
+        assert.strictEqual(
+          storedInstance('person-1.json').data.attributes?.lastName,
+          'Tangle',
+          'the field the rewrite added survived to the stored file',
+        );
+      });
+
+      test('a prerender-originated POST persists a field the rewrite added', async function (assert) {
+        // The during-prerender marker is what a headless command's tab
+        // carries. It skips `createCard`'s pre-write drain — waiting there
+        // would deadlock on the render slot the caller holds — so this path
+        // has no indexing step between the rewrite and the serialization.
+        await primeDefinitionCache(assert);
+        await widenPersonSchema();
+
+        let response = await request
+          .post('/')
+          .send({
+            data: {
+              type: 'card',
+              attributes: { firstName: 'Van Gogh', lastName: 'Tangle' },
+              meta: {
+                adoptsFrom: { module: rri('./person'), name: 'Person' },
+              },
+            },
+          })
+          .set('Accept', 'application/vnd.card+json')
+          .set(DURING_PRERENDER_HEADER, 'true');
+
+        assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        // A prerender-originated write indexes deferred, so its response is
+        // echoed straight from the serialization that lands on disk — the
+        // same document the stale schema would have stripped the field from.
+        assert.strictEqual(
+          response.body.data.attributes?.lastName,
+          'Tangle',
+          'the field the rewrite added survived serialization',
+        );
+      });
+
+      test('an instance of a module that has never been cached still serializes', async function (assert) {
+        // The bug is a stale cache HIT and the fix turns those into misses,
+        // so this pins the other half of the contract: a module with no
+        // cached row at all still resolves, through `prerenderModule` reading
+        // it off disk, rather than failing the write.
+        await testRealm.write(
+          'pet.gts',
+          `
+            import { contains, field, CardDef } from "@cardstack/base/card-api";
+            import StringField from "@cardstack/base/string";
+
+            export class Pet extends CardDef {
+              @field nickname = contains(StringField);
+            }
+          `,
+          { waitForIndex: false },
+        );
+
+        let response = await request
+          .post('/')
+          .send({
+            data: {
+              type: 'card',
+              attributes: { nickname: 'Mango' },
+              meta: {
+                adoptsFrom: { module: rri('./pet'), name: 'Pet' },
+              },
+            },
+          })
+          .set('Accept', 'application/vnd.card+json')
+          .set(DURING_PRERENDER_HEADER, 'true');
+
+        assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        assert.strictEqual(
+          response.body.data.attributes?.nickname,
+          'Mango',
+          'a never-cached module serializes through the read-through path',
+        );
+      });
+    },
+  );
+});

--- a/packages/realm-server/tests/definition-cache-write-invalidation-test.ts
+++ b/packages/realm-server/tests/definition-cache-write-invalidation-test.ts
@@ -11,7 +11,11 @@ import type {
   QueuePublisher,
   Realm,
 } from '@cardstack/runtime-common';
-import { DURING_PRERENDER_HEADER, rri } from '@cardstack/runtime-common';
+import {
+  DURING_PRERENDER_HEADER,
+  readRealmLoaderEpoch,
+  rri,
+} from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
 import {
   createRealm,
@@ -56,163 +60,279 @@ const personV2 = `
 `;
 
 module(basename(import.meta.filename), function () {
-  module('module write invalidates the definition cache', function (hooks) {
-    let realmURL = 'http://127.0.0.1:4448/write-invalidation/';
-    let realm: Realm;
-    let dbAdapter: PgAdapter;
-    let publisher: QueuePublisher;
-    let tmpDir: DirResult;
-    // Every module URL handed to DefinitionLookup#invalidate, in call order.
-    let invalidated: string[];
+  module(
+    'module write invalidates the definition cache and mints a loader epoch',
+    function (hooks) {
+      let realmURL = 'http://127.0.0.1:4448/write-invalidation/';
+      let realm: Realm;
+      let dbAdapter: PgAdapter;
+      let publisher: QueuePublisher;
+      let tmpDir: DirResult;
+      // Every module URL handed to DefinitionLookup#invalidate, in call order.
+      let invalidated: string[];
+      // The realm's committed loader epoch as each of those calls was made.
+      // The write path mints before it invalidates, so this samples what a
+      // lookup racing that invalidation would have threaded.
+      let epochAtInvalidate: string[];
 
-    setGracefulCleanup();
+      setGracefulCleanup();
 
-    // The realm runs without a worker, so the index jobs these writes enqueue
-    // are never claimed. That makes the indexing job's `onInvalidation` — the
-    // other caller of DefinitionLookup#invalidate — structurally unable to
-    // fire, so every recorded call came from the write path and no assertion
-    // below depends on how fast a worker drains. It also means writes must
-    // pass `waitForIndex: false`; a write that waits would block on a job
-    // nothing is going to run.
-    setupDB(hooks, {
-      beforeEach: async (_dbAdapter, _publisher) => {
-        dbAdapter = _dbAdapter;
-        publisher = _publisher;
-        invalidated = [];
-        // unsafeCleanup: the realm writes files into this dir, and the
-        // default cleanup only removes an empty one.
-        tmpDir = dirSync({ unsafeCleanup: true });
-        let realmDir = join(tmpDir.name, 'realm');
-        ensureDirSync(realmDir);
-        writeJSONSync(join(realmDir, 'realm.json'), {
-          data: {
-            type: 'card',
-            attributes: { cardInfo: { name: 'Write Invalidation Realm' } },
-            meta: {
-              adoptsFrom: {
-                module: '@cardstack/base/realm-config',
-                name: 'RealmConfig',
+      // The realm runs without a worker, so the index jobs these writes enqueue
+      // are never claimed. That makes the indexing job's `onInvalidation` — the
+      // other caller of DefinitionLookup#invalidate — structurally unable to
+      // fire, so every recorded call came from the write path and no assertion
+      // below depends on how fast a worker drains. It also means writes must
+      // pass `waitForIndex: false`; a write that waits would block on a job
+      // nothing is going to run.
+      setupDB(hooks, {
+        beforeEach: async (_dbAdapter, _publisher) => {
+          dbAdapter = _dbAdapter;
+          publisher = _publisher;
+          invalidated = [];
+          epochAtInvalidate = [];
+          // unsafeCleanup: the realm writes files into this dir, and the
+          // default cleanup only removes an empty one.
+          tmpDir = dirSync({ unsafeCleanup: true });
+          let realmDir = join(tmpDir.name, 'realm');
+          ensureDirSync(realmDir);
+          writeJSONSync(join(realmDir, 'realm.json'), {
+            data: {
+              type: 'card',
+              attributes: { cardInfo: { name: 'Write Invalidation Realm' } },
+              meta: {
+                adoptsFrom: {
+                  module: '@cardstack/base/realm-config',
+                  name: 'RealmConfig',
+                },
               },
             },
-          },
-        });
-        ({ realm } = await createRealm({
-          dir: realmDir,
-          // Only `invalidate` and `forRealm` are reachable from the write
-          // path: nothing here writes with `serializeFile`, so no lookup
-          // runs. A recorder is enough, and it keeps the assertions on the
-          // realm's behavior rather than on the cache implementation.
-          definitionLookup: {
-            forRealm() {
-              return this;
+          });
+          ({ realm } = await createRealm({
+            dir: realmDir,
+            // Only `invalidate` and `forRealm` are reachable from the write
+            // path: nothing here writes with `serializeFile`, so no lookup
+            // runs. A recorder is enough, and it keeps the assertions on the
+            // realm's behavior rather than on the cache implementation.
+            definitionLookup: {
+              forRealm() {
+                return this;
+              },
+              async invalidate(moduleURL: string) {
+                invalidated.push(moduleURL);
+                epochAtInvalidate.push(
+                  await readRealmLoaderEpoch(dbAdapter, realmURL),
+                );
+                return [];
+              },
+            } as unknown as DefinitionLookup,
+            realmURL,
+            permissions: { '*': ['read', 'write'] },
+            virtualNetwork: createVirtualNetwork(),
+            publisher,
+            dbAdapter,
+          }));
+        },
+      });
+
+      hooks.afterEach(function () {
+        tmpDir?.removeCallback();
+      });
+
+      test('writing a module invalidates that module', async function (assert) {
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+
+        assert.deepEqual(
+          invalidated,
+          [`${realmURL}person.gts`],
+          'the write invalidated the definition cache for the module it wrote',
+        );
+      });
+
+      test('a rewritten module is invalidated before the write resolves', async function (assert) {
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+        invalidated = [];
+
+        await realm.write('person.gts', personV2, { waitForIndex: false });
+
+        // Asserted synchronously off the resolved write: an instance write
+        // arriving the moment this one returns must already miss the cache,
+        // which is the whole guarantee — a definition dropped "shortly after"
+        // still leaves the window the drop exists to close.
+        assert.deepEqual(
+          invalidated,
+          [`${realmURL}person.gts`],
+          'the rewrite invalidated the module before the write resolved',
+        );
+      });
+
+      test('writing a card instance invalidates nothing', async function (assert) {
+        await realm.write(
+          'person-1.json',
+          JSON.stringify({
+            data: {
+              type: 'card',
+              attributes: { firstName: 'Mango' },
+              meta: { adoptsFrom: { module: './person', name: 'Person' } },
             },
-            async invalidate(moduleURL: string) {
-              invalidated.push(moduleURL);
-              return [];
+          }),
+          { waitForIndex: false },
+        );
+
+        assert.deepEqual(
+          invalidated,
+          [],
+          'an instance write leaves the definition cache alone — its bytes are not a schema',
+        );
+      });
+
+      test('a batch write invalidates every module it contains', async function (assert) {
+        // Modules only. A batch that mixes in an instance flushes the modules
+        // written so far to the index before serializing it, and that flush
+        // waits on a worker this realm deliberately does not have.
+        await realm.writeMany(
+          new Map([
+            ['person.gts', personV1],
+            ['employee.gts', personV1],
+          ]),
+          { waitForIndex: false },
+        );
+
+        assert.deepEqual(
+          invalidated.sort(),
+          [`${realmURL}employee.gts`, `${realmURL}person.gts`],
+          'every module in the batch was invalidated, not just the last one',
+        );
+      });
+
+      test('rewriting a module with identical bytes invalidates nothing', async function (assert) {
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+        invalidated = [];
+
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+
+        assert.deepEqual(
+          invalidated,
+          [],
+          'an unchanged rewrite short-circuits before the write, so the cached definition still matches the bytes',
+        );
+      });
+
+      test('writing a non-executable file invalidates nothing', async function (assert) {
+        await realm.write('notes.txt', 'hello', { waitForIndex: false });
+
+        assert.deepEqual(
+          invalidated,
+          [],
+          'a non-executable file has no definition to invalidate',
+        );
+      });
+
+      // The epoch is what stops the repopulate the invalidation forces from
+      // being derived off a prerender tab that still holds the pre-write
+      // module. Asserted on the committed `realm_generations` row rather than
+      // on a render, because that row is what `lookupDefinition` threads and
+      // what a peer replica reads: an epoch that never lands is invisible to
+      // both. `'0'` is the column's no-epoch-yet sentinel — each test here
+      // starts from a realm no index pass and no module write has touched.
+      test('writing a module mints a loader epoch', async function (assert) {
+        assert.strictEqual(
+          await readRealmLoaderEpoch(dbAdapter, realmURL),
+          '0',
+          'the realm starts with no epoch — nothing has invalidated a module yet',
+        );
+
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+
+        assert.notStrictEqual(
+          await readRealmLoaderEpoch(dbAdapter, realmURL),
+          '0',
+          'the write left an epoch behind for the next module render to thread',
+        );
+      });
+
+      test('a rewrite mints a different epoch than the write before it', async function (assert) {
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+        let firstEpoch = await readRealmLoaderEpoch(dbAdapter, realmURL);
+
+        await realm.write('person.gts', personV2, { waitForIndex: false });
+
+        // Only identity matters: a tab clears when the epoch it is handed
+        // differs from the one it last cleared for, so re-minting the same
+        // token would read as "this tab is already current" and leave the
+        // superseded module loaded.
+        assert.notStrictEqual(
+          await readRealmLoaderEpoch(dbAdapter, realmURL),
+          firstEpoch,
+          'the rewrite superseded the epoch its own first write minted',
+        );
+      });
+
+      test('a batch mints one epoch however many modules it writes', async function (assert) {
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+        let beforeBatch = await readRealmLoaderEpoch(dbAdapter, realmURL);
+        invalidated = [];
+        epochAtInvalidate = [];
+
+        await realm.writeMany(
+          new Map([
+            ['person.gts', personV2],
+            ['employee.gts', personV1],
+          ]),
+          { waitForIndex: false },
+        );
+
+        let afterBatch = await readRealmLoaderEpoch(dbAdapter, realmURL);
+        assert.strictEqual(
+          invalidated.length,
+          2,
+          'both modules in the batch reached the definition cache',
+        );
+        assert.notStrictEqual(
+          afterBatch,
+          beforeBatch,
+          'the batch superseded the epoch standing before it',
+        );
+        // Sampled at each module's invalidation rather than counted after
+        // the fact: one token across the whole batch is the point. The
+        // token only has to differ from what a tab holds, so minting per
+        // file would cost every warm tab a loader reset per module and buy
+        // no freshness the first mint had not already bought.
+        assert.deepEqual(
+          [...new Set(epochAtInvalidate)],
+          [afterBatch],
+          'both modules landed under the same single new epoch',
+        );
+      });
+
+      test('a write that changes no module leaves the epoch alone', async function (assert) {
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+        let epoch = await readRealmLoaderEpoch(dbAdapter, realmURL);
+
+        await realm.write('person.gts', personV1, { waitForIndex: false });
+        await realm.write('notes.txt', 'hello', { waitForIndex: false });
+        await realm.write(
+          'person-1.json',
+          JSON.stringify({
+            data: {
+              type: 'card',
+              attributes: { firstName: 'Mango' },
+              meta: { adoptsFrom: { module: './person', name: 'Person' } },
             },
-          } as unknown as DefinitionLookup,
-          realmURL,
-          permissions: { '*': ['read', 'write'] },
-          virtualNetwork: createVirtualNetwork(),
-          publisher,
-          dbAdapter,
-        }));
-      },
-    });
+          }),
+          { waitForIndex: false },
+        );
 
-    hooks.afterEach(function () {
-      tmpDir?.removeCallback();
-    });
-
-    test('writing a module invalidates that module', async function (assert) {
-      await realm.write('person.gts', personV1, { waitForIndex: false });
-
-      assert.deepEqual(
-        invalidated,
-        [`${realmURL}person.gts`],
-        'the write invalidated the definition cache for the module it wrote',
-      );
-    });
-
-    test('a rewritten module is invalidated before the write resolves', async function (assert) {
-      await realm.write('person.gts', personV1, { waitForIndex: false });
-      invalidated = [];
-
-      await realm.write('person.gts', personV2, { waitForIndex: false });
-
-      // Asserted synchronously off the resolved write: an instance write
-      // arriving the moment this one returns must already miss the cache,
-      // which is the whole guarantee — a definition dropped "shortly after"
-      // still leaves the window the drop exists to close.
-      assert.deepEqual(
-        invalidated,
-        [`${realmURL}person.gts`],
-        'the rewrite invalidated the module before the write resolved',
-      );
-    });
-
-    test('writing a card instance invalidates nothing', async function (assert) {
-      await realm.write(
-        'person-1.json',
-        JSON.stringify({
-          data: {
-            type: 'card',
-            attributes: { firstName: 'Mango' },
-            meta: { adoptsFrom: { module: './person', name: 'Person' } },
-          },
-        }),
-        { waitForIndex: false },
-      );
-
-      assert.deepEqual(
-        invalidated,
-        [],
-        'an instance write leaves the definition cache alone — its bytes are not a schema',
-      );
-    });
-
-    test('a batch write invalidates every module it contains', async function (assert) {
-      // Modules only. A batch that mixes in an instance flushes the modules
-      // written so far to the index before serializing it, and that flush
-      // waits on a worker this realm deliberately does not have.
-      await realm.writeMany(
-        new Map([
-          ['person.gts', personV1],
-          ['employee.gts', personV1],
-        ]),
-        { waitForIndex: false },
-      );
-
-      assert.deepEqual(
-        invalidated.sort(),
-        [`${realmURL}employee.gts`, `${realmURL}person.gts`],
-        'every module in the batch was invalidated, not just the last one',
-      );
-    });
-
-    test('rewriting a module with identical bytes invalidates nothing', async function (assert) {
-      await realm.write('person.gts', personV1, { waitForIndex: false });
-      invalidated = [];
-
-      await realm.write('person.gts', personV1, { waitForIndex: false });
-
-      assert.deepEqual(
-        invalidated,
-        [],
-        'an unchanged rewrite short-circuits before the write, so the cached definition still matches the bytes',
-      );
-    });
-
-    test('writing a non-executable file invalidates nothing', async function (assert) {
-      await realm.write('notes.txt', 'hello', { waitForIndex: false });
-
-      assert.deepEqual(
-        invalidated,
-        [],
-        'a non-executable file has no definition to invalidate',
-      );
-    });
-  });
+        // An unchanged rewrite, a non-executable, and an instance all leave
+        // every loaded module in a warm tab still current, so re-minting would
+        // buy a loader reset per tab and change nothing about what they hold.
+        assert.strictEqual(
+          await readRealmLoaderEpoch(dbAdapter, realmURL),
+          epoch,
+          'none of these changed a module, so no tab needs to drop one',
+        );
+      });
+    },
+  );
 
   module(
     'a schema-widening module rewrite is visible to the next instance write',

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1795,8 +1795,19 @@ module(basename(import.meta.filename), function () {
         },
         async prerenderModule(args: ModulePrerenderArgs) {
           calls++;
-          await gate;
-          return buildModuleResponse(args.url, 'StalePersist', []);
+          // Only the first prerender parks; the retry after the discard
+          // runs straight through. `deps` tags which call produced a row,
+          // so the assertions below can tell the discarded pre-invalidate
+          // result apart from the post-invalidate one.
+          if (calls === 1) {
+            await gate;
+            return buildModuleResponse(args.url, 'StalePersist', [
+              'pre-invalidate',
+            ]);
+          }
+          return buildModuleResponse(args.url, 'StalePersist', [
+            'post-invalidate',
+          ]);
         },
       };
 
@@ -1831,25 +1842,34 @@ module(basename(import.meta.filename), function () {
       // invalidate just deleted.
       releaseGate();
       let result = await Promise.allSettled([pA]);
+      // The module is on disk, so the invalidation means "re-derive it", not
+      // "it does not exist". A re-populates under the post-invalidate
+      // generation and answers from that.
       assert.strictEqual(
         result[0].status,
-        'rejected',
-        'A rejects because the post-skip readFromDatabaseCache misses (row was deleted)',
+        'fulfilled',
+        'A resolves from a populate that ran after the invalidation',
       );
       assert.strictEqual(
         calls,
-        1,
-        'prerenderModule was still called once (no double-prerender)',
+        2,
+        'the discarded populate was re-run exactly once',
       );
 
       let rows = (await dbAdapter.execute(
-        `SELECT url FROM modules WHERE url = $1`,
+        `SELECT deps FROM modules WHERE url = $1`,
         { bind: [moduleURL] },
-      )) as { url: string }[];
-      assert.strictEqual(
-        rows.length,
-        0,
-        'invalidate is honored — no zombie row from A persist',
+      )) as { deps: string[] | string }[];
+      assert.strictEqual(rows.length, 1, 'exactly one row for the module');
+      let deps =
+        typeof rows[0].deps === 'string'
+          ? (JSON.parse(rows[0].deps) as string[])
+          : rows[0].deps;
+      // deps are persisted resolved against the realm.
+      assert.deepEqual(
+        deps,
+        [`${realmURL}post-invalidate`],
+        'invalidate is honored — the row came from the post-invalidate populate, not the discarded one',
       );
     });
 
@@ -2162,9 +2182,11 @@ module(basename(import.meta.filename), function () {
         'C coalesced into B without adding a prerender',
       );
 
-      // Settle A. Its .finally must NOT delete B's entry.
+      // Release A's prerender. The invalidation discarded its result, so A
+      // re-populates — and finds B already in-flight under the same key, so
+      // it joins B rather than starting a third prerender. A therefore
+      // settles with B, not before it.
       gates[0].release();
-      await Promise.allSettled([pA]);
 
       // D should STILL coalesce into B. If A's finally deleted B's entry,
       // D would create a third prerender here.
@@ -2181,10 +2203,16 @@ module(basename(import.meta.filename), function () {
 
       // Release B; everyone converges.
       gates[1].release();
-      let [rB, rC, rD] = await Promise.allSettled([pB, pC, pD]);
+      let [rA, rB, rC, rD] = await Promise.allSettled([pA, pB, pC, pD]);
+      assert.strictEqual(rA.status, 'fulfilled');
       assert.strictEqual(rB.status, 'fulfilled');
       assert.strictEqual(rC.status, 'fulfilled');
       assert.strictEqual(rD.status, 'fulfilled');
+      assert.strictEqual(
+        calls,
+        2,
+        "A's retry joined B's in-flight populate instead of prerendering again",
+      );
     });
 
     test('in-flight prerender persists normally when no invalidate runs', async function (assert) {

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -1776,6 +1776,95 @@ module(basename(import.meta.filename), function () {
       }
     });
 
+    test("a peer's invalidation drops in-flight populates, so a caller arriving after it does not inherit a discarded result", async function (assert) {
+      // A peer realm-server's invalidation reaches this process as a NOTIFY
+      // that ModuleCacheInvalidationListener replays by calling
+      // bumpModuleGeneration. That has to drop in-flight populates the same
+      // way the in-process invalidate() does. If it only bumped, caller B
+      // below would coalesce onto A's pre-invalidation populate, receive the
+      // result the generation guard discards, and — its own snapshot already
+      // carrying the peer's bump — read that empty answer as "no such type"
+      // instead of as a race worth re-running. For a card write serializing
+      // against this module, that is a spurious 500.
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}peer-invalidation-inflight.gts`;
+      let calls = 0;
+      let releaseGate!: () => void;
+      let gate = new Promise<void>((resolve) => {
+        releaseGate = resolve;
+      });
+
+      let prerenderer: Prerenderer = {
+        async prerenderVisit() {
+          throw new Error('Not implemented in mock');
+        },
+        async runCommand() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          if (calls === 1) {
+            await gate;
+          }
+          return buildModuleResponse(args.url, 'PeerInvalidation', []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let pA = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'PeerInvalidation',
+      });
+      pA.catch(() => {});
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      assert.strictEqual(calls, 1, 'A started the only populate so far');
+
+      // Exactly what the listener does on a peer's NOTIFY — no DB delete
+      // here, because the peer already ran it.
+      lookup.bumpModuleGeneration(realmURL, moduleURL);
+
+      let pB = lookup.lookupDefinition({
+        module: rri(moduleURL),
+        name: 'PeerInvalidation',
+      });
+      pB.catch(() => {});
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      assert.strictEqual(
+        calls,
+        2,
+        "B started its own populate — the peer's bump dropped A's in-flight entry",
+      );
+
+      releaseGate();
+      let [rA, rB] = await Promise.allSettled([pA, pB]);
+      assert.strictEqual(
+        rB.status,
+        'fulfilled',
+        'B resolves rather than reporting a readable module as a nonexistent type',
+      );
+      assert.strictEqual(
+        rA.status,
+        'fulfilled',
+        'A re-runs its discarded populate and resolves too',
+      );
+    });
+
     test('in-flight prerender result is dropped when invalidate runs concurrently', async function (assert) {
       await dbAdapter.execute('DELETE FROM modules');
 
@@ -2157,6 +2246,13 @@ module(basename(import.meta.filename), function () {
         module: rri(moduleURL),
         name: 'Identity',
       });
+      // A is not awaited until the end of the test, and its rejection handler
+      // would otherwise attach only then. A regression that makes A reject
+      // would surface in that gap as an unhandled rejection, which
+      // tests/index.ts rethrows — killing the process and taking the rest of
+      // the shard with it. Attaching here keeps such a regression to a failed
+      // assertion on the status asserted below.
+      pA.catch(() => {});
       await waitForCalls(1);
 
       // invalidate drops A's #inFlight entry synchronously.

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -5,6 +5,7 @@ import {
   CachingDefinitionLookup,
   internalKeyFor,
   logger,
+  mintRealmLoaderEpoch,
   trimExecutableExtension,
   type ErrorEntry,
   type JobInfo,
@@ -109,12 +110,14 @@ module(basename(import.meta.filename), function () {
     let dbAdapter: PgAdapter;
     let prerenderModuleCalls: number = 0;
     let prerenderModulePriorities: (number | undefined)[] = [];
+    let prerenderModuleLoaderEpochs: (string | undefined)[] = [];
     let forceEmptyDefinitions: boolean = false;
     let virtualNetwork: VirtualNetwork;
 
     hooks.beforeEach(async () => {
       prerenderModuleCalls = 0;
       prerenderModulePriorities = [];
+      prerenderModuleLoaderEpochs = [];
       forceEmptyDefinitions = false;
     });
     hooks.before(async () => {
@@ -123,6 +126,7 @@ module(basename(import.meta.filename), function () {
         async prerenderModule(args: ModulePrerenderArgs) {
           prerenderModuleCalls++;
           prerenderModulePriorities.push(args.priority);
+          prerenderModuleLoaderEpochs.push(args.renderOptions?.loaderEpoch);
           if (forceEmptyDefinitions) {
             return Promise.resolve({
               id: 'example-id',
@@ -281,6 +285,51 @@ module(basename(import.meta.filename), function () {
         prerenderModuleCalls,
         1,
         'prerenderModule was called once',
+      );
+    });
+
+    // A populate is the one moment a definition is derived from a running
+    // module rather than read back from a row, so it is the one moment the
+    // tab it runs in has to be holding the current bytes. Threading the
+    // realm's epoch is what lets the module route decide that; a populate
+    // that threads nothing renders against whatever the tab already
+    // evaluated, and the definition it caches describes those bytes rather
+    // than the ones on disk.
+    test('a populate threads the realm loader epoch the write path minted', async function (assert) {
+      // Start from a cold modules cache; see lookupDefinition above.
+      await dbAdapter.execute('DELETE FROM modules');
+      let epoch = await mintRealmLoaderEpoch(dbAdapter, realmURL);
+
+      await definitionLookup.lookupDefinition({
+        module: rri(`${realmURL}person.gts`),
+        name: 'Person',
+      });
+
+      // De-duplicated rather than indexed: a lookup can prerender more than
+      // one candidate URL for the same module, and the epoch is per realm,
+      // so what matters is that no candidate went out under a stale one.
+      assert.deepEqual(
+        [...new Set(prerenderModuleLoaderEpochs)],
+        [epoch],
+        'the populate rendered under the epoch the realm currently holds',
+      );
+
+      await dbAdapter.execute('DELETE FROM modules');
+      let rewriteEpoch = await mintRealmLoaderEpoch(dbAdapter, realmURL);
+      prerenderModuleLoaderEpochs = [];
+
+      await definitionLookup.lookupDefinition({
+        module: rri(`${realmURL}person.gts`),
+        name: 'Person',
+      });
+
+      // Read per populate, not captured once: a lookup that kept threading
+      // the epoch it first saw would stop clearing tabs after the first
+      // module write of a process's life.
+      assert.deepEqual(
+        [...new Set(prerenderModuleLoaderEpochs)],
+        [rewriteEpoch],
+        'the next populate picked up the epoch minted after it',
       );
     });
 

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -6,6 +6,8 @@ import {
   SupportedMimeType,
   Deferred,
   IndexWriter,
+  mintRealmLoaderEpoch,
+  readRealmLoaderEpoch,
   VirtualNetwork,
   userInitiatedPriority,
   diffDoc,
@@ -1707,6 +1709,64 @@ module(basename(import.meta.filename), function () {
         assert.ok(
           jsonSeedBatch.invalidations.includes(`${testRealm}mango.json`),
           '.json seed resolves to concrete indexed URL',
+        );
+      });
+
+      // A batch reads the realm's loader epoch when it starts, and with no
+      // executable in its invalidation set its own epoch getter returns that
+      // same token. Committing it unconditionally would write the read-at-start
+      // value back over anything minted in between — including the epoch a
+      // module write mints for the definition it invalidates, whose whole
+      // point is to be current for the populate that follows the write. Those
+      // two overlap on the deferred-indexing paths: a `waitForIndex: false`
+      // write skips the drain, so an instance batch for the realm can be
+      // in flight when a module lands.
+      test('an instance-only batch commit leaves an epoch minted after it started', async function (assert) {
+        let batch = await new IndexWriter(testDbAdapter).createBatch(
+          new URL(realm.url),
+          virtualNetwork,
+        );
+        await batch.invalidate([new URL(`${testRealm}mango.json`)]);
+        assert.false(
+          batch.invalidations.some((url) => url.endsWith('.gts')),
+          'precondition: nothing executable is in this batch, so it mints no epoch of its own',
+        );
+
+        let mintedMidBatch = await mintRealmLoaderEpoch(
+          testDbAdapter,
+          realm.url,
+        );
+
+        await batch.done();
+
+        assert.strictEqual(
+          await readRealmLoaderEpoch(testDbAdapter, realm.url),
+          mintedMidBatch,
+          'the commit left the newer epoch standing rather than restoring the one it read at start',
+        );
+      });
+
+      test('a batch that invalidates an executable commits an epoch of its own', async function (assert) {
+        let before = await readRealmLoaderEpoch(testDbAdapter, realm.url);
+        let batch = await new IndexWriter(testDbAdapter).createBatch(
+          new URL(realm.url),
+          virtualNetwork,
+        );
+        await batch.invalidate([new URL(`${testRealm}person.gts`)]);
+        assert.true(
+          batch.invalidations.some((url) => url.endsWith('.gts')),
+          'precondition: the batch carries an executable',
+        );
+
+        await batch.done();
+
+        // The other half of the contract the test above pins: skipping the
+        // write when nothing was minted must not skip it when something was,
+        // or an index pass would stop clearing warm tabs entirely.
+        assert.notStrictEqual(
+          await readRealmLoaderEpoch(testDbAdapter, realm.url),
+          before,
+          'the executable invalidation advanced the realm epoch',
         );
       });
 

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -91,6 +91,17 @@ const COALESCE_NOTIFY_WAIT_MS = 180_000; // 180 seconds
 // principle cycle the loser indefinitely; capping at a small number and
 // throwing surfaces it instead of silently hanging.
 const COALESCE_MAX_ITERATIONS = 4;
+// How many times `lookupDefinition` re-runs a populate whose result an
+// invalidation discarded out from under it. A populate that loses this race
+// returns the post-invalidate cache state — `undefined` once the invalidation
+// has deleted the row — which is indistinguishable at the call site from "this
+// module does not exist" even though the module is on disk and readable. A
+// module write invalidates and then indexes, and the index job invalidates
+// again, so any serialization that follows a module write can land inside that
+// second invalidation's window. Retrying re-snapshots the generation and
+// converges as soon as no invalidation lands mid-populate; the cap keeps an
+// invalidation storm from spinning on prerenders instead of surfacing.
+const POPULATE_RACE_MAX_ATTEMPTS = 3;
 const modulesTableCoerceTypes: TypeCoercion = Object.freeze({
   definitions: 'JSON',
   deps: 'JSON',
@@ -770,6 +781,25 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     };
   }
 
+  // Narrower than `generationChanged`: true only when THIS module was
+  // invalidated, ignoring realm-wide and global wipes. `invalidate()` says
+  // "these bytes changed, re-derive them", so a populate it discarded is
+  // worth re-running. `clearRealmDefinitions` / `clearAllDefinitions` say
+  // "drop this realm's (or every) definition now" — re-populating into one of
+  // those would refill rows the caller just cleared, so a populate they
+  // discard stays discarded.
+  private moduleGenerationChanged(
+    resolvedRealmURL: string,
+    moduleURL: string,
+    snapshot: { module: number; realm: number; global: number },
+  ): boolean {
+    return (
+      (this.#moduleGenerations.get(
+        moduleGenerationKey(resolvedRealmURL, moduleURL),
+      ) ?? 0) !== snapshot.module
+    );
+  }
+
   private generationChanged(
     resolvedRealmURL: string,
     moduleURL: string,
@@ -926,15 +956,40 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolvedRealmURL,
     } = context;
 
-    let moduleEntry = await this.loadDefinitionCacheEntry({
-      moduleURL: canonicalModuleURL,
-      realmURL,
-      resolvedRealmURL,
-      cacheScope,
-      cacheUserId,
-      prerenderUserId,
-      priority: contextOpts?.priority,
-    });
+    // An empty result means one of two things, and only the generation
+    // separates them: the module genuinely has no definition to load, or a
+    // populate ran and an invalidation discarded its result before it could
+    // persist. Retry only the second — the module is on disk, and the next
+    // populate reads it under the post-invalidate generation.
+    let moduleEntry: DefinitionCacheEntry | undefined;
+    for (let attempt = 0; attempt < POPULATE_RACE_MAX_ATTEMPTS; attempt++) {
+      let snapshot = this.snapshotGeneration(
+        resolvedRealmURL,
+        canonicalModuleURL,
+      );
+      moduleEntry = await this.loadDefinitionCacheEntry({
+        moduleURL: canonicalModuleURL,
+        realmURL,
+        resolvedRealmURL,
+        cacheScope,
+        cacheUserId,
+        prerenderUserId,
+        priority: contextOpts?.priority,
+      });
+      if (
+        moduleEntry ||
+        !this.moduleGenerationChanged(
+          resolvedRealmURL,
+          canonicalModuleURL,
+          snapshot,
+        )
+      ) {
+        break;
+      }
+      log.debug(
+        `definition populate for ${canonicalModuleURL} was discarded by a concurrent invalidation; retrying (attempt ${attempt + 1} of ${POPULATE_RACE_MAX_ATTEMPTS})`,
+      );
+    }
 
     if (!moduleEntry) {
       throw new FilterRefersToNonexistentTypeError(codeRef, {

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -821,12 +821,22 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   // double-bump from the self-notify echo is observationally indistinguishable
   // from a single bump because in-flight prerenders only test for snapshot
   // equality, not absolute value.
+  //
+  // Each bump drops the in-flight entries it invalidates, so the two always
+  // move together no matter who bumps. A bump without the drop leaves a
+  // populate that started before the invalidation joinable: a caller arriving
+  // afterwards coalesces onto it, gets the discarded (empty) result, and —
+  // because its own generation snapshot already includes the bump — reads that
+  // as "this module has no definition" rather than as a race it should retry.
+  // For a `fileSerialization` that is a failed card write for a module sitting
+  // readable on disk.
   bumpModuleGeneration(resolvedRealmURL: string, moduleURL: string): void {
     let key = moduleGenerationKey(resolvedRealmURL, moduleURL);
     this.#moduleGenerations.set(
       key,
       (this.#moduleGenerations.get(key) ?? 0) + 1,
     );
+    this.dropInFlightForRealm(resolvedRealmURL, [moduleURL]);
   }
 
   bumpRealmGeneration(resolvedRealmURL: string): void {
@@ -834,10 +844,12 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       resolvedRealmURL,
       (this.#realmGenerations.get(resolvedRealmURL) ?? 0) + 1,
     );
+    this.dropInFlightForRealm(resolvedRealmURL);
   }
 
   bumpGlobalGeneration(): void {
     this.#globalGeneration += 1;
+    this.#inFlight.clear();
   }
 
   // Returns true if the cached entry has a top-level error and has exceeded
@@ -986,9 +998,11 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       ) {
         break;
       }
-      log.debug(
-        `definition populate for ${canonicalModuleURL} was discarded by a concurrent invalidation; retrying (attempt ${attempt + 1} of ${POPULATE_RACE_MAX_ATTEMPTS})`,
-      );
+      if (attempt + 1 < POPULATE_RACE_MAX_ATTEMPTS) {
+        log.debug(
+          `definition populate for ${canonicalModuleURL} was discarded by a concurrent invalidation; retrying (attempt ${attempt + 2} of ${POPULATE_RACE_MAX_ATTEMPTS})`,
+        );
+      }
     }
 
     if (!moduleEntry) {
@@ -1055,9 +1069,9 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     // leaves unrelated in-flight prerenders in the same realm untouched —
     // their generations are unchanged, their persists proceed normally.
     for (let invalidatedURL of uniqueInvalidations) {
+      // Drops the matching in-flight entries as it bumps.
       this.bumpModuleGeneration(resolvedRealmURL, invalidatedURL);
     }
-    this.dropInFlightForRealm(resolvedRealmURL, uniqueInvalidations);
     await this.deleteModuleAliases(resolvedRealmURL, uniqueInvalidations);
     await this.notifyDefinitionCacheInvalidations(
       resolvedRealmURL,
@@ -1070,7 +1084,6 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     // Realm-scope bump: every in-flight prerender for this realm (any
     // module URL, any scope/user) sees the mismatch at persist time.
     this.bumpRealmGeneration(resolvedRealmURL);
-    this.dropInFlightForRealm(resolvedRealmURL);
     await this.query([
       'DELETE FROM',
       MODULES_TABLE,
@@ -1084,7 +1097,6 @@ export class CachingDefinitionLookup implements DefinitionLookup {
 
   async clearAllDefinitions(): Promise<void> {
     this.bumpGlobalGeneration();
-    this.#inFlight.clear();
     await this.query(['DELETE FROM', MODULES_TABLE]);
     await this.notifyGlobalDefinitionCacheInvalidation();
   }

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -785,9 +785,14 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   // invalidated, ignoring realm-wide and global wipes. `invalidate()` says
   // "these bytes changed, re-derive them", so a populate it discarded is
   // worth re-running. `clearRealmDefinitions` / `clearAllDefinitions` say
-  // "drop this realm's (or every) definition now" — re-populating into one of
-  // those would refill rows the caller just cleared, so a populate they
-  // discard stays discarded.
+  // "drop this realm's (or every) definition now", so a populate they discard
+  // stays discarded rather than refilling what the caller just cleared.
+  //
+  // A wipe landing in the same populate window as a module invalidation is
+  // read as the module invalidation and does retry, refilling that one row.
+  // That is the deliberate reading: the retry re-derives from current disk
+  // bytes, which is the state a wipe exists to force, and answering the
+  // caller beats failing a card write over a module that is readable.
   private moduleGenerationChanged(
     resolvedRealmURL: string,
     moduleURL: string,

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -11,6 +11,7 @@ import {
   type Querier,
 } from './expression.ts';
 import { clampSerializedError, type SerializedError } from './error.ts';
+import { readRealmLoaderEpoch } from './loader-epoch.ts';
 import { logger } from './log.ts';
 
 // Debug instrumentation for diagnosing pre-warm vs visit-phase cache-key
@@ -1369,6 +1370,18 @@ export class CachingDefinitionLookup implements DefinitionLookup {
   ): Promise<ModuleRenderResponse> {
     let permissions = await fetchUserPermissions(this.#dbAdapter, { userId });
     let auth = this.#createPrerenderAuth(userId, permissions);
+    // A populate exists because no usable row was found, which on the write
+    // path is precisely because the module's bytes just changed — so the tab
+    // this render lands on is the one most likely to be holding the module it
+    // superseded. Threading the realm's loader epoch lets the module route
+    // decide: it resets the tab's loader when the epoch differs from the one
+    // that tab last cleared for, so a rewritten module costs one reset per
+    // tab and a realm whose modules have not changed costs none. Without it
+    // the render imports out of whatever the tab already evaluated and the
+    // definition we cache under the new bytes' URL describes the old ones.
+    //
+    // A read per populate, not per lookup: cache hits never reach here.
+    let loaderEpoch = await readRealmLoaderEpoch(this.#dbAdapter, realmURL);
     return await this.#prerenderer.prerenderModule({
       affinityType: 'realm',
       affinityValue: realmURL,
@@ -1376,6 +1389,7 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       url: moduleUrl,
       auth,
       priority,
+      renderOptions: { loaderEpoch },
     });
   }
 

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -980,6 +980,10 @@ export class CachingDefinitionLookup implements DefinitionLookup {
     // persist. Retry only the second — the module is on disk, and the next
     // populate reads it under the post-invalidate generation.
     let moduleEntry: DefinitionCacheEntry | undefined;
+    // Set when the final attempt ended on a generation change rather than on
+    // an empty cache: the two are indistinguishable in the result and only
+    // this separates "no such module" from "every populate was discarded".
+    let exhaustedByInvalidation = false;
     for (let attempt = 0; attempt < POPULATE_RACE_MAX_ATTEMPTS; attempt++) {
       let snapshot = this.snapshotGeneration(
         resolvedRealmURL,
@@ -1008,12 +1012,16 @@ export class CachingDefinitionLookup implements DefinitionLookup {
         log.debug(
           `definition populate for ${canonicalModuleURL} was discarded by a concurrent invalidation; retrying (attempt ${attempt + 2} of ${POPULATE_RACE_MAX_ATTEMPTS})`,
         );
+      } else {
+        exhaustedByInvalidation = true;
       }
     }
 
     if (!moduleEntry) {
       throw new FilterRefersToNonexistentTypeError(codeRef, {
-        cause: `Module entry not found for URL: ${codeRef.module}`,
+        cause: exhaustedByInvalidation
+          ? `Module entry not found for URL: ${codeRef.module} — every one of ${POPULATE_RACE_MAX_ATTEMPTS} populate attempts was discarded by a concurrent invalidation, so the module may be readable on disk and this is not evidence that the type is absent`
+          : `Module entry not found for URL: ${codeRef.module}`,
       });
     }
 

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -1872,10 +1872,22 @@ export class Batch {
   }
 
   private async applyBatchUpdates() {
+    // Reading the getter is what mints, so read it before asking whether it
+    // did. `loader_epoch` joins the upsert only when this batch minted one:
+    // the getter otherwise returns the token read at batch start, and writing
+    // that back would clobber any epoch minted after this batch began —
+    // including the one a concurrent module write minted for the definition
+    // it invalidated, whose whole purpose is to be current for the populate
+    // that follows the write rather than for the index pass. Omitted from the
+    // insert too; a realm's first row takes the column's own '0' default,
+    // which is the no-epoch-yet sentinel a fresh tab mismatches anyway.
+    let loaderEpoch = this.loaderEpoch;
     let { nameExpressions, valueExpressions } = asExpressions({
       realm_url: this.realmURL.href,
       current_generation: this.generation,
-      loader_epoch: this.loaderEpoch,
+      ...(this.#mintedLoaderEpoch === undefined
+        ? {}
+        : { loader_epoch: loaderEpoch }),
     } as RealmGenerationsTable);
     await this.#query([
       ...upsert(

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1245,6 +1245,7 @@ export * from './published-realm-url.ts';
 export * from './realm-index-card.ts';
 export * from './cached-fetch.ts';
 export * from './definition-lookup.ts';
+export * from './loader-epoch.ts';
 export * from './definitions.ts';
 export * from './query-canonicalization.ts';
 export * from './searchable-routes.ts';

--- a/packages/runtime-common/loader-epoch.ts
+++ b/packages/runtime-common/loader-epoch.ts
@@ -1,0 +1,70 @@
+import { v4 as uuidv4 } from '@lukeed/uuid';
+import type { DBAdapter } from './db.ts';
+import {
+  addExplicitParens,
+  param,
+  query,
+  separatedByCommas,
+  type Expression,
+} from './expression.ts';
+import type { RealmGenerationsTable } from './index-structure.ts';
+
+// `realm_generations.loader_epoch` is the token a prerender tab uses to decide
+// when the modules it has already evaluated belong to a superseded timeline:
+// a render threads the realm's epoch, and the route resets that tab's loader
+// whenever the threaded value differs from the one it last cleared for. The
+// column's original writer is the index pass — `IndexWriter.loaderEpoch` mints
+// a fresh token whenever a batch's invalidation set contains an executable —
+// which covers a tab that has to re-render a module after indexing observed
+// the edit.
+//
+// It does not cover the window before that: a module's bytes change at write
+// time, and everything that resolves a definition in the meantime (the whole
+// of it on the deferred-indexing paths) prerenders that module against
+// whatever a warm tab still holds. The prerendered definition is derived from
+// the pre-write module, cached under the post-write module's URL, and outlives
+// the write — the same staleness the write-time definition-cache invalidation
+// exists to remove, reinstated one layer down. So the write path mints an
+// epoch too, at the point the bytes change.
+
+// Mint a fresh loader epoch for `realmURL` and return it. Called by the write
+// path once per batch that carries at least one module: the token's only
+// meaning is "different from what a tab may be holding", so one per batch is
+// enough no matter how many modules the batch rewrites, and minting per file
+// would cost a warm tab one loader reset per file.
+//
+// The insert covers a realm whose first module write lands before any index
+// pass has committed a `realm_generations` row. `current_generation` is only
+// in the column list to satisfy the insert; the conflict clause deliberately
+// leaves it alone so this never disturbs the generation counter an index pass
+// owns.
+export async function mintRealmLoaderEpoch(
+  dbAdapter: DBAdapter,
+  realmURL: string,
+): Promise<string> {
+  let loaderEpoch = uuidv4();
+  await query(dbAdapter, [
+    'INSERT INTO realm_generations (realm_url, current_generation, loader_epoch) VALUES',
+    ...(addExplicitParens(
+      separatedByCommas([[param(realmURL)], [param(0)], [param(loaderEpoch)]]),
+    ) as Expression),
+    'ON CONFLICT ON CONSTRAINT realm_generations_pkey DO UPDATE SET loader_epoch=EXCLUDED.loader_epoch',
+  ] as Expression);
+  return loaderEpoch;
+}
+
+// The realm's committed loader epoch, or the `'0'` no-epoch-yet sentinel for a
+// realm that has neither indexed nor had a module written. Threading the
+// sentinel rather than nothing is deliberate: a tab holding no epoch at all
+// mismatches every value, so the first module render against a realm
+// synchronizes the tab either way.
+export async function readRealmLoaderEpoch(
+  dbAdapter: DBAdapter,
+  realmURL: string,
+): Promise<string> {
+  let [row] = (await query(dbAdapter, [
+    'SELECT loader_epoch FROM realm_generations WHERE realm_url =',
+    param(realmURL),
+  ] as Expression)) as Pick<RealmGenerationsTable, 'loader_epoch'>[];
+  return row?.loader_epoch ?? '0';
+}

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2422,6 +2422,7 @@ export class Realm {
       let { lastModified } = await this.#adapter.write(path, content);
       (isNewFile ? addedFiles : updatedFiles).push(path);
       this.invalidateCache(path);
+      await this.#notifyFileChange(path);
       if (currentWriteType === 'module') {
         // The definition cache is keyed by module URL with no freshness
         // check on the row — `readFromDatabaseCache` never compares content
@@ -2441,7 +2442,20 @@ export class Realm {
         // reports success; a dropped attribute is indistinguishable from an
         // unset one, so nothing downstream can tell it happened.
         //
-        // Best-effort, like `#notifyFileChange` below. The bytes are already
+        // Ordered after `#notifyFileChange` deliberately. This replica dropped
+        // its own byte caches synchronously in `invalidateCache(path)` above,
+        // but peer replicas only drop theirs when they receive that
+        // notification. Deleting the definition row is what makes the next
+        // `lookupDefinition` — on any replica — prerender the module; a peer
+        // that prerenders while still holding pre-write bytes derives the old
+        // schema and caches THAT, reinstating the staleness this call removes
+        // and making it durable until indexing lands. Publishing the byte
+        // invalidation first narrows that to peers which have not yet
+        // processed the notification; it does not close it, since the notify
+        // is best-effort and applied asynchronously. The index job's own
+        // invalidation stays the backstop.
+        //
+        // Best-effort, like `#notifyFileChange` above. The bytes are already
         // durable at this point but `urls` has not been appended to yet, so
         // letting this throw would abandon the batch before ANY index job is
         // enqueued — for this file and for every file written ahead of it —
@@ -2459,7 +2473,6 @@ export class Realm {
           );
         }
       }
-      await this.#notifyFileChange(path);
       results.push({ path, lastModified });
       fileMetaRows.push({ path, contentHash, contentSize });
       urls.push(url);

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2422,6 +2422,32 @@ export class Realm {
       let { lastModified } = await this.#adapter.write(path, content);
       (isNewFile ? addedFiles : updatedFiles).push(path);
       this.invalidateCache(path);
+      if (currentWriteType === 'module') {
+        // The definition cache is keyed by module URL with no freshness
+        // check on the row — `readFromDatabaseCache` never compares content
+        // hashes or mtimes, and only error rows carry a TTL — so a cached
+        // definition for this module stays authoritative until something
+        // deletes it. Dropping it here, where the bytes change, keeps that
+        // cache in step with the file rather than with the index: the next
+        // `lookupDefinition` misses and reads the rewritten module through
+        // `prerenderModule`, which resolves it off disk.
+        //
+        // Leaving this to the index job's `onInvalidation` instead would
+        // leave a window — the whole of it on the deferred-indexing paths —
+        // in which `fileSerialization` resolves an instance against the
+        // module's previous schema. `serializeCardResource` skips every
+        // attribute whose field that schema doesn't declare, so the
+        // instance lands on disk missing the new field and the write still
+        // reports success; a dropped attribute is indistinguishable from an
+        // unset one, so nothing downstream can tell it happened.
+        //
+        // Awaited, and allowed to reject: a failed invalidation leaves rows
+        // that silently drop fields out of every instance serialized
+        // against them, which is worse for the caller than a failed write
+        // whose bytes are already durable and whose index job will
+        // invalidate again regardless.
+        await this.#definitionLookup.invalidate(url.href);
+      }
       await this.#notifyFileChange(path);
       results.push({ path, lastModified });
       fileMetaRows.push({ path, contentHash, contentSize });
@@ -5620,11 +5646,10 @@ export class Realm {
     // caller is holding, so waiting deadlocks. Serialization still resolves a
     // definition it has never seen — `lookupDefinition` reads through to
     // `prerenderModule`, which serves the module off disk rather than out of
-    // the index. What the drain did cover and this path does not is a module
-    // the same caller just rewrote: the cached definition stays authoritative
-    // until the deferred index job invalidates it, so a serialization run in
-    // that window is against the previous schema and `fileSerialization`
-    // drops attributes whose fields it doesn't know.
+    // the index. A module the same caller just rewrote reads through for the
+    // same reason: `_batchWriteUnlocked` drops that module's cached
+    // definition as it writes the bytes, so no indexing-dependent step
+    // stands between a module rewrite and the serialization that follows it.
     if (!duringPrerender) {
       let pending = this.incrementalIndexing();
       if (pending) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2427,10 +2427,10 @@ export class Realm {
         // check on the row — `readFromDatabaseCache` never compares content
         // hashes or mtimes, and only error rows carry a TTL — so a cached
         // definition for this module stays authoritative until something
-        // deletes it. Dropping it here, where the bytes change, keeps that
-        // cache in step with the file rather than with the index: the next
-        // `lookupDefinition` misses and reads the rewritten module through
-        // `prerenderModule`, which resolves it off disk.
+        // deletes it. Dropping it here, where the bytes change, keeps a
+        // written module's cached definition in step with the file rather
+        // than with the index: the next `lookupDefinition` misses and reads
+        // the rewritten module through `prerenderModule`, off disk.
         //
         // Leaving this to the index job's `onInvalidation` instead would
         // leave a window — the whole of it on the deferred-indexing paths —
@@ -2441,12 +2441,23 @@ export class Realm {
         // reports success; a dropped attribute is indistinguishable from an
         // unset one, so nothing downstream can tell it happened.
         //
-        // Awaited, and allowed to reject: a failed invalidation leaves rows
-        // that silently drop fields out of every instance serialized
-        // against them, which is worse for the caller than a failed write
-        // whose bytes are already durable and whose index job will
-        // invalidate again regardless.
-        await this.#definitionLookup.invalidate(url.href);
+        // Best-effort, like `#notifyFileChange` below. The bytes are already
+        // durable at this point but `urls` has not been appended to yet, so
+        // letting this throw would abandon the batch before ANY index job is
+        // enqueued — for this file and for every file written ahead of it —
+        // and the caller's natural remedy makes it worse: a retry with the
+        // same bytes takes the unchanged-content short-circuit above, so it
+        // enqueues nothing either and the file stays on disk and out of the
+        // index until an unrelated edit or a full reindex. Swallowing leaves
+        // only the staleness this call exists to remove, which the index
+        // job's own invalidation still clears.
+        try {
+          await this.#definitionLookup.invalidate(url.href);
+        } catch (err: unknown) {
+          this.#log.error(
+            `failed to invalidate the definition cache for ${url.href}; a stale cached definition may drop unknown attributes from instances serialized before indexing lands: ${stringifyErrorForLog(err)}`,
+          );
+        }
       }
       await this.#notifyFileChange(path);
       results.push({ path, lastModified });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -112,6 +112,7 @@ import {
   param,
   dbExpression,
   dbAdapterQuerier,
+  mintRealmLoaderEpoch,
   type Querier,
   type CodeRef,
   type LooseSingleCardDocument,
@@ -2320,6 +2321,11 @@ export class Realm {
       contentSize?: number;
     }[] = [];
     let lastWriteType: 'module' | 'instance' | undefined;
+    // Whether this batch has already minted a loader epoch. The token only
+    // has to differ from whatever a prerender tab is holding, so one per
+    // batch covers every module in it; minting per file would cost each warm
+    // tab a loader reset per file for no extra freshness.
+    let mintedLoaderEpoch = false;
     let addedFiles: LocalPath[] = [];
     let updatedFiles: LocalPath[] = [];
     let invalidations: Set<string> = new Set();
@@ -2457,14 +2463,52 @@ export class Realm {
         //
         // Best-effort, like `#notifyFileChange` above. The bytes are already
         // durable at this point but `urls` has not been appended to yet, so
-        // letting this throw would abandon the batch before ANY index job is
-        // enqueued — for this file and for every file written ahead of it —
-        // and the caller's natural remedy makes it worse: a retry with the
-        // same bytes takes the unchanged-content short-circuit above, so it
-        // enqueues nothing either and the file stays on disk and out of the
-        // index until an unrelated edit or a full reindex. Swallowing leaves
-        // only the staleness this call exists to remove, which the index
-        // job's own invalidation still clears.
+        // letting either step throw would abandon the batch before ANY index
+        // job is enqueued — for this file and for every file written ahead of
+        // it — and the caller's natural remedy makes it worse: a retry with
+        // the same bytes takes the unchanged-content short-circuit above, so
+        // it enqueues nothing either and the file stays on disk and out of
+        // the index until an unrelated edit or a full reindex. Swallowing
+        // leaves only the staleness these steps exist to remove, which the
+        // index job's own invalidation still clears. They are caught
+        // separately so a failure in one still leaves the other's benefit:
+        // the delete without the epoch is what this write path did before
+        // the epoch existed, and the epoch without the delete still stops a
+        // later invalidation from re-deriving the definition off a warm tab.
+        //
+        // Deleting the cached definition only guarantees the next lookup
+        // re-derives one; it says nothing about what that lookup derives it
+        // FROM. `lookupDefinition` repopulates by prerendering the module,
+        // and a prerender tab that already evaluated this module keeps
+        // serving the evaluated copy — the route re-reads the file's metadata
+        // (so the response even carries the post-write mtime) but imports out
+        // of the loader it is holding. The result is the pre-write schema,
+        // cached under the post-write module's URL and durable until
+        // something else invalidates it: the staleness the delete removes,
+        // reinstated one layer down.
+        //
+        // Minting a loader epoch is how this codebase already says "warm tabs
+        // are stale for this realm" — an index pass whose invalidation set
+        // contains an executable mints one, and the render routes reset a
+        // tab's loader once per epoch it has not cleared for. The write path
+        // has to mint too, because every definition resolved between the
+        // write and that index pass — the whole of the window on the
+        // deferred-indexing paths — is resolved before the pass's epoch
+        // exists. Ordered before the delete so the epoch is already current
+        // for any lookup that observes the missing row.
+        if (!mintedLoaderEpoch) {
+          try {
+            await mintRealmLoaderEpoch(this.#dbAdapter, this.url);
+            // Only on success: a transient failure here gets another attempt
+            // from the next module in the batch rather than leaving every
+            // module in it renderable off a warm tab.
+            mintedLoaderEpoch = true;
+          } catch (err: unknown) {
+            this.#log.error(
+              `failed to mint a loader epoch for ${this.url} after writing ${url.href}; a prerender tab holding the pre-write module may re-derive its previous schema: ${stringifyErrorForLog(err)}`,
+            );
+          }
+        }
         try {
           await this.#definitionLookup.invalidate(url.href);
         } catch (err: unknown) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2472,9 +2472,9 @@ export class Realm {
         // leaves only the staleness these steps exist to remove, which the
         // index job's own invalidation still clears. They are caught
         // separately so a failure in one still leaves the other's benefit:
-        // the delete without the epoch is what this write path did before
-        // the epoch existed, and the epoch without the delete still stops a
-        // later invalidation from re-deriving the definition off a warm tab.
+        // the delete alone still drops the row a stale definition sits in,
+        // and the epoch alone still stops a later invalidation from
+        // re-deriving that definition off a warm tab.
         //
         // Deleting the cached definition only guarantees the next lookup
         // re-derives one; it says nothing about what that lookup derives it


### PR DESCRIPTION
## What this changes

A module rewrite must be visible to the instance write that follows it. Four pieces — the first three in `packages/runtime-common`, the fourth spanning it and `packages/host`:

1. **`_batchWriteUnlocked` invalidates the definition cache for every executable file it writes** — the same pair the foreign-write file watcher already runs, so a module rewrite has the same cache semantics regardless of which process wrote the bytes.
2. **`lookupDefinition` re-runs a populate that an invalidation discarded**, bounded, when the module's own generation moved during it.
3. **Generation bumps drop the in-flight populates they invalidate**, so the counter and the `#inFlight` map cannot move apart.
4. **The write mints a loader epoch, and the module route honours it**, so the populate (1) forces is rendered against the bytes on disk rather than out of a warm prerender tab.

## Why (1)

The DB definition cache is keyed by module URL, and `readFromDatabaseCache` applies no freshness check — no content hash, no mtime, and a TTL only for error rows. A module's cached definition therefore stays authoritative until something deletes it, and the only things that did were the indexing job's `onInvalidation` and the foreign-write watcher.

Between a `.gts` write and that write being indexed, `fileSerialization` resolves an instance's type through the cache and gets the previous schema. `serializeCardResource` skips every attribute whose field that schema doesn't declare (`file-serializer.ts`, `processAttributes`). The instance lands on disk without the new field, the write reports success, and the response echo is built from the same dropped-field serialization. A dropped attribute is indistinguishable from an unset one, so nothing downstream can tell.

Two reachable paths:

- **Prerender-originated POST/PATCH** — `createCard`'s pre-serialization drain is skipped here, because waiting would deadlock on the render slot (and, on the queued-command path, the worker) the caller holds. A headless command that rewrites a module and then runs `SaveCardCommand` goes through this.
- **Plain `PATCH`** — `patchCardInstance` serializes before `_batchWriteUnlocked` drains, and never had a drain of its own.

Invalidating at the write closes both without adding a drain: the next `lookupDefinition` misses and reads the rewritten module through `prerenderModule`.

## Why (2)

On its own, (1) trades a silent field drop for a 500 on those same paths.

`populateDefinitionCacheEntry` guards against an in-flight populate resurrecting a row an invalidation just deleted: if the generation moved while it was prerendering, it discards its result and returns whatever the cache now holds — `undefined` once the row is gone. `lookupDefinition` can't tell that from "this module has no definition", so it raises `FilterRefersToNonexistentTypeError` for a module readable on disk.

A module write now invalidates, and its index job invalidates the same URLs again, so a serialization in between lands in that second window routinely rather than rarely:

1. write `person.gts` → invalidate (generation N→N+1), enqueue index job
2. PATCH → miss → populate starts, snapshots N+1
3. index job → `onInvalidation` → invalidate (N+1→N+2)
4. populate discarded, returns `undefined` → 500

**Returning the discarded result to the caller instead does not work**, and the existing suite proves it: the populate may have started *before* the invalidating write, in which case its result is genuinely stale. Doing that fails `invalidate drops in-flight entries so post-invalidation lookups do not join the stale promise` with `actual: CoalesceInvalidate v1, expected: v2` — it serves the stale schema this PR exists to stop. The generation counter cannot distinguish "started before the write" from "started after, redundant invalidation landed", so re-deriving is the only sound answer.

The retry keys off the **module** generation. `invalidate()` means "these bytes changed, re-derive"; `clearRealmDefinitions` / `clearAllDefinitions` mean "drop these rows now", and a populate they discard stays discarded. A wipe landing in the same window as a module invalidation reads as the module invalidation and does retry, refilling that one row — deliberate, and stated in the comment.

## Why (3)

`ModuleCacheInvalidationListener` replays a peer's NOTIFY with `bumpModuleGeneration` alone, while in-process `invalidate()` also drops the matching in-flight populates. That asymmetry defeated (2) across replicas: a populate started before the peer's invalidation stayed joinable, a caller arriving after coalesced onto it, received the discarded empty result, and — its own snapshot already carrying the bump — read that as "no such type" without retrying.

Fixed at the cause rather than at the listener: each bump now drops what it invalidates, so the two move together whoever bumps. The explicit drops at the `invalidate` / `clearRealmDefinitions` / `clearAllDefinitions` sites were doing this already and are now carried by the bump.

## Why (4)

(1) guarantees the next `lookupDefinition` re-derives a definition. It says nothing about what that lookup derives one **from**.

A populate prerenders the module, and a prerender tab that already evaluated it keeps serving the evaluated copy: `routes/module.ts` re-reads the file's metadata — so the response carries the post-write mtime — but imports out of the loader the tab is holding. The definition cached under the rewritten module's URL then describes the bytes it replaced, and stays authoritative until something else drops it. That is the staleness (1) removes, reinstated one layer down.

This is what the end-to-end `PATCH` test in this PR was catching: the row was dropped, the repopulate went out to a reused tab, and the field the rewrite added was still missing from the response and from disk. Instrumented against a real prerender pool, the same module rendered three times across that one test — the pre-warm (`firstName`), the post-rewrite populate on a **reused** tab (`firstName` only, carrying the post-rewrite mtime), and the index job's own render on a pristine loader (`firstName`, `lastName`). The middle one is what got cached.

The realm's loader epoch is how this codebase already says "warm tabs are stale for this realm": `IndexWriter.loaderEpoch` mints a fresh token whenever a batch's invalidation set contains an executable, and `routes/render.ts` resets a tab's loader once per epoch it has not cleared for. Two pieces were missing for the write path:

- **Nothing minted at write time.** The token only advances when an index pass commits, so every definition resolved before that — the whole of the window on the deferred-indexing paths, which is exactly the window this PR is about — was resolved before an epoch describing the change existed.
- **`routes/module.ts` never read one.** It honours `clearCache` and nothing else, and `prerenderModule` — the call the definition populate makes — drives that route. So even a minted epoch would not have reached the render that needed it.

So `_batchWriteUnlocked` mints once per batch that carries a module, immediately before it invalidates, and the populate threads the realm's committed epoch into the render. One mint per batch rather than per file: the token only has to differ from what a tab is holding, so per-file minting would cost every warm tab a loader reset per module and buy no freshness the first mint had not already bought. Writes that change no module — an unchanged rewrite, a non-executable, an instance — leave it alone.

The reset lives on the **route's** model hook rather than in `buildModuleModel`, which the route shares with `card-prerender.gts`. That component renders in the app's own tab, where the loader and store belong to the session and are already kept current by the file resources and realm subscriptions the app runs. Replacing them there discards live state on a schedule the app has no part in, and it collides with the app's own flush: `saveSource`'s `resetLoader` is the debounced variety, so a reset from a module render inside the same 250 ms window suppresses it and leaves the just-written module loaded. A tab that reached the route exists to serve renders and holds nothing else worth keeping. The prerender pool goes through that route, so the realm-server behaviour is the same either way.

The route holds its epoch under its own key (`__boxelModuleLoaderEpoch`) rather than the one `routes/render.ts` uses. Visits thread the epoch their indexing batch minted, which is not committed until the batch ends, while this route's callers read the committed column. A shared key would read that lag as two timelines alternating and reset the loader on every render for the length of the batch. Separate keys cost a tab one extra reset per epoch — each series synchronizes independently — and a reset only ever leaves the loader fresher than the other series assumes.

## Ordering and failure semantics

The invalidation runs **after** `#notifyFileChange`. This replica drops its own byte caches synchronously in `invalidateCache(path)`, but peers only drop theirs on the notification; clearing the definition row first is what lets a peer holding pre-write bytes prerender the old schema and cache it, making the staleness durable instead of transient. Notifying first narrows that to peers which haven't processed the notification — it does not close it, since the notify is best-effort and asynchronous, and the index job's invalidation remains the backstop.

The mint runs **before** the invalidation, so the epoch is already current for any lookup that observes the missing row.

Both are **best-effort rather than fatal**, and caught separately. They run after the bytes are durable but before the URL joins the batch's index-enqueue list, so a throw abandoned the write with the file on disk and no index job queued — for it or for anything written ahead of it — and a retry with identical bytes takes the unchanged-content short-circuit and enqueues nothing either. Swallowing leaves only the staleness the calls remove, which indexing still clears. Separate `catch`es so a failure in one keeps the other's benefit: the delete without the epoch is what this write path did before the epoch existed, and the epoch without the delete still stops a later invalidation from re-deriving off a warm tab. The mint records success only after it commits, so a transient failure gets another attempt from the next module in the batch.

## Cost

One dependency fan-out plus a delete and a NOTIFY per changed module, on the pinned connection holding the realm write lock, plus one `realm_generations` upsert per batch that carries a module. Bounded by two existing guards: only executable extensions reach it, and an unchanged-content write short-circuits earlier. Unlike `handleExecutableInvalidations`, which fans out with `Promise.all`, these run sequentially — a known cost on large `/_atomic` batches, left as a follow-up rather than widening this PR.

On the read side, (4) adds one indexed single-row read per definition **populate** — cache hits never reach it — and one loader reset per tab per epoch, which is the same rate the indexing renders already pay.

## Not in scope

Module *deletes* still leave their cached definition to the index job. The failure mode there is a definition for a module no longer on disk, not a silent field drop.

## Tests

New `packages/realm-server/tests/definition-cache-write-invalidation-test.ts`:

- **`module write invalidates the definition cache and mints a loader epoch`** — a realm built without a worker, so the index jobs its writes enqueue are never claimed and `onInvalidation` is structurally unable to fire. Every recorded invalidation came from the write path, independent of drain timing. Covers a module write, a rewrite, a multi-module batch, and the three cases that must *not* invalidate (a card instance, an unchanged rewrite, a non-executable file). For (4) it asserts on the committed `realm_generations` row rather than on a render — that row is what the populate threads and what a peer replica reads, so an epoch that never lands is invisible to both: a module write mints, a rewrite mints a token distinct from the one before it, a two-module batch mints exactly one (sampled at each module's invalidation, not counted afterwards), and the three no-op writes leave it untouched.
- **`a schema-widening module rewrite is visible to the next instance write`** — end-to-end over HTTP: a `Person` module gains `lastName` on a deferred-indexing write and the following instance write must carry it to disk. One test per reachable path, plus a guard that a never-cached module still serializes through the read-through.

In `definition-lookup-test.ts`, two new tests. One pins (3) directly: it bumps the module generation the way the listener does, and asserts a caller arriving afterwards starts its own populate and resolves rather than inheriting the discarded one. The other pins (4)'s read side — a populate renders under the epoch the realm currently holds, and a later populate picks up an epoch minted after it, so the value is read per populate rather than captured once.

Two existing tests are updated for (2). Both keep the invariant they were written for — a discarded result is never persisted — and now assert that the lookup re-derives instead of reporting a nonexistent type. The `clearRealmDefinitions` and `clearAllDefinitions` siblings pass unchanged, which is what the module-only scoping preserves. The identity-check test also gains a rejection handler on its deferred caller: its assertion runs at the end, so a regression that made it reject surfaced first as an unhandled rejection, which the suite runner rethrows — killing the process and the rest of the shard instead of failing one assertion.

## Verification

Run against a full local stack (Synapse, host dist built the way CI builds it, prerender pool, realm servers, containerised test Postgres):

- **Shard 1 of the realm-server suite, the shard that carries this PR's new file: 472/472**, including `prerendering-test.ts` (whose `module prerender reuses pooled page after updates` covers the tab reuse (4) now synchronizes).
- The new file 13/13, and the suites nearest the change — `definition-lookup-test`, `module-cache-race-test`, `module-cache-invalidation-listener-test`, `card-endpoints-test`, `atomic-endpoints-test`, `atomic-batch-indexing-test`, `card-source-endpoints-test` — **241/241** together with it.
- Each piece is pinned by coverage that fails without it: reverting the `realm.ts` invalidation hunk reddens the write-path tests and both end-to-end tests; reverting the retry reddens the two end-to-end tests; reverting the bump-drop binding reddens the peer-invalidation test plus two pre-existing ones; and disabling the mint alone reddens `PATCH persists a field the rewrite added` with exactly the CI failure — `the response echoes the field the rewrite added: expected "Tangle", actual null` — while its two siblings stay green.
- Host: the four tests that caught the first placement of (4)'s reset — `Integration | Store > module rebuild` (12/12) and `Acceptance | Query Fields` (11/11) — pass with it on the route.
- `runtime-common`, `realm-server` and `host` typecheck and eslint clean; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwTVM78Gvdz8tWxKU1GfWA