### PR TITLE
Extract the store's post-create identity steps and mutation lock

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -3364,94 +3364,137 @@ export default class StoreService extends Service implements StoreInterface {
   ): Promise<CardDef | CardErrorJSONAPI> {
     let waiterLabel = `persistAndUpdate ${instance.id ?? instance[localIdSymbol]}`;
     return await this.withTestWaiters(waiterLabel, async () => {
+      // Sampled before the mutation lock is taken, so a save that queues behind
+      // an in-flight create of the same instance counts as a create as well: it
+      // PATCHes the card the create named, then re-runs the identity assignment
+      // against that same id.
       let isNew = !instance.id;
-      let inflightMutation = this.inflightCardMutations.get(
+      return await this.withCardMutationLock(
         instance[localIdSymbol],
-      );
-      if (inflightMutation) {
-        // the local instance is always up-to-date, but things can get messy if
-        // we try to update an instance that is in the process of being created on
-        // the server, because then it still looks like to the client another
-        // POST should be issued when instead we really want to PATCH.
-        await inflightMutation;
-      }
-      let deferred = new Deferred<void>();
-      this.inflightCardMutations.set(instance[localIdSymbol], deferred.promise);
-      try {
-        let doc = await this.cardService.serializeCard(instance, {
-          // for a brand new card that has no id yet, we don't know what we are
-          // relativeTo because its up to the realm server to assign us an ID, so
-          // URL's should be absolute
-          useAbsoluteURL: true,
-          withIncluded: true,
-          omitQueryFields: true,
-        });
+        async () => {
+          try {
+            let doc = await this.cardService.serializeCard(instance, {
+              // for a brand new card that has no id yet, we don't know what we are
+              // relativeTo because its up to the realm server to assign us an ID, so
+              // URL's should be absolute
+              useAbsoluteURL: true,
+              withIncluded: true,
+              omitQueryFields: true,
+            });
 
-        // send doc over the wire with absolute URL's. The realm server will convert
-        // to relative URL's as it serializes the cards
-        let realmURL = instance[realmURLSymbol];
-        // in the case where we get no realm URL from the card, we are dealing with
-        // a new card instance that does not have a realm URL yet.
-        if (!realmURL) {
-          let defaultRealmHref =
-            opts?.realm ?? this.realm.defaultWritableRealm?.path;
-          if (!defaultRealmHref) {
-            throw new Error('Could not find a writable realm');
+            // send doc over the wire with absolute URL's. The realm server will convert
+            // to relative URL's as it serializes the cards
+            let realmURL = instance[realmURLSymbol];
+            // in the case where we get no realm URL from the card, we are dealing with
+            // a new card instance that does not have a realm URL yet.
+            if (!realmURL) {
+              let defaultRealmHref =
+                opts?.realm ?? this.realm.defaultWritableRealm?.path;
+              if (!defaultRealmHref) {
+                throw new Error('Could not find a writable realm');
+              }
+              realmURL = new URL(defaultRealmHref);
+            }
+            let json = await this.saveCardDocument(doc, {
+              realm: realmURL.href,
+              localDir: opts?.localDir,
+              clientRequestId: opts?.clientRequestId,
+            });
+
+            let api = await this.cardService.getAPI();
+            // the store state represents the latest state and the server state is
+            // potentially out-of-date. As such we only merge the server state that
+            // the store does not know about specifically remote ID's and realm
+            // meta. the attributes and relationships state from the server are
+            // thrown away since the store has a more recent version of these.
+            if (needsServerStateMerge(instance, json)) {
+              let serverState = cloneDeep(json);
+              delete serverState.data.attributes;
+              delete serverState.data.relationships;
+              await api.updateFromSerialized(instance, serverState, this.store);
+            }
+            if (isNew) {
+              await this.assignRemoteIdentity(instance, json.data.id!);
+            }
+            if (this.onSaveSubscriber) {
+              this.onSaveSubscriber(
+                this.network.virtualNetwork.toURL(json.data.id!),
+                json,
+              );
+            }
+            return instance;
+          } catch (err) {
+            console.error(`Failed to save ${instance.id}: `, err);
+            let errorResponse = processCardError(
+              instance.id ?? instance[localIdSymbol],
+              err,
+            );
+            let cardError = errorResponse.errors[0];
+            this.setIdentityContext(cardError);
+            let remoteId = cardError.meta?.remoteId;
+            if (remoteId && (!cardError.id || isLocalId(cardError.id))) {
+              this.store.addCardInstanceOrError(remoteId, cardError);
+            }
+            return cardError;
           }
-          realmURL = new URL(defaultRealmHref);
-        }
-        let json = await this.saveCardDocument(doc, {
-          realm: realmURL.href,
-          localDir: opts?.localDir,
-          clientRequestId: opts?.clientRequestId,
-        });
-
-        let api = await this.cardService.getAPI();
-        // the store state represents the latest state and the server state is
-        // potentially out-of-date. As such we only merge the server state that
-        // the store does not know about specifically remote ID's and realm
-        // meta. the attributes and relationships state from the server are
-        // thrown away since the store has a more recent version of these.
-        if (needsServerStateMerge(instance, json)) {
-          let serverState = cloneDeep(json);
-          delete serverState.data.attributes;
-          delete serverState.data.relationships;
-          await api.updateFromSerialized(instance, serverState, this.store);
-        }
-        if (isNew) {
-          api.setId(instance, json.data.id!);
-          this.subscribeToRealm(rri(instance.id));
-          this.operatorModeStateService.handleCardIdAssignment(
-            instance[localIdSymbol],
-          );
-          await this.updateForeignConsumersOf(instance);
-          this.setIdentityContext(instance);
-          await this.startAutoSaving(instance);
-        }
-        if (this.onSaveSubscriber) {
-          this.onSaveSubscriber(
-            this.network.virtualNetwork.toURL(json.data.id!),
-            json,
-          );
-        }
-        return instance;
-      } catch (err) {
-        console.error(`Failed to save ${instance.id}: `, err);
-        let errorResponse = processCardError(
-          instance.id ?? instance[localIdSymbol],
-          err,
-        );
-        let cardError = errorResponse.errors[0];
-        this.setIdentityContext(cardError);
-        let remoteId = cardError.meta?.remoteId;
-        if (remoteId && (!cardError.id || isLocalId(cardError.id))) {
-          this.store.addCardInstanceOrError(remoteId, cardError);
-        }
-        return cardError;
-      } finally {
-        deferred.fulfill();
-      }
+        },
+      );
     });
+  }
+
+  // Serializes mutations of one instance, keyed by its local id, so a save
+  // issued while a create of the same instance is still in flight waits for
+  // the realm-assigned id and issues a PATCH rather than a second POST.
+  //
+  // The map entry is overwritten rather than chained: callers that arrive
+  // while a mutation is in flight all await that same promise and are then
+  // released together, so each mutation is serialized against the one in
+  // flight when it arrived, not against its queued peers. Entries are never
+  // deleted; a settled promise left in the map costs the next caller a
+  // microtask and nothing else.
+  private async withCardMutationLock<T>(
+    localId: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    let inflightMutation = this.inflightCardMutations.get(localId);
+    if (inflightMutation) {
+      await inflightMutation;
+    }
+    let deferred = new Deferred<void>();
+    this.inflightCardMutations.set(localId, deferred.promise);
+    try {
+      return await fn();
+    } finally {
+      deferred.fulfill();
+    }
+  }
+
+  // Promotes an instance the realm has just named from local-id-only to fully
+  // addressable. The steps are ordered and every one of them is required, so
+  // any code path that learns a new instance's remote id routes through here
+  // rather than repeating them:
+  //
+  //   1. the instance takes the remote id;
+  //   2. the store subscribes to its realm's index events;
+  //   3. a stack showing the instance switches the URL bar to the remote id;
+  //   4. consumers in *other* realms re-save so their links to this instance
+  //      resolve to the remote id instead of the local one;
+  //   5. the identity map indexes the instance under both ids, so lookups by
+  //      either return this same object;
+  //   6. autosave takes over subsequent edits.
+  private async assignRemoteIdentity(
+    instance: CardDef,
+    remoteId: RealmResourceIdentifier,
+  ) {
+    let api = await this.cardService.getAPI();
+    api.setId(instance, remoteId);
+    this.subscribeToRealm(rri(instance.id));
+    this.operatorModeStateService.handleCardIdAssignment(
+      instance[localIdSymbol],
+    );
+    await this.updateForeignConsumersOf(instance);
+    this.setIdentityContext(instance);
+    await this.startAutoSaving(instance);
   }
 
   // in the case we are making a cross realm relationship with a link that

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -2140,6 +2140,146 @@ module('Integration | Store', function (hooks) {
     );
   });
 
+  // Records the store-side identity steps a create runs, filtered to `instance`
+  // so unrelated saves in the same test cannot pad the sequence. The three
+  // subjects are the three shapes the steps are called with: the instance
+  // itself, its remote id, and its local id. Returns a restore function.
+  function spyOnIdentitySteps(instance: CardDefType, steps: string[]) {
+    let store = storeService as any;
+    let operatorModeState = operatorModeStateService as any;
+    let isSubject = (subject: unknown) =>
+      subject === instance ||
+      subject === instance[localId] ||
+      (instance.id != null && subject === instance.id);
+    let spied: [Record<string, any>, string, any][] = [
+      [store, 'subscribeToRealm', store.subscribeToRealm],
+      [store, 'updateForeignConsumersOf', store.updateForeignConsumersOf],
+      [store, 'setIdentityContext', store.setIdentityContext],
+      [store, 'startAutoSaving', store.startAutoSaving],
+      [
+        operatorModeState,
+        'handleCardIdAssignment',
+        operatorModeState.handleCardIdAssignment,
+      ],
+    ];
+    for (let [target, name, original] of spied) {
+      target[name] = function (...args: any[]) {
+        if (isSubject(args[0])) {
+          steps.push(name);
+        }
+        return original.apply(target, args);
+      };
+    }
+    return () => {
+      for (let [target, name, original] of spied) {
+        target[name] = original;
+      }
+    };
+  }
+
+  test('a create assigns the instance its remote identity in a fixed order', async function (assert) {
+    // A second way to create cards has to run these same steps in this same
+    // order, so the sequence is pinned here rather than just its end state.
+    let instance = new PersonDef({ name: 'Sequence' });
+    let steps: string[] = [];
+    let restore = spyOnIdentitySteps(instance, steps);
+    let result: unknown;
+    try {
+      result = await (storeService as any).persistAndUpdate(instance);
+    } finally {
+      restore();
+    }
+
+    assert.true(isCardInstance(result), 'the create resolved to the instance');
+    assert.ok(instance.id, 'the instance took the realm-assigned remote id');
+    // `subscribeToRealm` is recorded only when its argument matches the
+    // instance's remote id, so its presence also pins the id assignment ahead
+    // of it — the sequence below is the whole assignment, in order.
+    assert.deepEqual(
+      steps,
+      [
+        'subscribeToRealm',
+        'handleCardIdAssignment',
+        'updateForeignConsumersOf',
+        'setIdentityContext',
+        'startAutoSaving',
+      ],
+      'the remote-identity steps ran in order',
+    );
+    assert.strictEqual(
+      storeService.peek(instance[localId]),
+      instance,
+      'the identity map resolves the local id to this instance',
+    );
+    assert.strictEqual(
+      storeService.peek(instance.id!),
+      instance,
+      'the identity map resolves the remote id to the same instance',
+    );
+  });
+
+  test('a save overlapping a create PATCHes instead of issuing a second POST', async function (assert) {
+    let instance = new PersonDef({ name: 'Overlap' });
+
+    // Hold the POST open so the second save is guaranteed to arrive while the
+    // create is still in flight — the window the per-instance mutation lock
+    // exists to cover. Without it the second save serializes a card that still
+    // has no remote id and POSTs it again, leaving two cards in the realm.
+    let cardService = getService('card-service') as any;
+    let originalFetchJSON = cardService.fetchJSON.bind(cardService);
+    let methods: string[] = [];
+    let reachedPost = new Deferred<void>();
+    let releasePost = new Deferred<void>();
+    cardService.fetchJSON = async (url: string | URL, args?: any) => {
+      if (args?.method !== 'POST' && args?.method !== 'PATCH') {
+        return originalFetchJSON(url, args);
+      }
+      methods.push(args.method);
+      if (args.method === 'POST') {
+        reachedPost.fulfill();
+        await releasePost.promise;
+      }
+      return originalFetchJSON(url, args);
+    };
+
+    try {
+      let creating = (storeService as any).persistAndUpdate(instance);
+      await reachedPost.promise;
+      (instance as any).name = 'Overlap Edited';
+      let overlapping = (storeService as any).persistAndUpdate(instance);
+      releasePost.fulfill();
+      await Promise.all([creating, overlapping]);
+    } finally {
+      // Released here too: if the create never reaches its POST the intercepted
+      // fetch would otherwise never return, and the test would hang to the
+      // qunit timeout instead of failing with a reason.
+      releasePost.fulfill();
+      delete cardService.fetchJSON;
+    }
+    await settled();
+
+    assert.deepEqual(
+      methods.slice(0, 2),
+      ['POST', 'PATCH'],
+      'the overlapping save waited for the remote id and updated the created card',
+    );
+    assert.strictEqual(
+      methods.filter((method) => method === 'POST').length,
+      1,
+      'the card was created exactly once',
+    );
+
+    let file = await testRealmAdapter.openFile(
+      `${instance.id!.substring(testRealmURL.length)}.json`,
+    );
+    assert.ok(file, 'the created card exists in the realm');
+    assert.strictEqual(
+      JSON.parse(file!.content as string).data.attributes.name,
+      'Overlap Edited',
+      'the overlapping edit reached the realm',
+    );
+  });
+
   test('loads FileDef links from included resources', async function (assert) {
     await testRealm.writeMany(
       new Map<string, string>([

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -2146,6 +2146,14 @@ module('Integration | Store', function (hooks) {
     // and `add` would have supplied both before any save ran.
     let instance = new PersonDef({ name: 'Sequence' });
     let instanceLocalId = instance[localId];
+    let subscriptions = (storeService as any).subscriptions as Map<
+      string,
+      { unsubscribe: () => void }
+    >;
+    assert.false(
+      subscriptions.has(testRealmURL),
+      'the realm is not subscribed before the create',
+    );
 
     let result = await (storeService as any).persistAndUpdate(instance);
     assert.true(isCardInstance(result), 'the create resolved to the instance');
@@ -2165,6 +2173,10 @@ module('Integration | Store', function (hooks) {
       storeService.peek(instance.id!),
       instance,
       'the remote id resolves to the same instance',
+    );
+    assert.true(
+      subscriptions.has(testRealmURL),
+      "the store is listening for the realm's index events",
     );
 
     let cardPath = `${instance.id!.substring(testRealmURL.length)}.json`;
@@ -2200,7 +2212,8 @@ module('Integration | Store', function (hooks) {
     // Hold the POST open so the second save is guaranteed to arrive while the
     // create is still in flight — the window the per-instance mutation lock
     // exists to cover. Without it the second save serializes a card that still
-    // has no remote id and POSTs it again, leaving two cards in the realm.
+    // has no remote id and issues a second create for a card the realm has
+    // already named, rather than updating it.
     let cardService = getService('card-service') as any;
     let originalFetchJSON = cardService.fetchJSON.bind(cardService);
     let methods: string[] = [];
@@ -2220,14 +2233,24 @@ module('Integration | Store', function (hooks) {
 
     try {
       let creating = (storeService as any).persistAndUpdate(instance);
-      await reachedPost.promise;
+      // `persistAndUpdate` absorbs its errors and resolves to a card error, so
+      // a create that dies before its POST would otherwise leave this parked on
+      // `reachedPost` until the qunit timeout, with nothing saying why. Racing
+      // the two turns that into an assertion failure naming the error.
+      let reachedPostFirst = await Promise.race([
+        reachedPost.promise.then(() => true),
+        creating.then(() => false),
+      ]);
+      assert.true(
+        reachedPostFirst,
+        `the create reached its POST (resolved early as: ${JSON.stringify(
+          await Promise.race([creating, Promise.resolve('still in flight')]),
+        )})`,
+      );
       let overlapping = (storeService as any).persistAndUpdate(instance);
       releasePost.fulfill();
       await Promise.all([creating, overlapping]);
     } finally {
-      // Released here too: if the create never reaches its POST the intercepted
-      // fetch would otherwise never return, and the test would hang to the
-      // qunit timeout instead of failing with a reason.
       releasePost.fulfill();
       delete cardService.fetchJSON;
     }
@@ -2238,14 +2261,11 @@ module('Integration | Store', function (hooks) {
       ['POST', 'PATCH'],
       'the overlapping save waited for the remote id and updated the created card',
     );
-    let file = await testRealmAdapter.openFile(
-      `${instance.id!.substring(testRealmURL.length)}.json`,
-    );
-    assert.ok(file, 'the created card exists in the realm');
-    assert.strictEqual(
-      JSON.parse(file!.content as string).data.attributes.name,
-      'Overlap',
-      'the card the realm holds is the one the store created',
+    assert.ok(
+      await testRealmAdapter.openFile(
+        `${instance.id!.substring(testRealmURL.length)}.json`,
+      ),
+      'the realm holds the created card',
     );
   });
 

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -2178,9 +2178,13 @@ module('Integration | Store', function (hooks) {
   }
 
   test('a create assigns the instance its remote identity in a fixed order', async function (assert) {
-    // A second way to create cards has to run these same steps in this same
-    // order, so the sequence is pinned here rather than just its end state.
+    // Any other way of creating a card has to run these same steps in this same
+    // order, so the sequence is pinned here, not just its end state. The spies
+    // go on after the instance is in the store so that only the create's own
+    // steps are recorded.
     let instance = new PersonDef({ name: 'Sequence' });
+    await storeService.add(instance, { doNotPersist: true });
+
     let steps: string[] = [];
     let restore = spyOnIdentitySteps(instance, steps);
     let result: unknown;
@@ -2220,6 +2224,7 @@ module('Integration | Store', function (hooks) {
 
   test('a save overlapping a create PATCHes instead of issuing a second POST', async function (assert) {
     let instance = new PersonDef({ name: 'Overlap' });
+    await storeService.add(instance, { doNotPersist: true });
 
     // Hold the POST open so the second save is guaranteed to arrive while the
     // create is still in flight — the window the per-instance mutation lock
@@ -2245,7 +2250,6 @@ module('Integration | Store', function (hooks) {
     try {
       let creating = (storeService as any).persistAndUpdate(instance);
       await reachedPost.promise;
-      (instance as any).name = 'Overlap Edited';
       let overlapping = (storeService as any).persistAndUpdate(instance);
       releasePost.fulfill();
       await Promise.all([creating, overlapping]);
@@ -2259,24 +2263,18 @@ module('Integration | Store', function (hooks) {
     await settled();
 
     assert.deepEqual(
-      methods.slice(0, 2),
+      methods,
       ['POST', 'PATCH'],
       'the overlapping save waited for the remote id and updated the created card',
     );
-    assert.strictEqual(
-      methods.filter((method) => method === 'POST').length,
-      1,
-      'the card was created exactly once',
-    );
-
     let file = await testRealmAdapter.openFile(
       `${instance.id!.substring(testRealmURL.length)}.json`,
     );
     assert.ok(file, 'the created card exists in the realm');
     assert.strictEqual(
       JSON.parse(file!.content as string).data.attributes.name,
-      'Overlap Edited',
-      'the overlapping edit reached the realm',
+      'Overlap',
+      'the card the realm holds is the one the store created',
     );
   });
 

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -2140,89 +2140,60 @@ module('Integration | Store', function (hooks) {
     );
   });
 
-  // Records the store-side identity steps a create runs, filtered to `instance`
-  // so unrelated saves in the same test cannot pad the sequence. The three
-  // subjects are the three shapes the steps are called with: the instance
-  // itself, its remote id, and its local id. Returns a restore function.
-  function spyOnIdentitySteps(instance: CardDefType, steps: string[]) {
-    let store = storeService as any;
-    let operatorModeState = operatorModeStateService as any;
-    let isSubject = (subject: unknown) =>
-      subject === instance ||
-      subject === instance[localId] ||
-      (instance.id != null && subject === instance.id);
-    let spied: [Record<string, any>, string, any][] = [
-      [store, 'subscribeToRealm', store.subscribeToRealm],
-      [store, 'updateForeignConsumersOf', store.updateForeignConsumersOf],
-      [store, 'setIdentityContext', store.setIdentityContext],
-      [store, 'startAutoSaving', store.startAutoSaving],
-      [
-        operatorModeState,
-        'handleCardIdAssignment',
-        operatorModeState.handleCardIdAssignment,
-      ],
-    ];
-    for (let [target, name, original] of spied) {
-      target[name] = function (...args: any[]) {
-        if (isSubject(args[0])) {
-          steps.push(name);
-        }
-        return original.apply(target, args);
-      };
-    }
-    return () => {
-      for (let [target, name, original] of spied) {
-        target[name] = original;
-      }
-    };
-  }
-
-  test('a create assigns the instance its remote identity in a fixed order', async function (assert) {
-    // Any other way of creating a card has to run these same steps in this same
-    // order, so the sequence is pinned here, not just its end state. The spies
-    // go on after the instance is in the store so that only the create's own
-    // steps are recorded.
+  test('a create gives the instance a remote identity the rest of the store can use', async function (assert) {
+    // Deliberately not put in the store first: the identity-map registration
+    // and the autosave subscription asserted below are the create's own doing,
+    // and `add` would have supplied both before any save ran.
     let instance = new PersonDef({ name: 'Sequence' });
-    await storeService.add(instance, { doNotPersist: true });
+    let instanceLocalId = instance[localId];
 
-    let steps: string[] = [];
-    let restore = spyOnIdentitySteps(instance, steps);
-    let result: unknown;
-    try {
-      result = await (storeService as any).persistAndUpdate(instance);
-    } finally {
-      restore();
-    }
-
+    let result = await (storeService as any).persistAndUpdate(instance);
     assert.true(isCardInstance(result), 'the create resolved to the instance');
-    assert.ok(instance.id, 'the instance took the realm-assigned remote id');
-    // `subscribeToRealm` is recorded only when its argument matches the
-    // instance's remote id, so its presence also pins the id assignment ahead
-    // of it — the sequence below is the whole assignment, in order.
-    assert.deepEqual(
-      steps,
-      [
-        'subscribeToRealm',
-        'handleCardIdAssignment',
-        'updateForeignConsumersOf',
-        'setIdentityContext',
-        'startAutoSaving',
-      ],
-      'the remote-identity steps ran in order',
+
+    // The realm named the card, and the store left it reachable under both the
+    // id the browser picked and the one the realm assigned.
+    assert.ok(
+      instance.id?.startsWith(testRealmURL),
+      'the instance took a remote id in the realm',
     );
     assert.strictEqual(
-      storeService.peek(instance[localId]),
+      storeService.peek(instanceLocalId),
       instance,
-      'the identity map resolves the local id to this instance',
+      'the local id still resolves to this instance',
     );
     assert.strictEqual(
       storeService.peek(instance.id!),
       instance,
-      'the identity map resolves the remote id to the same instance',
+      'the remote id resolves to the same instance',
+    );
+
+    let cardPath = `${instance.id!.substring(testRealmURL.length)}.json`;
+    assert.ok(
+      await testRealmAdapter.openFile(cardPath),
+      'the realm holds the created card',
+    );
+
+    // Autosave is live on the instance the create just named, so an edit
+    // reaches the realm without anyone asking for a save.
+    (instance as any).name = 'Sequence Edited';
+    await waitUntil(
+      () => storeService.getSaveState(instanceLocalId)?.lastSaved,
+      { timeout: 10000 },
+    );
+    await settled();
+    let file = await testRealmAdapter.openFile(cardPath);
+    assert.strictEqual(
+      JSON.parse(file!.content as string).data.attributes.name,
+      'Sequence Edited',
+      'an edit after the create autosaves to the realm',
     );
   });
 
   test('a save overlapping a create PATCHes instead of issuing a second POST', async function (assert) {
+    // Driven through `persistAndUpdate` rather than `save`, because the
+    // autosave queue awaits the in-flight mutation before it saves at all —
+    // it never reaches the window the mutation lock covers, which is the
+    // window under test here.
     let instance = new PersonDef({ name: 'Overlap' });
     await storeService.add(instance, { doNotPersist: true });
 


### PR DESCRIPTION
## What this does

`persistAndUpdate` spelled out two things inline that any other create path needs verbatim. Both are now methods on the store:

- **`assignRemoteIdentity(instance, remoteId)`** — the six steps that promote an instance the realm has just named from local-id-only to fully addressable: it takes the remote id, the store subscribes to its realm's index events, a stack showing it switches the URL bar over, consumers in *other* realms re-save so their links resolve to the remote id instead of the local one, the identity map indexes it under both ids, and autosave takes over subsequent edits.
- **`withCardMutationLock(localId, fn)`** — the per-instance lock over `inflightCardMutations`, so a save issued while a create of the same instance is still in flight waits for the realm-assigned id and PATCHes rather than POSTing a second card.

An all-or-nothing batch write to the realm has to run exactly these steps, in this order, under this same lock, or the store ends up with duplicate identities and racing saves. Sharing one implementation is what keeps that true.

## Why the diff reads as moved code

No behavior change. The six steps keep their order and their awaits; the lock keeps its exact semantics, including that the map entry is **overwritten rather than chained** — every caller arriving during one mutation awaits that same promise and they are all released together, so each mutation serializes against the one in flight when it arrived, not against its queued peers — and that entries are never deleted.

One deliberate difference: `assignRemoteIdentity` resolves the card API itself instead of taking it as an argument, so it can be called standalone. That matches what the steps around it already do — `updateForeignConsumersOf` and `startAutoSaving` each re-resolve it, the latter with a comment saying a module update invalidates a held reference. In `persistAndUpdate` the promise is already cached by the `getAPI()` call above it, so this costs a microtask.

Most of the line count is re-indentation — the body of `persistAndUpdate` moved inside the lock callback. `git diff -w` shows the actual change.

## Tests

`store-test.gts` is unchanged apart from two additions, both asserting observable outcomes rather than which internal methods ran:

- **the created identity** — after a create, the realm has named the card, the store is listening for that realm's index events, both the local id and the remote id resolve to the same instance, the realm holds the file, and an edit made afterwards autosaves to the realm. The instance is deliberately not put in the store beforehand, so the identity-map registration and the autosave subscription can only have come from the create itself; the trailing edit reaching the realm is unreachable unless both happened.
- **the lock** — the POST is held open, a second save is started inside that window, and the pair must come back `['POST', 'PATCH']`. This one drives `persistAndUpdate` directly on purpose: `drainAutoSaveQueue` awaits the in-flight mutation before saving at all, so a save issued through the public path never reaches the window the lock covers.

Two of the six effects are still unpinned: the URL-bar fixup for a card on a stack, and the cross-realm consumer re-save. Neither has an observable outcome reachable without standing up a stack or a second realm.

## Known, and deliberately not changed here

Two pre-existing behaviors that this change preserves rather than introduces, both worth knowing before a batch-create path is built on these methods:

- `inflightCardMutations` entries outlive their mutation: nothing deletes them, so the map grows until `resetState`/`resetCache` replaces it, and the store's instance GC evicts an instance while leaving its lock entry behind. Cleaning it up would change what the next save observes — an already-settled promise awaited for a microtask today, versus no await at all. See the review thread on `withCardMutationLock`.
- `isNew` is sampled before the lock is taken, so a save that queues behind a create re-runs `assignRemoteIdentity` after its PATCH. Five of the six steps are idempotent; `updateForeignConsumersOf` is not — it re-saves every cross-realm consumer with no already-done guard. Harmless today (one redundant PATCH per consumer, in a rare interleaving), but it scales with the number of concurrent creates, so whether `assignRemoteIdentity` is idempotent by contract is worth settling alongside the batch path.

## Verification

Typecheck (`ember-tsc --noEmit`), ESLint, and prettier pass. The host suite needs the realm-server stack (Synapse over Docker), which was not reachable from where this was written, so the new tests run first in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSoTLhQM5yLfzcGS1JUeRa