### PR TITLE
After a failed correctness check, tell the model to repair with SEARCH/REPLACE blocks and no tools

### DIFF
--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -5050,7 +5050,7 @@ new content
     let userMessages =
       messages?.filter((message) => message.role === 'user') ?? [];
     let retryMessages = userMessages.filter((message) =>
-      messageText(message).includes('Propose fixes for the above errors'),
+      messageText(message).includes('Fix the errors above'),
     );
     assert.strictEqual(
       retryMessages.length,
@@ -5070,9 +5070,7 @@ new content
     );
     let failureLimitMessage = failureLimitMessages[0];
     assert.notOk(
-      messageText(failureLimitMessage).includes(
-        'Propose fixes for the above errors',
-      ),
+      messageText(failureLimitMessage).includes('Fix the errors above'),
       'The failure limit prompt should not ask for another round of fixes',
     );
   });

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1276,9 +1276,13 @@ type FormattedCorrectnessSummary = {
   hasErrors: boolean;
 };
 
-const SEARCH_REPLACE_FIX_INSTRUCTION = `1. Propose fixes for the above errors by using one or more SEARCH/REPLACE blocks (DO NOT use the patchCardInstance tool function, because it will not work for broken cards).
-2. You MUST re-fetch the files that have errors so that you can see their updated content before proposing fixes.
-3. Respond very briefly that there is an issue with the file(s) (1 sentence max) that you will attempt to fix and do not mention SEARCH/REPLACE blocks in your prose.`;
+// Sent after a correctness check fails. The fix must be a SEARCH/REPLACE block
+// against the file: a card that just failed its check is usually not indexed,
+// so any card-editing tool (patch-fields, patchCardInstance) applies to
+// nothing and costs a turn. Name no tool, ban them all.
+const SEARCH_REPLACE_FIX_INSTRUCTION = `1. Fix the errors above by editing the failing file(s) with SEARCH/REPLACE blocks. Do not call any tool to make the fix — a card that just failed its check is not indexed yet, so a tool applies to nothing.
+2. First re-fetch the files that have errors so the SEARCH block matches their current content, then write the fixing blocks in the same reply.
+3. One short sentence of prose before the blocks saying there is an issue you are fixing; do not mention SEARCH/REPLACE blocks in the prose.`;
 
 const CORRECTNESS_SUCCESS_SUMMARY_INSTRUCTION =
   'Summarize the results above in one short sentence confirming that the target is now auto-corrected. Mention any warnings if they exist. Do not mention correctness or automated checks or tool calls.';


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

Twice in Sonnet 5 smoke runs the correctness check flagged a `cardInfo.theme: null` in an instance the model had just written, and the model tried to repair it with `patch-fields`. The card was not indexed yet, so the tool applied to nothing, and a turn was lost before the model wrote the fix as a SEARCH/REPLACE block.

The instruction the ai-bot sends after a failed check said "DO NOT use the patchCardInstance tool function, because it will not work for broken cards". That bans one tool by its old name. The tool the model actually has is `patch-fields`, declared by the environment skill, so the ban did not apply to it.

The instruction now names no tool: fix the failing files with SEARCH/REPLACE blocks, do not call any tool to make the fix because a card that just failed its check is not indexed yet, re-fetch the files first so the SEARCH half matches, and write the blocks in the same reply after one short sentence. The two ai-bot tests that asserted the old opening phrase assert the new one.

The matching skill-text change, dropping "patch-fields is often better than rewriting the .json" from the editing skill, is in boxel-skills PR "Tell the assistant how to write files so it stops wasting turns and writing broken patches".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
