### PR TITLE
Let one user's rooms generate at the same time

### DIFF
--- a/packages/ai-bot/lib/credit-tracking.ts
+++ b/packages/ai-bot/lib/credit-tracking.ts
@@ -10,10 +10,10 @@ const CREDIT_TRACKING_TIMEOUT_MS = 5_000;
 
 /**
  * Waits for any pending fallback credit tracking to complete before starting
- * a new generation. The primary serialization is now the per-user
- * `withUserCostLock` barrier around generate → debit (see main.ts); this
- * remains a secondary net for the rare fallback path below, whose debit lands
- * outside the lock.
+ * a new generation. The primary serialization is the per-user
+ * `withUserCostLock` barrier around the credit gate and the debit (see
+ * main.ts; the generation itself runs outside it); this remains a secondary
+ * net for the rare fallback path below, whose debit lands outside the lock.
  *
  * Uses a timeout to avoid blocking indefinitely when
  * fetchGenerationCostWithBackoff is retrying with exponential backoff

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -535,15 +535,15 @@ Common issues are:
           let costInUsd: number | undefined;
           let generationCompleted = false;
 
-          // Serialize this user's credit gate → generate → debit across all
-          // rooms and replicas with the per-user cost lock (CS-11128),
-          // mirroring the realm-server proxy paths. The room lock only
-          // serializes per room, so without this a user firing concurrent
-          // requests in N rooms passes the balance gate N times against the
-          // same stale balance and overspends (CS-11504). The inline-cost
-          // debit is awaited inside the lock so the next same-user request
-          // cannot validate against a pre-deduction balance.
-          await assistant.pgAdapter.withUserCostLock(
+          // The per-user cost lock guards the credit gate here and the debit
+          // in the finally below, across all of this user's rooms and all
+          // replicas. It does not wrap the generation itself: a user with two
+          // rooms open gets two generations at once, and every debit still
+          // lands before the next gate on that user runs. What the short
+          // sections give up is that rooms started together are all gated on
+          // the same balance, so the overshoot is one turn per open room
+          // rather than one turn. The room lock still serializes per room.
+          let creditGatePassed = await assistant.pgAdapter.withUserCostLock(
             senderMatrixUserId,
             async () => {
               // Do not generate new responses if previous ones' cost is still being reported
@@ -556,7 +556,7 @@ Common issues are:
                 await responder.onError(
                   'There was an error saving your Boxel credits usage. Try again or contact support if the problem persists.',
                 );
-                return;
+                return false;
               }
 
               const creditValidation = await profTime(
@@ -572,160 +572,166 @@ Common issues are:
                   `You need a minimum of ${MINIMUM_AI_CREDITS_TO_CONTINUE} credits to continue using the AI bot. Please upgrade to a larger plan, or top up your account.`,
                   { reloadBillingData: true },
                 );
-                return;
+                return false;
               }
+              return true;
+            },
+          );
+          if (!creditGatePassed) {
+            return;
+          }
 
-              log.info(
-                `[${eventId}] Starting generation with model %s`,
-                promptParts.model,
-              );
-              const requestStart = Date.now();
-              let firstChunkAt: number | undefined;
-              if (profEnabled()) {
-                profNote(eventId, 'llm:request:start', {
-                  model: promptParts.model,
-                });
-              }
-              try {
-                let roundCostInUsd: number | undefined;
-                const runner = assistant
-                  .getResponse(
-                    promptParts,
-                    senderMatrixUserId,
-                    realmFileReadingAllowed,
-                  )
-                  .on('chunk', async (chunk, snapshot) => {
-                    log.info(`[${eventId}] Received chunk %s`, chunk.id);
-                    if (profEnabled() && firstChunkAt == null) {
-                      firstChunkAt = Date.now();
-                      profNote(eventId, 'llm:ttft', {
-                        ms: firstChunkAt - requestStart,
-                        model: promptParts.model,
-                      });
-                    }
-                    generationId = chunk.id;
-                    if (chunk.usage && (chunk.usage as any).cost != null) {
-                      roundCostInUsd = (chunk.usage as any).cost;
-                    }
-                    let activeGeneration = activeGenerations.get(room.roomId);
-                    if (activeGeneration) {
-                      activeGeneration.lastGeneratedChunkId = generationId;
-                    }
-
-                    let chunkProcessingResult = await profTime(
-                      eventId,
-                      'llm:chunk:onChunk',
-                      async () => responder.onChunk(chunk, snapshot),
-                    );
-                    let chunkProcessingResultError = chunkProcessingResult.find(
-                      (promiseResult) =>
-                        promiseResult &&
-                        'errorMessage' in promiseResult &&
-                        promiseResult.errorMessage != null,
-                    ) as { errorMessage: string } | undefined;
-
-                    if (chunkProcessingResultError) {
-                      chunkHandlingError =
-                        chunkProcessingResultError.errorMessage;
-
-                      // If there was an error processing the chunk, e.g. matrix sending error (e.g. event too large),
-                      // then we want to stop accepting more chunks by aborting the runner. This will throw an error
-                      // where the await responder.finalize() is called (the catch block below will handle this)
-                      runner.abort();
-                    }
-                  })
-                  .on('error', async (error) => {
-                    await responder.onError(error);
+          log.info(
+            `[${eventId}] Starting generation with model %s`,
+            promptParts.model,
+          );
+          const requestStart = Date.now();
+          let firstChunkAt: number | undefined;
+          if (profEnabled()) {
+            profNote(eventId, 'llm:request:start', {
+              model: promptParts.model,
+            });
+          }
+          try {
+            let roundCostInUsd: number | undefined;
+            const runner = assistant
+              .getResponse(
+                promptParts,
+                senderMatrixUserId,
+                realmFileReadingAllowed,
+              )
+              .on('chunk', async (chunk, snapshot) => {
+                log.info(`[${eventId}] Received chunk %s`, chunk.id);
+                if (profEnabled() && firstChunkAt == null) {
+                  firstChunkAt = Date.now();
+                  profNote(eventId, 'llm:ttft', {
+                    ms: firstChunkAt - requestStart,
+                    model: promptParts.model,
                   });
+                }
+                generationId = chunk.id;
+                if (chunk.usage && (chunk.usage as any).cost != null) {
+                  roundCostInUsd = (chunk.usage as any).cost;
+                }
+                let activeGeneration = activeGenerations.get(room.roomId);
+                if (activeGeneration) {
+                  activeGeneration.lastGeneratedChunkId = generationId;
+                }
 
-                activeGenerations.set(room.roomId, {
-                  responder,
-                  runner,
-                  lastGeneratedChunkId: generationId,
-                  completionPromise: generationCompletionPromise,
-                });
-
-                let completion = await profTime(
+                let chunkProcessingResult = await profTime(
                   eventId,
-                  'llm:finalChatCompletion',
-                  async () => runner.finalChatCompletion(),
+                  'llm:chunk:onChunk',
+                  async () => responder.onChunk(chunk, snapshot),
                 );
-                if (typeof roundCostInUsd === 'number') {
-                  costInUsd = (costInUsd ?? 0) + roundCostInUsd;
-                }
+                let chunkProcessingResultError = chunkProcessingResult.find(
+                  (promiseResult) =>
+                    promiseResult &&
+                    'errorMessage' in promiseResult &&
+                    promiseResult.errorMessage != null,
+                ) as { errorMessage: string } | undefined;
 
-                log.info(`[${eventId}] Generation complete`);
-                await profTime(eventId, 'response:finalize', async () =>
-                  responder.finalize(),
-                );
-                log.info(`[${eventId}] Response finalized`);
+                if (chunkProcessingResultError) {
+                  chunkHandlingError = chunkProcessingResultError.errorMessage;
 
-                // readRealmFile is a tool ai-bot fulfills itself. The answer has
-                // already streamed (with the reads surfaced as executedBy:
-                // 'ai-bot' command requests); now fetch each file, attach it to
-                // a command-result event, and let the normal command-result path
-                // drive the continuation on a later turn — exactly as a host
-                // command result would. Because reads now resolve next-turn like
-                // host commands, an answer may freely mix the two; the host
-                // fulfills its commands, we fulfill ours, and getShouldRespond
-                // waits for all of them before generating again.
-                let message = completion.choices?.[0]?.message;
-                let { botToolCalls } = message
-                  ? classifyToolCalls(message)
-                  : { botToolCalls: [] };
-                if (
-                  realmFileReadingAllowed &&
-                  botToolCalls.length > 0 &&
-                  responder.responseEventId
-                ) {
-                  // Defer fulfillment until after the room lock is released
-                  // (see the finally below): fulfilling posts a result event
-                  // that re-triggers the bot, and that re-trigger needs the
-                  // room lock this handler still holds here.
-                  pendingFulfillBotToolCalls = botToolCalls;
-                  pendingFulfillRequestEventId = responder.responseEventId;
-                  pendingFulfillAgentId = agentId;
+                  // If there was an error processing the chunk, e.g. matrix sending error (e.g. event too large),
+                  // then we want to stop accepting more chunks by aborting the runner. This will throw an error
+                  // where the await responder.finalize() is called (the catch block below will handle this)
+                  runner.abort();
                 }
-              } catch (error) {
-                // Aborting the runner always surfaces as APIUserAbortError, but
-                // the user is not the only one who aborts it: the chunk handler
-                // does too when publishing a chunk fails, and that failure is
-                // the answer being cut off rather than withdrawn. Telling them
-                // apart by `chunkHandlingError` keeps a send failure from being
-                // recorded as a cancellation — which reads to the user as an
-                // answer that simply stops mid-sentence, with no error to act on
-                // and nothing in the log but "canceled by user".
-                if (error instanceof APIUserAbortError && chunkHandlingError) {
-                  log.error(
-                    `[${eventId}] Generation aborted after a chunk could not be published`,
-                  );
-                  log.error(chunkHandlingError);
-                  await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large
-                } else if (error instanceof APIUserAbortError) {
-                  log.info(`[${eventId}] Generation was canceled by user`);
-                  await responder.finalize({ isCanceled: true });
-                } else {
-                  log.error(
-                    `[${eventId}] Error during generation or finalization`,
-                  );
-                  log.error(error);
-                  if (chunkHandlingError) {
-                    await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large
-                  } else {
-                    await responder.onError(error as OpenAIError);
-                  }
-                }
-              } finally {
-                // Debit the inline cost INSIDE the lock so the next same-user
-                // request observes it before validating. This path has the
-                // best data (both costInUsd from inline chunks and
-                // generationId). The user-facing response is already
-                // finalized, so a billing-write failure here must not skip the
-                // activeGenerations cleanup below (a stale entry would make a
-                // later message abort an already-finished run); swallow and log
-                // it, and let the next request surface any billing error via
-                // validateAICredits / waitForPendingCreditTracking.
-                try {
+              })
+              .on('error', async (error) => {
+                await responder.onError(error);
+              });
+
+            activeGenerations.set(room.roomId, {
+              responder,
+              runner,
+              lastGeneratedChunkId: generationId,
+              completionPromise: generationCompletionPromise,
+            });
+
+            let completion = await profTime(
+              eventId,
+              'llm:finalChatCompletion',
+              async () => runner.finalChatCompletion(),
+            );
+            if (typeof roundCostInUsd === 'number') {
+              costInUsd = (costInUsd ?? 0) + roundCostInUsd;
+            }
+
+            log.info(`[${eventId}] Generation complete`);
+            await profTime(eventId, 'response:finalize', async () =>
+              responder.finalize(),
+            );
+            log.info(`[${eventId}] Response finalized`);
+
+            // readRealmFile is a tool ai-bot fulfills itself. The answer has
+            // already streamed (with the reads surfaced as executedBy:
+            // 'ai-bot' command requests); now fetch each file, attach it to
+            // a command-result event, and let the normal command-result path
+            // drive the continuation on a later turn — exactly as a host
+            // command result would. Because reads now resolve next-turn like
+            // host commands, an answer may freely mix the two; the host
+            // fulfills its commands, we fulfill ours, and getShouldRespond
+            // waits for all of them before generating again.
+            let message = completion.choices?.[0]?.message;
+            let { botToolCalls } = message
+              ? classifyToolCalls(message)
+              : { botToolCalls: [] };
+            if (
+              realmFileReadingAllowed &&
+              botToolCalls.length > 0 &&
+              responder.responseEventId
+            ) {
+              // Defer fulfillment until after the room lock is released
+              // (see the finally below): fulfilling posts a result event
+              // that re-triggers the bot, and that re-trigger needs the
+              // room lock this handler still holds here.
+              pendingFulfillBotToolCalls = botToolCalls;
+              pendingFulfillRequestEventId = responder.responseEventId;
+              pendingFulfillAgentId = agentId;
+            }
+          } catch (error) {
+            // Aborting the runner always surfaces as APIUserAbortError, but
+            // the user is not the only one who aborts it: the chunk handler
+            // does too when publishing a chunk fails, and that failure is
+            // the answer being cut off rather than withdrawn. Telling them
+            // apart by `chunkHandlingError` keeps a send failure from being
+            // recorded as a cancellation — which reads to the user as an
+            // answer that simply stops mid-sentence, with no error to act on
+            // and nothing in the log but "canceled by user".
+            if (error instanceof APIUserAbortError && chunkHandlingError) {
+              log.error(
+                `[${eventId}] Generation aborted after a chunk could not be published`,
+              );
+              log.error(chunkHandlingError);
+              await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large
+            } else if (error instanceof APIUserAbortError) {
+              log.info(`[${eventId}] Generation was canceled by user`);
+              await responder.finalize({ isCanceled: true });
+            } else {
+              log.error(`[${eventId}] Error during generation or finalization`);
+              log.error(error);
+              if (chunkHandlingError) {
+                await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large
+              } else {
+                await responder.onError(error as OpenAIError);
+              }
+            }
+          } finally {
+            // Debit the inline cost under the per-user lock so the next
+            // same-user gate observes it before validating. This path has the
+            // best data (both costInUsd from inline chunks and
+            // generationId). The user-facing response is already
+            // finalized, so a billing-write failure here must not skip the
+            // activeGenerations cleanup below (a stale entry would make a
+            // later message abort an already-finished run); swallow and log
+            // it, and let the next request surface any billing error via
+            // validateAICredits / waitForPendingCreditTracking.
+            try {
+              await assistant.pgAdapter.withUserCostLock(
+                senderMatrixUserId,
+                async () => {
                   if (
                     typeof costInUsd === 'number' &&
                     Number.isFinite(costInUsd) &&
@@ -756,19 +762,18 @@ Common issues are:
                       `No usage cost and no generation ID for user ${senderMatrixUserId}, skipping credit deduction`,
                     );
                   }
-                } catch (costError) {
-                  log.error(`[${eventId}] Failed to record AI usage cost`);
-                  log.error(costError);
-                  Sentry.captureException(costError, {
-                    extra: { roomId: room.roomId, eventId },
-                  });
-                }
-                activeGenerations.delete(room.roomId);
-              }
-
-              generationCompleted = true;
-            },
-          );
+                },
+              );
+            } catch (costError) {
+              log.error(`[${eventId}] Failed to record AI usage cost`);
+              log.error(costError);
+              Sentry.captureException(costError, {
+                extra: { roomId: room.roomId, eventId },
+              });
+            }
+            activeGenerations.delete(room.roomId);
+          }
+          generationCompleted = true;
 
           if (
             generationCompleted &&


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

A user with two AI assistant rooms could not generate in both at once. The second room sat on "Thinking..." until the first room's turn was over, and with a slow reasoning turn that was minutes. We saw a second room wait ten minutes when testing with GPT-5.6 Sol in the AI Assistant. 

The cause was the shape of the per-user cost lock. Since the overspend fix in June the bot ran credit check, generation, and debit inside one locked section per user. The lock did its job, two rooms could not pass the balance check on the same stale balance, but it also queued the generations themselves.

This change keeps the lock only where it matters and lets the generation run outside it:

```
lock { credit check }  →  generate (no lock)  →  lock { debit }
```

Every debit still lands before the next check on that user, so the balance a room sees is never older than the last finished turn. Rooms of one user now run in parallel.

What it gives up: rooms started at the same moment are all checked against the same balance, so the possible overshoot is one turn per open room instead of one turn. For a person with two or three sessions that is the intended behaviour. A per-user cap on in-flight generations can be added on top if that ever matters.

No behaviour change for the realm-server proxy paths, which keep their own use of the lock.
