### PR TITLE
Fix four paths where the assistant lost correct model output: read stall, patch index mismatch, invalid LLM mode, patch split across events

### DIFF
--- a/packages/ai-bot/lib/matrix/response-event-data.ts
+++ b/packages/ai-bot/lib/matrix/response-event-data.ts
@@ -38,9 +38,17 @@ export default class ResponseEventData {
         content: '',
       };
     }
+    let contentEnd = this.contentStartIndex + remainingBudget;
+    if (contentEnd < content.length) {
+      contentEnd = cutOutsideCodeBlocks(
+        content,
+        this.contentStartIndex,
+        contentEnd,
+      );
+    }
     let contentForNextMessage = content.slice(
       this.contentStartIndex,
-      this.contentStartIndex + remainingBudget,
+      contentEnd,
     );
     return {
       reasoning: reasoningForNextMessage,
@@ -64,4 +72,32 @@ export default class ResponseEventData {
     nextEvent.reasoningStartIndex = this.reasoningEndIndex;
     return nextEvent;
   }
+}
+
+// A SEARCH/REPLACE block that is cut across two events is never applied: the
+// host reads patches per event, so each half is a malformed block. When the
+// cut would land inside a fenced code block, move it back to the start of
+// that block (the opening fence line, or the URL line the host expects right
+// after it), so the whole block moves to the next event. A block bigger than
+// one event still has to be cut; the hard cut stays as the fallback.
+export function cutOutsideCodeBlocks(
+  content: string,
+  start: number,
+  proposedEnd: number,
+): number {
+  let piece = content.slice(start, proposedEnd);
+  let fences = piece.match(/^```/gm) ?? [];
+  if (fences.length % 2 === 0) {
+    return proposedEnd; // the cut is not inside a fence
+  }
+  let lastFence = piece.lastIndexOf('\n```');
+  if (lastFence === -1) {
+    lastFence = piece.startsWith('```') ? 0 : -1;
+  } else {
+    lastFence += 1; // the fence line itself starts after the newline
+  }
+  if (lastFence <= 0) {
+    return proposedEnd; // the open block is the whole piece; cut anyway
+  }
+  return start + lastFence;
 }

--- a/packages/ai-bot/lib/read-realm-file-fulfillment.ts
+++ b/packages/ai-bot/lib/read-realm-file-fulfillment.ts
@@ -113,14 +113,22 @@ export async function fulfillReadRealmFileCalls(
     deps.uploadText ??
     ((content: string, contentType: string) =>
       uploadTextToMatrix(deps.client, content, contentType));
-  return Promise.all(
-    botToolCalls
-      .filter(
-        (call): call is ChatCompletionMessageToolCall & { type: 'function' } =>
-          call.type === 'function',
-      )
-      .map((call) => fulfillOne(call, deps, upload)),
-  );
+  // One call at a time, on purpose. Every published result re-triggers the
+  // bot, and that handler decides whether the turn is complete by fetching
+  // the room history from the server and splicing in the one result it was
+  // triggered by. When several results are published at once, a handler can
+  // run while a sibling's send is still in flight: the sibling is missing
+  // from the fetch, the turn looks unfinished, and no handler ever starts
+  // the next turn. Publishing in sequence means that by the time result N
+  // triggers its handler, results 1..N-1 are on the server.
+  let outcomes: ReadRealmFileFulfillmentOutcome[] = [];
+  for (let call of botToolCalls) {
+    if (call.type !== 'function') {
+      continue;
+    }
+    outcomes.push(await fulfillOne(call, deps, upload));
+  }
+  return outcomes;
 }
 
 type FileRead =

--- a/packages/ai-bot/tests/index.ts
+++ b/packages/ai-bot/tests/index.ts
@@ -2,6 +2,7 @@ import './qunit-bootstrap.ts'; // configures QUnit before any test registers
 import QUnit from 'qunit';
 import '../setup-logger.ts'; // This should be first
 import './response-parsing-test.ts';
+import './response-event-data-test.ts';
 import './history-construction-test.ts';
 import './prompt-construction-test.ts';
 import './code-patch-correctness-test.ts';

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -3844,6 +3844,32 @@ Current date and time: 2025-06-11T11:43:00.533Z
     );
   });
 
+  test('patch results reported with host-style block indexes still complete the turn', async () => {
+    // The host numbers a patch result by its position among all fenced code
+    // blocks in the message, so a message with example fences before its
+    // patches reports indexes like 4 and 5 for its two patches. The bot must
+    // not wait for indexes 0 and 1 that will never come.
+    const eventList: DiscreteMatrixEvent[] = JSON.parse(
+      readFileSync(
+        path.join(
+          import.meta.dirname,
+          'resources/chats/two-code-blocks-offset-indexes.json',
+        ),
+        'utf-8',
+      ),
+    );
+    const { shouldRespond } = await getPromptParts(
+      eventList,
+      '@aibot:localhost',
+      fakeMatrixClient,
+    );
+    assert.strictEqual(
+      shouldRespond,
+      true,
+      'both patches have a result, so the bot should respond',
+    );
+  });
+
   test('Responds to second code patch result when two patches were proposed', async function () {
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
       readFileSync(

--- a/packages/ai-bot/tests/resources/chats/two-code-blocks-offset-indexes.json
+++ b/packages/ai-bot/tests/resources/chats/two-code-blocks-offset-indexes.json
@@ -1,0 +1,392 @@
+[
+  {
+    "type": "m.room.create",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "room_version": "10",
+      "creator": "@user:localhost"
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864362728,
+    "unsigned": {
+      "age": 71431
+    },
+    "event_id": "$BbFv3bQk_6IXS845CttWkNqprc00PaW7egknDPzAb3U",
+    "user_id": "@user:localhost",
+    "age": 71431
+  },
+  {
+    "type": "m.room.member",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "membership": "join",
+      "displayname": "admin"
+    },
+    "state_key": "@user:localhost",
+    "origin_server_ts": 1736864362765,
+    "unsigned": {
+      "age": 71394
+    },
+    "event_id": "$auoMF6x0EHAGAIVbeHjsLdrepN5NWaoXVkWPa_QNZ1o",
+    "user_id": "@user:localhost",
+    "age": 71394
+  },
+  {
+    "type": "m.room.power_levels",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "users": {
+        "@user:localhost": 100
+      },
+      "users_default": 0,
+      "events": {
+        "m.room.name": 50,
+        "m.room.power_levels": 100,
+        "m.room.history_visibility": 100,
+        "m.room.canonical_alias": 50,
+        "m.room.avatar": 50,
+        "m.room.tombstone": 100,
+        "m.room.server_acl": 100,
+        "m.room.encryption": 100
+      },
+      "events_default": 0,
+      "state_default": 50,
+      "ban": 50,
+      "kick": 50,
+      "redact": 50,
+      "invite": 0,
+      "historical": 100
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864362793,
+    "unsigned": {
+      "age": 71366
+    },
+    "event_id": "$XPa4Nfoi-LpJRvCCHMPd088dnrzt-Uc8R0lb-56MCUQ",
+    "user_id": "@user:localhost",
+    "age": 71366
+  },
+  {
+    "type": "m.room.canonical_alias",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "alias": "#Weather%20Travel%20Advice%20-%202025-01-14T14%3A19%3A22.706%2B00%3A00%20-%20%40admin%3Alocalhost:localhost"
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864362807,
+    "unsigned": {
+      "age": 71352
+    },
+    "event_id": "$C7j2gqIzpWOjWp5yabZ2JLVGc5sh_KjuOdrtv7TavNE",
+    "user_id": "@user:localhost",
+    "age": 71352
+  },
+  {
+    "type": "m.room.join_rules",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "join_rule": "invite"
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864362808,
+    "unsigned": {
+      "age": 71351
+    },
+    "event_id": "$8FT4iaFSox71dX5-Z0xgbiY2isoPL6ybLM37wXSKJOs",
+    "user_id": "@user:localhost",
+    "age": 71351
+  },
+  {
+    "type": "m.room.history_visibility",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "history_visibility": "shared"
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864362809,
+    "unsigned": {
+      "age": 71350
+    },
+    "event_id": "$cxBIW2re3D1puIfhAyg067GLdW24FXctOqQ8Juma-Hs",
+    "user_id": "@user:localhost",
+    "age": 71350
+  },
+  {
+    "type": "m.room.guest_access",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "guest_access": "can_join"
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864362809,
+    "unsigned": {
+      "age": 71350
+    },
+    "event_id": "$hSlWgIKf_y_uycz1Ae4USMOa4K17dq7f6VHSrN2nhcU",
+    "user_id": "@user:localhost",
+    "age": 71350
+  },
+  {
+    "type": "m.room.name",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "name": "Weather Travel Advice"
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864362810,
+    "unsigned": {
+      "age": 71349
+    },
+    "event_id": "$isUAMN-pIaBk9gFFTn6UyyTk9QcG59QwOuWhXbfCEkw",
+    "user_id": "@user:localhost",
+    "age": 71349
+  },
+  {
+    "type": "m.room.member",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "membership": "invite",
+      "displayname": "aibot"
+    },
+    "state_key": "@aibot:localhost",
+    "origin_server_ts": 1736864362916,
+    "unsigned": {
+      "age": 71243
+    },
+    "event_id": "$Odud1s75LuD0WjceV_Y_Ek-OVoH5unWa_-g_NI_D1rc",
+    "user_id": "@user:localhost",
+    "age": 71243
+  },
+  {
+    "type": "m.room.power_levels",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "users": {
+        "@user:localhost": 100,
+        "@aibot:localhost": 50
+      },
+      "users_default": 0,
+      "events": {
+        "m.room.name": 50,
+        "m.room.power_levels": 100,
+        "m.room.history_visibility": 100,
+        "m.room.canonical_alias": 50,
+        "m.room.avatar": 50,
+        "m.room.tombstone": 100,
+        "m.room.server_acl": 100,
+        "m.room.encryption": 100
+      },
+      "events_default": 0,
+      "state_default": 50,
+      "ban": 50,
+      "kick": 50,
+      "redact": 50,
+      "invite": 0,
+      "historical": 100
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864363018,
+    "unsigned": {
+      "replaces_state": "$XPa4Nfoi-LpJRvCCHMPd088dnrzt-Uc8R0lb-56MCUQ",
+      "prev_content": {
+        "users": {
+          "@user:localhost": 100
+        },
+        "users_default": 0,
+        "events": {
+          "m.room.name": 50,
+          "m.room.power_levels": 100,
+          "m.room.history_visibility": 100,
+          "m.room.canonical_alias": 50,
+          "m.room.avatar": 50,
+          "m.room.tombstone": 100,
+          "m.room.server_acl": 100,
+          "m.room.encryption": 100
+        },
+        "events_default": 0,
+        "state_default": 50,
+        "ban": 50,
+        "kick": 50,
+        "redact": 50,
+        "invite": 0,
+        "historical": 100
+      },
+      "prev_sender": "@user:localhost",
+      "age": 71141
+    },
+    "event_id": "$TM9oHBXj1Iaa56XU4WF-yxjREXQNQJE1cWaqOqaWqrQ",
+    "user_id": "@user:localhost",
+    "age": 71141,
+    "replaces_state": "$XPa4Nfoi-LpJRvCCHMPd088dnrzt-Uc8R0lb-56MCUQ",
+    "prev_content": {
+      "users": {
+        "@user:localhost": 100
+      },
+      "users_default": 0,
+      "events": {
+        "m.room.name": 50,
+        "m.room.power_levels": 100,
+        "m.room.history_visibility": 100,
+        "m.room.canonical_alias": 50,
+        "m.room.avatar": 50,
+        "m.room.tombstone": 100,
+        "m.room.server_acl": 100,
+        "m.room.encryption": 100
+      },
+      "events_default": 0,
+      "state_default": 50,
+      "ban": 50,
+      "kick": 50,
+      "redact": 50,
+      "invite": 0,
+      "historical": 100
+    }
+  },
+  {
+    "type": "m.room.member",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@aibot:localhost",
+    "content": {
+      "membership": "join",
+      "displayname": "aibot"
+    },
+    "state_key": "@aibot:localhost",
+    "origin_server_ts": 1736864363054,
+    "unsigned": {
+      "replaces_state": "$Odud1s75LuD0WjceV_Y_Ek-OVoH5unWa_-g_NI_D1rc",
+      "prev_content": {
+        "membership": "invite",
+        "displayname": "aibot"
+      },
+      "prev_sender": "@user:localhost",
+      "age": 71105
+    },
+    "event_id": "$Mp2uUXS9lIbgx8qKF43zBiqU-B0EXsdWv-IsAs8kz1I",
+    "user_id": "@aibot:localhost",
+    "age": 71105,
+    "replaces_state": "$Odud1s75LuD0WjceV_Y_Ek-OVoH5unWa_-g_NI_D1rc",
+    "prev_content": {
+      "membership": "invite",
+      "displayname": "aibot"
+    }
+  },
+  {
+    "type": "app.boxel.active-llm",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@aibot:localhost",
+    "content": {
+      "model": "openai/gpt-4o"
+    },
+    "state_key": "",
+    "origin_server_ts": 1736864363147,
+    "unsigned": {
+      "age": 71012
+    },
+    "event_id": "$fsEdqZdOBurry8ujwLTo38DlybaqGuOtas59BiZedeg",
+    "user_id": "@aibot:localhost",
+    "age": 71012
+  },
+  {
+    "type": "m.room.message",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "msgtype": "app.boxel.message",
+      "body": "Please update this file to be less riveting and more engagaing.",
+      "format": "org.matrix.custom.html",
+      "clientGeneratedId": "4a3d6e7f-f492-48de-b3e5-7ef8c5bda696",
+      "data": "{\"context\":{\"tools\":[],\"functions\":[]},\"attachedFiles\":[{\"sourceUrl\":\"http://test-realm-server/my-realm/spaghetti-recipe.gts\",\"url\":\"http://test.com/spaghetti-recipe.gts\",\"name\":\"spaghetti-recipe.gts\",\"contentType\":\"text/plain\"}]}"
+    },
+    "origin_server_ts": 1736864363324,
+    "unsigned": {
+      "age": 70835
+    },
+    "event_id": "$FKof2RxEh_MEfR5iSCwXPOyfcC-t961Nnmvn2Hid6_I",
+    "user_id": "@user:localhost",
+    "age": 70835
+  },
+  {
+    "type": "m.room.message",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@aibot:localhost",
+    "content": {
+      "body": "Updating the file...\nhttp://test.com/spaghetti-recipe.gts\n\u2554\u2550\u2550\u2550 SEARCH \u2550\u2550\u2550\u2550\u2557\nthis is the riveting content of the spaghetti-recipe.gts file\n\u2560\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2563\nthis is the engaging content of the spaghetti-recipe.gts file\n\u255a\u2550\u2550\u2550 REPLACE \u2550\u2550\u2550\u255d\n\nI will also create a file for rigatoni:\n\nhttp://test.com/rigatoni-recipe.gts\n\u2554\u2550\u2550\u2550 SEARCH \u2550\u2550\u2550\u2550\u2557\n\u2560\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2563\nthis is the holy content of the rigatoni-recipe.gts file\n\u255a\u2550\u2550\u2550 REPLACE \u2550\u2550\u2550\u255d\n",
+      "msgtype": "app.boxel.message",
+      "format": "org.matrix.custom.html",
+      "isStreamingFinished": true
+    },
+    "origin_server_ts": 1736864365020,
+    "unsigned": {
+      "age": 69139
+    },
+    "event_id": "$VyCYG0DAuudwMGN8hStuSVfXrjMVZu2ZcJgIs9sIwLE",
+    "user_id": "@aibot:localhost",
+    "age": 69139
+  },
+  {
+    "type": "app.boxel.codePatchResult",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "msgtype": "app.boxel.codePatchResult",
+      "m.relates_to": {
+        "event_id": "$VyCYG0DAuudwMGN8hStuSVfXrjMVZu2ZcJgIs9sIwLE",
+        "key": "applied",
+        "rel_type": "app.boxel.codePatchAnnotation"
+      },
+      "codeBlockIndex": 4,
+      "data": {
+        "context": {
+          "tools": [],
+          "functions": [],
+          "submode": "code"
+        }
+      }
+    },
+    "origin_server_ts": 1736864370892,
+    "unsigned": {
+      "age": 63267
+    },
+    "event_id": "$92DJh6JsIg0z0GmnkylmSz9BWPLcrN8pWnk1fiOEJTk",
+    "user_id": "@user:localhost",
+    "age": 63267
+  },
+  {
+    "type": "app.boxel.codePatchResult",
+    "room_id": "!EtlFgGnAaFCLoozHPV:localhost",
+    "sender": "@user:localhost",
+    "content": {
+      "msgtype": "app.boxel.codePatchResult",
+      "m.relates_to": {
+        "event_id": "$VyCYG0DAuudwMGN8hStuSVfXrjMVZu2ZcJgIs9sIwLE",
+        "key": "applied",
+        "rel_type": "app.boxel.codePatchAnnotation"
+      },
+      "codeBlockIndex": 5,
+      "data": {
+        "context": {
+          "tools": [],
+          "functions": [],
+          "submode": "code"
+        }
+      }
+    },
+    "origin_server_ts": 1736864370893,
+    "unsigned": {
+      "age": 63267
+    },
+    "event_id": "$000Jh6JsIg0z0GmnkylmSz9BWPLcrN8pWnk1fiOE111",
+    "user_id": "@user:localhost",
+    "age": 63267
+  }
+]

--- a/packages/ai-bot/tests/response-event-data-test.ts
+++ b/packages/ai-bot/tests/response-event-data-test.ts
@@ -1,0 +1,68 @@
+import QUnit from 'qunit';
+
+import ResponseEventData, {
+  cutOutsideCodeBlocks,
+} from '../lib/matrix/response-event-data.ts';
+
+const { module, test } = QUnit;
+
+module('ResponseEventData continuation cuts', () => {
+  const block = [
+    '```gts',
+    'http://test.com/hello-world.gts (new)',
+    '╔═══ SEARCH ════╗',
+    '╠═══════════════╣',
+    'export class HelloWorld {}',
+    '╚═══ REPLACE ═══╝',
+    '```',
+  ].join('\n');
+
+  test('a cut that lands inside a block moves back to the fence', (assert) => {
+    let intro = 'Writing the file now.\n\n';
+    let content = intro + block + '\nDone.';
+    // Propose a cut in the middle of the block body.
+    let proposed = intro.length + block.indexOf('export class') + 5;
+    let cut = cutOutsideCodeBlocks(content, 0, proposed);
+    assert.strictEqual(
+      content.slice(0, cut),
+      intro,
+      'the first part ends right before the opening fence',
+    );
+    assert.ok(
+      content.slice(cut).startsWith('```gts\n'),
+      'the next part starts with the whole block',
+    );
+  });
+
+  test('a cut outside any block is left where it is', (assert) => {
+    let content =
+      'Some text\n\n' + block + '\n\nAnd more text after the block.';
+    let proposed = content.length - 5;
+    assert.strictEqual(cutOutsideCodeBlocks(content, 0, proposed), proposed);
+  });
+
+  test('a block larger than one event is still cut', (assert) => {
+    let content = block; // the open block is the whole piece
+    let proposed = 40;
+    assert.strictEqual(cutOutsideCodeBlocks(content, 0, proposed), proposed);
+  });
+
+  test('the next message picks up from the moved cut', (assert) => {
+    let intro = 'Intro text that fills some of the budget.\n';
+    let content = intro + block + '\nDone.';
+    let eventData = new ResponseEventData('$first', intro.length + 30);
+    let first = eventData.reasoningAndContentForNextMessage('', content);
+    assert.strictEqual(
+      first.content,
+      intro,
+      'first event stops before the block',
+    );
+    eventData.updateEndIndices(first);
+    let next = eventData.buildNextEvent();
+    let second = next.reasoningAndContentForNextMessage('', content);
+    assert.ok(
+      second.content.startsWith('```gts\n'),
+      'the block opens the second event',
+    );
+  });
+});

--- a/packages/host/app/tools/check-correctness.ts
+++ b/packages/host/app/tools/check-correctness.ts
@@ -295,8 +295,9 @@ export default class CheckCorrectnessTool extends HostBaseTool<
   // the model only learns two turns later, from show-card's "Could not find".
   // Models get this wrong in a handful of ways (no "data" wrapper, "type" set
   // to the card's name instead of "card", no meta.adoptsFrom, a made-up
-  // "cardDef" link), so name what a card document needs. A .json with none of
-  // the card-shaped keys is left alone: not every JSON file is a card.
+  // "cardDef" link), so name what a card document needs. Only inspect files
+  // with a card-specific signal: ordinary JSON configuration can legitimately
+  // have its own type, meta, or attributes keys.
   private async describeNonCardJson(
     fileUrl: string,
   ): Promise<string | undefined> {
@@ -317,10 +318,20 @@ export default class CheckCorrectnessTool extends HostBaseTool<
       return `${fileUrl} is not valid JSON: ${e?.message ?? e}`;
     }
     let candidate = doc?.data ?? doc;
+    let candidateIsObject = candidate && typeof candidate === 'object';
+    let candidateMeta =
+      candidateIsObject && candidate.meta && typeof candidate.meta === 'object'
+        ? candidate.meta
+        : undefined;
     let cardShaped =
-      candidate &&
-      typeof candidate === 'object' &&
-      ('attributes' in candidate || 'meta' in candidate || 'type' in candidate);
+      doc &&
+      typeof doc === 'object' &&
+      ('data' in doc ||
+        (candidateIsObject &&
+          (candidate.type === 'card' ||
+            candidateMeta?.adoptsFrom ||
+            'cardDef' in candidate ||
+            'cardDef' in (candidateMeta ?? {}))));
     if (!cardShaped) {
       return undefined;
     }

--- a/packages/host/app/tools/check-correctness.ts
+++ b/packages/host/app/tools/check-correctness.ts
@@ -59,6 +59,7 @@ export default class CheckCorrectnessTool extends HostBaseTool<
     // Sometimes AI will patch cards directly as files (with search/replace blocks) so we need to check
     // whether the file is actually a card instance
 
+    let nonCardJsonError: string | undefined;
     if (targetType !== 'card' && input.targetRef.endsWith('.json')) {
       let inferredCardId = await this.checkIfFileIsACardInstance(
         input.targetRef,
@@ -66,6 +67,8 @@ export default class CheckCorrectnessTool extends HostBaseTool<
       if (inferredCardId) {
         targetType = 'card';
         cardId = inferredCardId;
+      } else {
+        nonCardJsonError = await this.describeNonCardJson(input.targetRef);
       }
     }
 
@@ -94,7 +97,9 @@ export default class CheckCorrectnessTool extends HostBaseTool<
       });
     }
 
-    if (targetType === 'file' && input.targetRef.endsWith('.gts')) {
+    if (nonCardJsonError) {
+      errors = [nonCardJsonError];
+    } else if (targetType === 'file' && input.targetRef.endsWith('.gts')) {
       errors = await this.collectModuleErrors(input.targetRef, roomId);
     } else if (targetType === 'card') {
       if (!cardId) {
@@ -283,6 +288,67 @@ export default class CheckCorrectnessTool extends HostBaseTool<
     let summary =
       pieces.length > 0 ? pieces.join(' - ').trim() : 'Unknown card error';
     return `${cardId}: ${summary}`;
+  }
+
+  // A .json that was meant to be a card instance but is not a card document
+  // used to pass this check clean: the indexer stores it as a plain file, and
+  // the model only learns two turns later, from show-card's "Could not find".
+  // Models get this wrong in a handful of ways (no "data" wrapper, "type" set
+  // to the card's name instead of "card", no meta.adoptsFrom, a made-up
+  // "cardDef" link), so name what a card document needs. A .json with none of
+  // the card-shaped keys is left alone: not every JSON file is a card.
+  private async describeNonCardJson(
+    fileUrl: string,
+  ): Promise<string | undefined> {
+    let content: string;
+    try {
+      let source = await this.cardService.getSource(rri(fileUrl));
+      if (source.status !== 200) {
+        return undefined;
+      }
+      content = source.content;
+    } catch {
+      return undefined;
+    }
+    let doc: any;
+    try {
+      doc = JSON.parse(content);
+    } catch (e: any) {
+      return `${fileUrl} is not valid JSON: ${e?.message ?? e}`;
+    }
+    let candidate = doc?.data ?? doc;
+    let cardShaped =
+      candidate &&
+      typeof candidate === 'object' &&
+      ('attributes' in candidate || 'meta' in candidate || 'type' in candidate);
+    if (!cardShaped) {
+      return undefined;
+    }
+    let problems: string[] = [];
+    if (!('data' in (doc ?? {}))) {
+      problems.push(
+        'the document must be wrapped in a top-level "data" object',
+      );
+    }
+    if (candidate.type !== 'card') {
+      problems.push(
+        `"data.type" must be "card" (found ${JSON.stringify(candidate.type)})`,
+      );
+    }
+    let adoptsFrom = candidate.meta?.adoptsFrom;
+    if (
+      !adoptsFrom ||
+      typeof adoptsFrom.module !== 'string' ||
+      typeof adoptsFrom.name !== 'string'
+    ) {
+      problems.push(
+        '"data.meta.adoptsFrom" must name the definition, e.g. { "module": "../hello-world", "name": "HelloWorld" }',
+      );
+    }
+    if (problems.length === 0) {
+      return undefined;
+    }
+    return `${fileUrl} is not a card document, so it will not be indexed as a card and show-card cannot find it: ${problems.join('; ')}.`;
   }
 
   private async checkIfFileIsACardInstance(

--- a/packages/host/app/tools/set-active-llm.ts
+++ b/packages/host/app/tools/set-active-llm.ts
@@ -24,18 +24,20 @@ export default class SetActiveLLMTool extends HostBaseTool<
   protected async run(
     input: BaseToolModule.SetActiveLLMInput,
   ): Promise<undefined> {
+    // The room reads any value other than 'act' as Ask. A model that mixes
+    // this up with the submode (GPT-5.4 Mini sent 'code') would switch the
+    // room out of Act mode and then wait on its own patches for approval.
+    // Validate before either event is sent so a rejected call cannot partially
+    // change the active model.
+    if (input.mode && input.mode !== 'act' && input.mode !== 'ask') {
+      throw new Error(
+        `mode must be "act" or "ask", got "${input.mode}". To open code mode, use switch-submode instead.`,
+      );
+    }
     if (input.model) {
       await this.matrixService.sendActiveLLMEvent(input.roomId, input.model);
     }
-    if (input.mode) {
-      // The room reads any value other than 'act' as Ask. A model that mixes
-      // this up with the submode (GPT-5.4 Mini sent 'code') would switch the
-      // room out of Act mode and then wait on its own patches for approval.
-      if (input.mode !== 'act' && input.mode !== 'ask') {
-        throw new Error(
-          `mode must be "act" or "ask", got "${input.mode}". To open code mode, use switch-submode instead.`,
-        );
-      }
+    if (input.mode === 'act' || input.mode === 'ask') {
       await this.matrixService.sendLLMModeEvent(input.roomId, input.mode);
     }
     return undefined;

--- a/packages/host/app/tools/set-active-llm.ts
+++ b/packages/host/app/tools/set-active-llm.ts
@@ -28,10 +28,15 @@ export default class SetActiveLLMTool extends HostBaseTool<
       await this.matrixService.sendActiveLLMEvent(input.roomId, input.model);
     }
     if (input.mode) {
-      await this.matrixService.sendLLMModeEvent(
-        input.roomId,
-        input.mode as 'act' | 'ask',
-      );
+      // The room reads any value other than 'act' as Ask. A model that mixes
+      // this up with the submode (GPT-5.4 Mini sent 'code') would switch the
+      // room out of Act mode and then wait on its own patches for approval.
+      if (input.mode !== 'act' && input.mode !== 'ask') {
+        throw new Error(
+          `mode must be "act" or "ask", got "${input.mode}". To open code mode, use switch-submode instead.`,
+        );
+      }
+      await this.matrixService.sendLLMModeEvent(input.roomId, input.mode);
     }
     return undefined;
   }

--- a/packages/host/tests/integration/tools/check-correctness-test.gts
+++ b/packages/host/tests/integration/tools/check-correctness-test.gts
@@ -61,6 +61,11 @@ module('Integration | tools | check-correctness', function (hooks) {
             });
           }
         `,
+          'settings.json': {
+            type: 'module',
+            meta: { version: 1 },
+            attributes: { enabled: true },
+          },
           'Pet/billy.json': {
             data: {
               type: 'card',
@@ -287,6 +292,22 @@ ${REPLACE_MARKER}`;
 
     assert.true(result.correct, 'empty file reports as correct');
     assert.deepEqual(result.errors, [], 'no errors are reported');
+  });
+
+  test('does not treat ordinary JSON configuration as a malformed card', async function (assert) {
+    let toolService = getService('tool-service') as {
+      toolContext: CommandContext;
+    };
+    let command = new CheckCorrectnessTool(toolService.toolContext);
+
+    let result = await command.execute({
+      targetType: 'file',
+      targetRef: `${testRealmURL}settings.json`,
+      roomId: '!room:example.com',
+    });
+
+    assert.true(result.correct, 'ordinary JSON is not treated as a card');
+    assert.deepEqual(result.errors, [], 'no card-document errors are reported');
   });
 
   test('reports size limit errors for file writes', async function (assert) {

--- a/packages/host/tests/integration/tools/use-ai-assistant-test.gts
+++ b/packages/host/tests/integration/tools/use-ai-assistant-test.gts
@@ -348,9 +348,10 @@ module('Integration | tools | ai-assistant', function (hooks) {
       'the invalid mode is rejected',
     );
 
-    assert.notOk(
-      getRoomState(roomId, APP_BOXEL_ACTIVE_LLM, ''),
-      'the model is not changed when the invocation is invalid',
+    assert.throws(
+      () => getRoomState(roomId, APP_BOXEL_ACTIVE_LLM, ''),
+      /M_NOT_FOUND/,
+      'no active LLM state is written when the invocation is invalid',
     );
   });
 

--- a/packages/host/tests/integration/tools/use-ai-assistant-test.gts
+++ b/packages/host/tests/integration/tools/use-ai-assistant-test.gts
@@ -16,6 +16,7 @@ import RealmService from '@cardstack/host/services/realm';
 import type ToolService from '@cardstack/host/services/tool-service';
 import UseAiAssistantTool from '@cardstack/host/tools/ai-assistant';
 import OpenAiAssistantRoomTool from '@cardstack/host/tools/open-ai-assistant-room';
+import SetActiveLLMTool from '@cardstack/host/tools/set-active-llm';
 
 import {
   setupIntegrationTestRealm,
@@ -331,6 +332,25 @@ module('Integration | tools | ai-assistant', function (hooks) {
       llmState.model,
       'gpt-4',
       'LLM model should be set to gpt-4',
+    );
+  });
+
+  test('does not set a model when the requested LLM mode is invalid', async function (assert) {
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-with-invalid-llm-mode',
+    });
+    let command = new SetActiveLLMTool(toolService.toolContext);
+
+    await assert.rejects(
+      command.execute({ roomId, model: 'gpt-4', mode: 'code' }),
+      /mode must be "act" or "ask"/,
+      'the invalid mode is rejected',
+    );
+
+    assert.notOk(
+      getRoomState(roomId, APP_BOXEL_ACTIVE_LLM, ''),
+      'the model is not changed when the invocation is invalid',
     );
   });
 

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -269,6 +269,31 @@ export async function getPromptParts(
   };
 }
 
+// The host reports a patch result with the fenced block's position among ALL
+// code blocks in the message, while `codePatchBlocks` holds the patch blocks
+// only. A message that quotes an example code fence before its first patch
+// therefore reports indexes that never line up with 0..n-1, so matching by
+// position waited forever on a patch the host had long applied. Match by
+// count instead: a result per distinct block index, at least one per patch.
+function allCodePatchesHaveAResult(
+  codePatchBlocks: string[],
+  results: CodePatchResultEvent[],
+  onlyApplied = false,
+): boolean {
+  if (codePatchBlocks.length === 0) {
+    return true;
+  }
+  let indexes = new Set(
+    results
+      .filter(
+        (result) =>
+          !onlyApplied || result.content['m.relates_to']?.key === 'applied',
+      )
+      .map((result) => result.content.codeBlockIndex),
+  );
+  return indexes.size >= codePatchBlocks.length;
+}
+
 function getShouldRespond(history: DiscreteMatrixEvent[]): boolean {
   // If the aibot is awaiting command or code patch results, it should not respond yet.
   let lastEventExcludingResults = findLast(
@@ -310,16 +335,10 @@ function getShouldRespond(history: DiscreteMatrixEvent[]): boolean {
         );
       });
     });
-  let allCodePatchesHaveResults =
-    codePatchBlocks.length === 0 ||
-    codePatchBlocks.every((_codePatchBlock: string, codePatchIndex: number) => {
-      return recentEventsToCheck.some((event) => {
-        return (
-          isCodePatchResultEvent(event) &&
-          event.content.codeBlockIndex === codePatchIndex
-        );
-      });
-    });
+  let allCodePatchesHaveResults = allCodePatchesHaveAResult(
+    codePatchBlocks,
+    recentEventsToCheck.filter(isCodePatchResultEvent),
+  );
   if (!allToolsHaveResults || !allCodePatchesHaveResults) {
     return false;
   }
@@ -1788,13 +1807,10 @@ function collectPendingCodePatchCorrectnessCheck(
     let appliedCodePatchResults = codePatchResults.filter(
       (result) => result.content['m.relates_to']?.key === 'applied',
     );
-    let allCodePatchesResolved =
-      codePatchBlocks.length === 0 ||
-      codePatchBlocks.every((_block, index) =>
-        appliedCodePatchResults.some(
-          (result) => result.content.codeBlockIndex === index,
-        ),
-      );
+    let allCodePatchesResolved = allCodePatchesHaveAResult(
+      codePatchBlocks,
+      appliedCodePatchResults,
+    );
     let allRelevantToolsResolved =
       relevantTools.length === 0 ||
       relevantTools.every((request) =>
@@ -1864,15 +1880,11 @@ function hasUnresolvedCodePatches(
     if (isCancelled && !appliedChanges) {
       return false;
     }
-    let allCodePatchesResolved =
-      codePatchBlocks.length === 0 ||
-      codePatchBlocks.every((_block, index) =>
-        codePatchResults.some(
-          (result) =>
-            result.content['m.relates_to']?.key === 'applied' &&
-            result.content.codeBlockIndex === index,
-        ),
-      );
+    let allCodePatchesResolved = allCodePatchesHaveAResult(
+      codePatchBlocks,
+      codePatchResults,
+      true,
+    );
     let allRelevantToolsResolved =
       relevantTools.length === 0 ||
       relevantTools.every((request) =>
@@ -1927,13 +1939,10 @@ function buildCodePatchCorrectnessMessage(
   let appliedCodePatchResults = codePatchResults.filter(
     (result) => result.content['m.relates_to']?.key === 'applied',
   );
-  let allCodePatchesResolved =
-    codePatchBlocks.length === 0 ||
-    codePatchBlocks.every((_block, index) =>
-      appliedCodePatchResults.some(
-        (result) => result.content.codeBlockIndex === index,
-      ),
-    );
+  let allCodePatchesResolved = allCodePatchesHaveAResult(
+    codePatchBlocks,
+    appliedCodePatchResults,
+  );
   let allRelevantToolsResolved =
     relevantTools.length === 0 ||
     relevantTools.every((request) =>


### PR DESCRIPTION
_(Written by Claude on Matic's behalf.)_

In today's model smoke runs, four models wrote correct files and still ended with no card on screen, because the platform lost their output on the way. Each case is a small fix, and they are bundled here because the smoke runner is how they were found and how they will be checked.

**Several skill reads in one turn stalled the bot.** When a model asked for two or three skill files in one message, the bot fulfilled the reads at the same time and posted the results at the same moment. Every result re-triggers the bot, and each re-trigger checks the room history from the server plus the one result it was triggered by. A sibling whose send was still in flight looked unresolved, so no re-trigger ever started the next turn. The reads are now published one after another, so by the time the last result triggers the bot, the others are on the server.

**Patch results were matched by the wrong index.** The host numbers a patch result by its position among all fenced code blocks in the message. The bot's "are all patches applied" check expected positions among patch blocks only. A model that quotes an example code block before its patches reports indexes like 4 and 5, the bot waited for 0 and 1, and the applied files were never followed by a correctness check or a next turn. The bot now counts distinct result indexes instead of matching positions.

**set-active-llm accepted any mode.** The tool cast the argument to `'act' | 'ask'` and sent it to the room, and the room reads anything but `act` as Ask. A model that confused the LLM mode with the submode sent `code`, dropped its room into Ask, and then waited on its own patches for approval. The tool now rejects anything but `act` or `ask` and points at switch-submode.

**A patch cut across two events was never applied.** Long answers are split into a chain of room events at 16 KB, and the cut ignored block boundaries. One model's reasoning text pushed the cut into the middle of a correct block; the host reads patches per event, so both halves were malformed. The cut now moves back to the opening fence when it would land inside a fenced block, so the whole block goes to the next event. A block bigger than one event is still cut, as before.

**The correctness check passed JSON that was not a card.** Four models today wrote an instance without the `data` wrapper, with `type` set to the card's name instead of `card`, or without `meta.adoptsFrom`. The check reported it correct, the indexer stored a plain file, and the model learned two turns later from show-card's "Could not find". The check now names what a card document needs, on the turn the file is written. JSON files with none of the card-shaped keys are left alone.

Tests: a unit test for the block-boundary cut, and a should-respond test with host-style patch indexes. The five models this unblocks are rerun through the smoke runner as the live check.
