### PR TITLE
Add a header to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
-# Boxel Runtime
+<div align="center">
 
-For a quickstart, see [here](./QUICKSTART.md)
+<img src="packages/host/public/boxel-webclip.png" alt="Boxel" width="96" height="96">
+
+# Boxel
+
+**Build software with AI. Then actually use it.**
+
+An open-source runtime for **cards** — small apps whose data, UI and behavior live in
+source you own, in your own storage, and can fork.
+
+[![Homepage](https://img.shields.io/badge/Homepage-boxel.ai-C2410C)](https://boxel.ai)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/boxel)
+[![Follow @boxel_ai](https://img.shields.io/badge/%40boxel__ai-follow-1878B9?logo=x&logoColor=white)](https://x.com/boxel_ai)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+
+[Docs](./docs/README.md) · [Quickstart](./QUICKSTART.md) · [Development](#setup)
+
+</div>
+
+<!-- DEMO: replace this comment with a ≤10s screen capture — browse the catalog, fork a
+     listing, see it running in your own realm. GIF or mp4, ≤5MB, committed under
+     ./docs/assets/demo.gif. This slot is above the fold and is the single highest-value
+     thing on the page; ship the README with it, not after it. -->
+
+---
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ source you own, in your own storage, and can fork.
 
 </div>
 
-<!-- DEMO: replace this comment with a ≤10s screen capture — browse the catalog, fork a
-     listing, see it running in your own realm. GIF or mp4, ≤5MB, committed under
-     ./docs/assets/demo.gif. This slot is above the fold and is the single highest-value
-     thing on the page; ship the README with it, not after it. -->
-
 ---
 
 ## Setup


### PR DESCRIPTION

<img width="882" height="402" alt="Screenshot 2026-09-08 at 21 09 21" src="https://github.com/user-attachments/assets/fc82ef33-cf1f-45bd-b156-de8198178b43" />


## Why

The README opened with `# Boxel Runtime` and went straight to `mise install`. There was no sentence anywhere saying **what Boxel is**, and no link to the homepage, Discord or X anywhere in the repo — so a stranger arriving from a link (HN, X, an awesome-list) had nothing to read and nowhere to go.

## What changed

**One file, `README.md`, +27 / -2.** A header above the existing docs:

- logo and the tagline "Build software with AI. Then actually use it."
- a one-sentence description of what a card is
- badges: npm `boxel-cli`, MIT, Discord, X
- two link rows: **Homepage · Discord · X**, then Docs · Quickstart · Development

Everything from `## Setup` down is unchanged. The two removed lines are the old `# Boxel Runtime` title and its bare quickstart pointer, both superseded by the header.

## Draft, because of one thing

**The demo slot.** There's an HTML comment where a <=10s capture (browse -> fork -> running in your realm) belongs. It's the highest-value pixel on the page and I can't produce it - someone with a screen recorder should, before this merges.

## Not in this PR

Repo metadata (About -> website, description, topics) is a settings change, not a commit:

```
gh repo edit cardstack/boxel \
  --homepage "https://boxel.ai" \
  --description "Open-source runtime for cards - small apps whose data, UI and behavior live in source you own." \
  --add-topic open-source,typescript,ember,internal-tools,ai-agents,self-hosted
```

The Discord badge is static because the server's widget is disabled (`403 Widget Disabled` from `widget.json`); enabling Server Settings -> Widget would allow a live member count.
