### PR TITLE
Add the @operation declaration API for card authors

### DIFF
--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -396,8 +396,17 @@ const CLAUSE_KEYS: Record<BaseOperationName, readonly string[]> = {
   query: ['query'],
 };
 
-// Clauses without which a declaration names no work at all: a create with no
-// type to create, a query with no query.
+// Clauses without which an authored declaration names no work at all: a
+// create with no type to create, a query with no query.
+//
+// The rule is about what an author writes, not about every entry a reader
+// returns. A base operation reached with no declaration takes both of these
+// from the invocation instead — a plain `create` is called with the class and
+// carries the type in the request, a plain `query` is called with the query —
+// so the entries `getOperations` synthesizes for them are bare by design and
+// do not satisfy this. Anything that needs the guarantee this rule provides
+// is reading authored declarations, which is what `getDeclaredOperations`
+// returns.
 const REQUIRED_CLAUSE: Partial<Record<BaseOperationName, string>> = {
   create: 'of',
   query: 'query',
@@ -452,6 +461,13 @@ export const operation = function (
 //
 // `create` and `query` are type-scoped rather than instance-scoped: they come
 // back for a card def either way, but they target the type, not one instance.
+//
+// A synthesized entry is the bare `{ base }`: the base operations are the
+// executors, so there is nothing for an author to have said about one, and
+// what a plain `create` or `query` needs travels with the invocation rather
+// than the declaration. Read `declaration.base` to dispatch and this record
+// is uniform; reach for a clause and only authored declarations can be
+// relied on to carry one, so lower from `getDeclaredOperations`.
 export function getOperations(
   classOrInstance: BaseDef | typeof BaseDef,
 ): Record<string, OperationDeclaration> {
@@ -473,6 +489,12 @@ export function getOperations(
 // drops everything an ancestor declared. Use it over `getOperations` when the
 // distinction matters: what an author wrote, as opposed to what the def type
 // provides on its own.
+//
+// Every entry here went through the decorator's validation, so a clause the
+// declaration's base requires is present. That makes this the reader to
+// lower from: lowering turns authored sugar into base-operation data plus
+// BXL, and a base operation reached with no declaration has nothing to
+// lower.
 export function getDeclaredOperations(
   classOrInstance: BaseDef | typeof BaseDef,
 ): Record<string, OperationDeclaration> {

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -1,5 +1,6 @@
 import {
   BaseDef,
+  CardDef,
   FieldDef,
   FileDef,
   type BaseDefConstructor,
@@ -53,11 +54,12 @@ import {
 // declared; the override then keeps its own literal types.
 // ============================================================================
 
-// The behaviors every declaration builds on. They are implied by the def type
-// rather than declared — a `CardDef` has all six, a `FileDef` only `read` —
-// so `getOperations` never synthesizes an entry for one. A declaration *named*
-// after a base op is an author's override of it and does come back, which is
-// how a card specializes its own `read` projection or `update` validation.
+// The behaviors every declaration builds on. Which of them a def carries is
+// implied by the def type rather than written in author code — a `CardDef`
+// has all six, a `FileDef` only `read`, a `FieldDef` none — so
+// `getOperations` synthesizes them. A declaration *named* after a base op is
+// an author's override of it and takes its place, which is how a card
+// specializes its own `read` projection or `update` validation.
 export const BASE_OPERATIONS = [
   'read',
   'create',
@@ -403,25 +405,70 @@ export const operation = function (
   };
 } as unknown as PropertyDecorator;
 
-// The one read path for `@operation` declarations: merges them by name up the
-// prototype chain, so a subclass adds new names and overrides inherited ones
-// wholesale, per name. Read through this rather than a class's static
-// directly — a plain property read sees only the nearest declaration and
-// drops everything an ancestor declared. The built-in base operations are
-// implied by the def type and are not included unless the author declared one
-// explicitly to override it.
+// Every operation a def carries: the base operations its def type implies,
+// plus everything its authors declared, with a declaration taking the place
+// of the base operation it names. This is the read path a caller wants —
+// dispatch, lowering and an invocation surface all need the whole set, and
+// which part of it came from author code is not something they branch on.
+//
+// `create` and `query` are type-scoped rather than instance-scoped: they come
+// back for a card def either way, but they target the type, not one instance.
 export function getOperations(
   classOrInstance: BaseDef | typeof BaseDef,
 ): Record<string, OperationDeclaration> {
-  let owner =
-    typeof classOrInstance === 'function'
-      ? classOrInstance
-      : classOrInstance?.constructor;
-  if (typeof owner !== 'function' || !isDefConstructor(owner)) {
-    throw new Error(
-      `getOperations() takes a class that extends BaseDef, or an instance of one`,
-    );
+  let owner = defConstructorFor(classOrInstance, 'getOperations');
+  let operations: Record<string, OperationDeclaration> = {};
+  for (let base of impliedOperations(owner)) {
+    // A base operation with nothing declared on it is the declaration
+    // `{ base }`; the cast is only because a union does not narrow from a
+    // computed discriminant.
+    operations[base] = { base } as OperationDeclaration;
   }
+  return Object.assign(operations, declaredOperations(owner));
+}
+
+// Only what `@operation` declarations put on the def, merged by name up the
+// prototype chain so a subclass adds new names and overrides inherited ones
+// wholesale, per name. Read through this rather than a class's static
+// directly — a plain property read sees only the nearest declaration and
+// drops everything an ancestor declared. Use it over `getOperations` when the
+// distinction matters: what an author wrote, as opposed to what the def type
+// provides on its own.
+export function getDeclaredOperations(
+  classOrInstance: BaseDef | typeof BaseDef,
+): Record<string, OperationDeclaration> {
+  return declaredOperations(
+    defConstructorFor(classOrInstance, 'getDeclaredOperations'),
+  );
+}
+
+// Which base operations a def type carries. Overriding one is a matter of
+// declaring an operation by its name; nothing here is written in author code.
+function impliedOperations(
+  owner: typeof BaseDef,
+): readonly BaseOperationName[] {
+  if (isSubclassOf(owner, FieldDef)) {
+    // A field's instances have no URL, so nothing is invocable on one; field
+    // data is reached through the operations of the card that contains it.
+    return [];
+  }
+  if (isSubclassOf(owner, CardDef)) {
+    return BASE_OPERATIONS;
+  }
+  if (isSubclassOf(owner, FileDef)) {
+    // A file's metadata is content-derived and read-only: there is no
+    // JSON:API mutation surface for anything else to reach.
+    return READ_ONLY;
+  }
+  // The one operation every addressable def shares.
+  return READ_ONLY;
+}
+
+const READ_ONLY = ['read'] as const;
+
+function declaredOperations(
+  owner: typeof BaseDef,
+): Record<string, OperationDeclaration> {
   // Collect declaration levels base-most first so a subclass's entry lands
   // after (and thus overrides) its ancestor's.
   let levels: Record<string, OperationDeclaration>[] = [];
@@ -434,6 +481,22 @@ export function getOperations(
     current = Object.getPrototypeOf(current);
   }
   return Object.assign({}, ...levels);
+}
+
+function defConstructorFor(
+  classOrInstance: BaseDef | typeof BaseDef,
+  reader: string,
+): typeof BaseDef {
+  let owner =
+    typeof classOrInstance === 'function'
+      ? classOrInstance
+      : classOrInstance?.constructor;
+  if (typeof owner !== 'function' || !isDefConstructor(owner)) {
+    throw new Error(
+      `${reader}() takes a class that extends BaseDef, or an instance of one`,
+    );
+  }
+  return owner;
 }
 
 function ownDeclarations(
@@ -502,7 +565,7 @@ function assertNameAvailable(owner: typeof BaseDef, key: string) {
   if (!(key in owner)) {
     return;
   }
-  if (key in getOperations(owner)) {
+  if (key in declaredOperations(owner)) {
     return;
   }
   throw new Error(

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -490,8 +490,10 @@ export function getOperations(
 // distinction matters: what an author wrote, as opposed to what the def type
 // provides on its own.
 //
-// Every entry here went through the decorator's validation, so a clause the
-// declaration's base requires is present. That makes this the reader to
+// Every entry here went through the decorator's validation, so a clause that
+// names a type is present where its base requires one — a `create` says what
+// it creates whichever form its work takes. A clause that describes work may
+// be absent when a raw program replaces it. That makes this the reader to
 // lower from: lowering turns authored sugar into base-operation data plus
 // BXL, and a base operation reached with no declaration has nothing to
 // lower.
@@ -702,7 +704,8 @@ function assertValidDeclaration(
     (clause) =>
       declaration[clause] !== undefined && !TYPE_NAMING_KEYS.includes(clause),
   );
-  if (declaration.transformations !== undefined) {
+  let hasProgram = declaration.transformations !== undefined;
+  if (hasProgram) {
     assertBxlProgram(label, 'transformations', declaration.transformations);
     if (usedClauses.length > 0) {
       throw new Error(
@@ -711,9 +714,18 @@ function assertValidDeclaration(
         )}) or with a raw \`transformations\` program, not both`,
       );
     }
-  } else {
-    let required = REQUIRED_CLAUSE[base];
-    if (required !== undefined && declaration[required] === undefined) {
+  }
+  let required = REQUIRED_CLAUSE[base];
+  if (required !== undefined && declaration[required] === undefined) {
+    // A program replaces the work a clause describes, but not a clause that
+    // names a type: a program computes a new card's fields without saying
+    // what kind of card to create.
+    if (TYPE_NAMING_KEYS.includes(required)) {
+      throw new Error(
+        `${label}: a "${base}" operation needs \`${required}\` to name what it creates`,
+      );
+    }
+    if (!hasProgram) {
       throw new Error(
         `${label}: a "${base}" operation needs \`${required}\`, or a raw \`transformations\` program`,
       );
@@ -868,6 +880,16 @@ function assertValidParamsSchema(label: string, schema: unknown): Set<string> {
         );
       }
       assertOnlyKeys(label, `params.${name}`, type, ['$linkTo']);
+      let linked = (type as { $linkTo: unknown }).$linkTo;
+      if (
+        isDefConstructor(linked) &&
+        !isSubclassOf(linked, CardDef) &&
+        !isSubclassOf(linked, FileDef)
+      ) {
+        throw new Error(
+          `${label}: param "${name}" links to a card or file class — a link points at something with a URL`,
+        );
+      }
     } else if (!isFieldDefConstructor(type)) {
       // A scalar param is typed by the field class that serializes it, so
       // any other function — a card class, a thunk, an unrelated callable —
@@ -907,11 +929,12 @@ function isFieldDefConstructor(value: unknown): boolean {
 // flattens away, a cycle JSON refuses outright — would leave the operation
 // running against something other than what the author wrote, silently.
 //
-// A def class is legal in exactly the two slots that name a type: the `of` a
-// `create` targets, and the `on` a query filters against (at any depth, since
-// filters nest). Naming those slots individually is what keeps a thunk from
-// being mistaken for a value everywhere else in a query — a function under
-// `eq` would lower to nothing and match every card instead of one.
+// A def class is legal only where the grammar names a type: the `of` a
+// `create` targets, and a filter node's `on` or `type` (`type` is how the
+// realm spells a pure card-type filter). Those are positions, not key names —
+// under `eq` / `in` / `contains` / `range` / `matches` the keys are field
+// names, so an `on` there means a field called `on` and a class would lower
+// to nothing, leaving a saved search that matches every card instead of one.
 function assertReferencesResolve(
   label: string,
   declaration: Record<string, unknown>,
@@ -921,17 +944,24 @@ function assertReferencesResolve(
   // so a cycle is caught while the same object legitimately appearing twice
   // is validated in each place it appears.
   let ancestors = new Set<object>();
-  let walk = (node: unknown, path: string, slot: SlotKind) => {
+  let walk = (node: unknown, path: string, position: WalkPosition) => {
     if (node === null) {
       return;
     }
     if (typeof node === 'function') {
-      if (slot.definitionAllowed) {
-        return;
+      if (position !== 'type') {
+        throw new Error(
+          `${label}: \`${path}\` is a function; a declaration is data — name a run-time value with params(), actor(), instance() or card(), or a program with the bxl tag`,
+        );
       }
-      throw new Error(
-        `${label}: \`${path}\` is a function; a declaration is data — name a run-time value with params(), actor(), instance() or card(), or a program with the bxl tag`,
-      );
+      // A thunk defers its class past this point; one named directly is held
+      // to a kind a query can match or a create can mint.
+      if (isDefConstructor(node) && !isSubclassOf(node, CardDef)) {
+        throw new Error(
+          `${label}: \`${path}\` must be a card class — only a card has a type to name here`,
+        );
+      }
+      return;
     }
     if (typeof node !== 'object') {
       if (typeof node === 'symbol' || typeof node === 'bigint') {
@@ -960,8 +990,8 @@ function assertReferencesResolve(
       assertBxlProgram(label, path, node);
       return;
     }
-    if ('$ref' in node) {
-      assertValidReference(label, path, node, paramNames);
+    if (isReferenceMarker(node)) {
+      assertValidReference(label, path, node, paramNames, ancestors);
       return;
     }
     if (!Array.isArray(node) && !isPlainObject(node)) {
@@ -973,39 +1003,87 @@ function assertReferencesResolve(
     }
     ancestors.add(node);
     if (Array.isArray(node)) {
+      let elementPosition = positionInside(position);
       node.forEach((entry, index) =>
-        walk(entry, `${path}[${index}]`, {
-          definitionAllowed: false,
-          inQuery: slot.inQuery,
-        }),
+        walk(entry, `${path}[${index}]`, elementPosition),
       );
     } else {
       for (let [key, value] of Object.entries(node)) {
         // The params schema holds field classes and linkTo markers rather
         // than references, and is validated on its own terms.
-        if (path === '' && key === 'params') {
+        if (position === 'declaration' && key === 'params') {
           continue;
         }
-        let inQuery = slot.inQuery || (path === '' && key === 'query');
-        walk(value, path === '' ? key : `${path}.${key}`, {
-          definitionAllowed:
-            (path === '' && key === 'of') || (inQuery && key === 'on'),
-          inQuery,
-        });
+        walk(
+          value,
+          path === '' ? key : `${path}.${key}`,
+          positionUnder(position, key),
+        );
       }
     }
     ancestors.delete(node);
   };
-  walk(declaration, '', { definitionAllowed: false, inQuery: false });
+  walk(declaration, '', 'declaration');
 }
 
-// Where in a declaration the walk currently is, in the only two terms it
-// changes behavior on.
-interface SlotKind {
-  // This slot names a type, so a def class (or a thunk returning one) belongs.
-  definitionAllowed: boolean;
-  // Somewhere inside a `query`, where a nested `on` names a type.
-  inQuery: boolean;
+// Where in a declaration the walk currently is. Only the positions that
+// govern whether a def class belongs are named; everything else is data.
+type WalkPosition =
+  | 'declaration'
+  | 'value'
+  | 'type'
+  | 'query'
+  | 'filter'
+  | 'filterList'
+  | 'sortList'
+  | 'sortEntry';
+
+// The realm's filter grammar, followed structurally: a filter node carries an
+// optional `on` (or a `type`, for a pure card-type filter) and one predicate,
+// where `any` and `every` hold further filter nodes and `not` holds one. A
+// sort entry names the type its `by` path is rooted in. Anything else — the
+// field-name maps under the predicates, `page`, `realms` — is data.
+function positionUnder(position: WalkPosition, key: string): WalkPosition {
+  switch (position) {
+    case 'declaration':
+      if (key === 'of') {
+        return 'type';
+      }
+      return key === 'query' ? 'query' : 'value';
+    case 'query':
+      if (key === 'filter') {
+        return 'filter';
+      }
+      return key === 'sort' ? 'sortList' : 'value';
+    case 'filter':
+      if (key === 'on' || key === 'type') {
+        return 'type';
+      }
+      if (key === 'any' || key === 'every') {
+        return 'filterList';
+      }
+      return key === 'not' ? 'filter' : 'value';
+    case 'sortEntry':
+      return key === 'on' ? 'type' : 'value';
+    // A code ref written out by hand is plain data, and nothing below a
+    // value slot names a type.
+    case 'type':
+    case 'value':
+    case 'filterList':
+    case 'sortList':
+      return 'value';
+  }
+}
+
+function positionInside(position: WalkPosition): WalkPosition {
+  switch (position) {
+    case 'filterList':
+      return 'filter';
+    case 'sortList':
+      return 'sortEntry';
+    default:
+      return 'value';
+  }
 }
 
 function describeValue(value: unknown): string {
@@ -1030,7 +1108,13 @@ function assertValidReference(
   path: string,
   node: object,
   paramNames: Set<string>,
+  ancestors: Set<object>,
 ) {
+  if (ancestors.has(node)) {
+    throw new Error(
+      `${label}: \`${path}\` refers back to a value that contains it; a declaration is a tree`,
+    );
+  }
   let reference = node as Record<string, unknown>;
   switch (reference.$ref) {
     case 'params': {
@@ -1072,12 +1156,20 @@ function assertValidReference(
         }
         return;
       }
-      if (!isPlainObject(value) || !('$ref' in value)) {
+      if (!isReferenceMarker(value)) {
         throw new Error(
           `${label}: the card reference at \`${path}\` must carry a card URL or a reference to one`,
         );
       }
-      assertValidReference(label, `${path}.value`, value, paramNames);
+      ancestors.add(node);
+      assertValidReference(
+        label,
+        `${path}.value`,
+        value as object,
+        paramNames,
+        ancestors,
+      );
+      ancestors.delete(node);
       return;
     }
     default:
@@ -1128,12 +1220,14 @@ function assertOptionalReferenceKey(kind: string, key: unknown) {
   }
 }
 
+// A marker is identified by a key of its own. Reached through a prototype it
+// would validate here and then serialize as `{}`.
 function isReferenceMarker(value: unknown): boolean {
-  return isPlainObject(value) && '$ref' in (value as object);
+  return isPlainObject(value) && hasOwn(value, '$ref');
 }
 
 function isBxlMarker(value: unknown): boolean {
-  return isPlainObject(value) && '$bxl' in (value as object);
+  return isPlainObject(value) && hasOwn(value, '$bxl');
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -1,0 +1,860 @@
+import {
+  BaseDef,
+  FieldDef,
+  FileDef,
+  type BaseDefConstructor,
+  type BaseInstanceType,
+  type CardDefConstructor,
+  type FieldDefConstructor,
+  type LinkableDefConstructor,
+} from './card-api';
+
+// ============================================================================
+// The `@operation` authoring surface for card definitions.
+//
+// An operation is a named, reusable action on a card — "add a comment",
+// "invite a guardian", "create an activity for this classroom" — declared by
+// the card author as plain data rather than as JavaScript. A declaration names
+// the built-in behavior it builds on (`base`), the payload it accepts
+// (`params`), and what it does to the target. Values that are only known at
+// invocation time are written as typed references: `params('body')` for a
+// member of the request payload, `actor()` for the invoking actor,
+// `instance()` for the target's stored source document, `card(…)` for a link
+// identity, and the `bxl` tag for a raw program.
+//
+//   class ExternalReport extends CardDef {
+//     @operation static addComment = {
+//       base: 'transform',
+//       params: { body: StringField },
+//       append: {
+//         to: 'comments',
+//         value: { body: params('body'), author: actor() },
+//       },
+//     } satisfies OperationDeclaration;
+//   }
+//
+// Everything here is data: a declaration is captured when a module's
+// definition-cache entry is built, lowered there to canonical base-operation
+// data plus BXL, and executed by the realm from that lowered form. No author
+// JavaScript runs on an operation's path, which is why this module declares
+// and validates shapes without running any of them, and why it reaches
+// neither the loader nor the network — it has to load inside a card module,
+// where only the card loader exists.
+//
+// The `satisfies OperationDeclaration` above is worth keeping in author code:
+// it type-checks the declaration in place and preserves the literal types
+// (`base: 'transform'` rather than `base: string`) that `OperationsOf` and
+// `ParamsOf` read.
+//
+// A subclass overrides an inherited operation by redeclaring its name.
+// TypeScript requires a subclass's static to stay assignable to the one it
+// shadows, so an operation meant to be overridden with a differently-shaped
+// declaration is annotated `: OperationDeclaration` where it is first
+// declared; the override then keeps its own literal types.
+// ============================================================================
+
+// The behaviors every declaration builds on. They are implied by the def type
+// rather than declared — a `CardDef` has all six, a `FileDef` only `read` —
+// so `getOperations` never synthesizes an entry for one. A declaration *named*
+// after a base op is an author's override of it and does come back, which is
+// how a card specializes its own `read` projection or `update` validation.
+export const BASE_OPERATIONS = [
+  'read',
+  'create',
+  'update',
+  'delete',
+  'query',
+  'transform',
+] as const;
+
+export type BaseOperationName = (typeof BASE_OPERATIONS)[number];
+
+// ============================================================================
+// Typed references
+//
+// Each constructor below returns a plain marker object that survives
+// `JSON.stringify` and carries the reference's kind in a `$`-prefixed key.
+// The same words name BXL builtins that read the injected operation context,
+// so what a declaration writes is what the lowered program evaluates — there
+// is no interpolation syntax and no sigil.
+// ============================================================================
+
+export interface ParamsReference<Key extends string = string> {
+  readonly $ref: 'params';
+  readonly key: Key;
+}
+
+export interface ActorReference {
+  readonly $ref: 'actor';
+  readonly key?: string;
+}
+
+export interface InstanceReference {
+  readonly $ref: 'instance';
+  readonly key?: string;
+}
+
+export interface CardReference {
+  readonly $ref: 'card';
+  readonly value: string | ParamsReference | ActorReference | InstanceReference;
+}
+
+export type OperationReference =
+  | ParamsReference
+  | ActorReference
+  | InstanceReference
+  | CardReference;
+
+export interface BxlProgram {
+  readonly $bxl: string;
+}
+
+// A member of the request payload, checked against the declaration's own
+// `params` schema.
+export function params<Key extends string>(key: Key): ParamsReference<Key> {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error(
+      `params() takes the name of a param declared in the operation's \`params\` schema`,
+    );
+  }
+  return { $ref: 'params', key };
+}
+
+// The invoking actor — the whole actor, or one of its members: `actor('id')`.
+export function actor(key?: string): ActorReference {
+  assertOptionalReferenceKey('actor', key);
+  return key === undefined ? { $ref: 'actor' } : { $ref: 'actor', key };
+}
+
+// The invocation target's stored source document — never a live card
+// instance. Unavailable to an operation invoked with no target in scope.
+export function instance(key?: string): InstanceReference {
+  assertOptionalReferenceKey('instance', key);
+  return key === undefined ? { $ref: 'instance' } : { $ref: 'instance', key };
+}
+
+// A link identity: the URL of a saved card, or the reference that resolves to
+// one — `card(params('activity'))`, `card(actor('id'))`.
+export function card(reference: CardReference['value']): CardReference {
+  if (typeof reference === 'string') {
+    if (reference.length === 0) {
+      throw new Error(`card() takes a card URL or a typed reference to one`);
+    }
+    return { $ref: 'card', value: reference };
+  }
+  if (!isReferenceMarker(reference)) {
+    throw new Error(`card() takes a card URL or a typed reference to one`);
+  }
+  return { $ref: 'card', value: reference };
+}
+
+// A raw BXL program, for the transformations the declarative clauses don't
+// express. The tag takes no substitutions: `params()`, `actor()` and
+// `instance()` are BXL builtins that read the operation context, so a program
+// reads the payload and the actor directly instead of having values spliced
+// into its text.
+export function bxl(
+  program: TemplateStringsArray,
+  ...substitutions: unknown[]
+): BxlProgram {
+  if (substitutions.length > 0) {
+    throw new Error(
+      `the bxl tag does not interpolate values; read the payload, the actor and the target inside the program with the params(), actor() and instance() builtins`,
+    );
+  }
+  return { $bxl: program.raw.join('') };
+}
+
+// ============================================================================
+// Declaration types
+// ============================================================================
+
+// A param that carries a card identity: the URL of a saved card, or the `lid`
+// of a card being created in the same atomic batch.
+export interface LinkToParam<
+  Def extends LinkableDefConstructor = LinkableDefConstructor,
+> {
+  readonly $linkTo: Def | (() => Def);
+}
+
+export type LinkParamValue = string | { lid: string };
+
+export function linkTo<Def extends LinkableDefConstructor>(
+  def: Def | (() => Def),
+): LinkToParam<Def> {
+  if (typeof def !== 'function') {
+    throw new Error(
+      `linkTo() takes a card class (or a thunk returning one, for a class declared later in the module)`,
+    );
+  }
+  return { $linkTo: def };
+}
+
+// A field class for a scalar param, or `linkTo(…)` for a card identity. The
+// schema is the single source for the payload's TypeScript type, for checking
+// `params(…)` references, and for the endpoint's payload validation.
+export type ParamType = FieldDefConstructor | LinkToParam;
+export type ParamsSchema = Record<string, ParamType>;
+
+export type OperationValue =
+  | string
+  | number
+  | boolean
+  | null
+  | OperationReference
+  | BxlProgram
+  | readonly OperationValue[]
+  | { readonly [key: string]: OperationValue };
+
+// Appends a value to a collection field. Cardinality (contained value vs.
+// link) comes from the field-type map, so a declaration names the field and
+// the value and nothing else.
+export interface AppendClause {
+  readonly to: string;
+  readonly value: OperationValue;
+}
+
+// A precondition on the target's stored data. It guards data state, not
+// identity — an assertion is never an authorization check.
+export interface AssertClause {
+  readonly unique: string;
+  readonly by: OperationValue;
+  readonly message?: string;
+}
+
+export type SetClause = { readonly [fieldName: string]: OperationValue };
+export type FillClause = { readonly [fieldName: string]: OperationValue };
+
+// Projects or reshapes the result. May reference the actor, which makes the
+// operation's response per-actor.
+export type OperationOutput =
+  | BxlProgram
+  | { readonly [key: string]: OperationValue };
+
+// A saved search, declared next to the card's other operations and lowered to
+// an ordinary realm query. `filter.on` takes the card class itself and the
+// code ref is derived when the declaration is lowered; a query that filters on
+// the very class it is declared on takes the thunk form, since the class
+// binding is not yet initialized while its own statics are being built.
+export interface QueryDeclaration {
+  readonly filter?: OperationQueryValue;
+  readonly sort?: OperationQueryValue;
+  readonly page?: { readonly size?: number; readonly cursor?: string };
+  readonly realms?: readonly string[];
+}
+
+export type OperationQueryValue =
+  | string
+  | number
+  | boolean
+  | null
+  | BaseDefConstructor
+  | (() => BaseDefConstructor)
+  | OperationReference
+  | readonly OperationQueryValue[]
+  | { readonly [key: string]: OperationQueryValue };
+
+interface OperationCommon {
+  readonly params?: ParamsSchema;
+  // The author's override of the automatically-detected eligibility for the
+  // client's optimistic path.
+  readonly optimistic?: boolean;
+  // The raw escape hatch: author-supplied BXL in place of the declarative
+  // clauses, for anything they don't express.
+  readonly input?: BxlProgram;
+  readonly transformations?: BxlProgram;
+  readonly output?: OperationOutput;
+}
+
+export interface TransformOperationDeclaration extends OperationCommon {
+  readonly base: 'transform';
+  readonly append?: AppendClause;
+  readonly assert?: AssertClause;
+  readonly set?: SetClause;
+}
+
+export interface CreateOperationDeclaration extends OperationCommon {
+  readonly base: 'create';
+  // The type to create. Required unless the declaration supplies a raw
+  // program instead.
+  readonly of?: CardDefConstructor | (() => CardDefConstructor);
+  readonly fill?: FillClause;
+}
+
+export interface UpdateOperationDeclaration extends OperationCommon {
+  readonly base: 'update';
+}
+
+export interface DeleteOperationDeclaration extends OperationCommon {
+  readonly base: 'delete';
+}
+
+export interface ReadOperationDeclaration extends OperationCommon {
+  readonly base: 'read';
+}
+
+export interface QueryOperationDeclaration extends OperationCommon {
+  readonly base: 'query';
+  // Required unless the declaration supplies a raw program instead.
+  readonly query?: QueryDeclaration;
+}
+
+export type OperationDeclaration =
+  | TransformOperationDeclaration
+  | CreateOperationDeclaration
+  | UpdateOperationDeclaration
+  | DeleteOperationDeclaration
+  | ReadOperationDeclaration
+  | QueryOperationDeclaration;
+
+// The operations declared on a def, read off the class type. Keyed by
+// operation name, so an invocation surface can be typed from the class alone.
+export type OperationsOf<Def> = {
+  [Name in keyof Def as Def[Name] extends { base: string }
+    ? Name
+    : never]: Def[Name];
+};
+
+// The payload an operation accepts, derived from its declared `params`
+// schema: each entry becomes the value type of the field class that declares
+// it, and a `linkTo(…)` param becomes a card identity.
+export type ParamsOf<Declaration> = Declaration extends {
+  params: infer Schema;
+}
+  ? { [Key in keyof Schema]: ParamValueOf<Schema[Key]> }
+  : Record<string, never>;
+
+type ParamValueOf<Param> =
+  Param extends LinkToParam<LinkableDefConstructor>
+    ? LinkParamValue
+    : Param extends BaseDefConstructor
+      ? BaseInstanceType<Param & BaseDefConstructor>
+      : unknown;
+
+// ============================================================================
+// The decorator
+// ============================================================================
+
+const operationDeclarations = Symbol.for('cardstack-operation-declarations');
+
+// Keys every declaration may carry, whichever base it builds on. `input`,
+// `transformations` and `output` are the raw program's stages.
+const COMMON_DECLARATION_KEYS = [
+  'base',
+  'params',
+  'optimistic',
+  'input',
+  'transformations',
+  'output',
+] as const;
+
+// The declarative clauses each base accepts. A declaration uses these or a
+// raw `transformations` program — the two are alternative spellings of the
+// same lowered program, not layers.
+const CLAUSE_KEYS: Record<BaseOperationName, readonly string[]> = {
+  transform: ['append', 'assert', 'set'],
+  create: ['of', 'fill'],
+  update: [],
+  delete: [],
+  read: [],
+  query: ['query'],
+};
+
+// Clauses without which a declaration names no work at all: a create with no
+// type to create, a query with no query.
+const REQUIRED_CLAUSE: Partial<Record<BaseOperationName, string>> = {
+  create: 'of',
+  query: 'query',
+};
+
+// Records a static declaration on the class it is declared on. Our decorators
+// are implemented by Babel, not TypeScript, so the signature differs from the
+// one TypeScript expects; a static-property decorator receives the
+// constructor.
+export const operation = function (
+  target: unknown,
+  key: string | symbol,
+  descriptor: { initializer?: (() => unknown) | null } | undefined,
+) {
+  if (typeof key === 'symbol') {
+    throw new Error(
+      `the @operation decorator only supports string operation names, not symbols`,
+    );
+  }
+  let owner = assertOperationTarget(target, key);
+  assertNameAvailable(owner, key);
+  if (typeof descriptor?.initializer !== 'function') {
+    throw new Error(
+      `${declarationLabel(owner, key)}: an operation must be assigned a declaration object`,
+    );
+  }
+  let declaration = descriptor.initializer.call(owner);
+  assertValidDeclaration(owner, key, declaration);
+  recordDeclaration(owner, key, declaration as OperationDeclaration);
+  // A descriptor carrying `value` (and no `initializer`) is what installs the
+  // property on the constructor at class-definition time. Leaving the
+  // initializer in place defers it to instance construction, where a static
+  // never runs.
+  return {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: declaration,
+  };
+} as unknown as PropertyDecorator;
+
+// The one read path for `@operation` declarations: merges them by name up the
+// prototype chain, so a subclass adds new names and overrides inherited ones
+// wholesale, per name. Read through this rather than a class's static
+// directly — a plain property read sees only the nearest declaration and
+// drops everything an ancestor declared. The built-in base operations are
+// implied by the def type and are not included unless the author declared one
+// explicitly to override it.
+export function getOperations(
+  classOrInstance: BaseDef | typeof BaseDef,
+): Record<string, OperationDeclaration> {
+  let owner =
+    typeof classOrInstance === 'function'
+      ? classOrInstance
+      : classOrInstance?.constructor;
+  if (typeof owner !== 'function' || !isDefConstructor(owner)) {
+    throw new Error(
+      `getOperations() takes a class that extends BaseDef, or an instance of one`,
+    );
+  }
+  // Collect declaration levels base-most first so a subclass's entry lands
+  // after (and thus overrides) its ancestor's.
+  let levels: Record<string, OperationDeclaration>[] = [];
+  let current: unknown = owner;
+  while (typeof current === 'function') {
+    let declarations = ownDeclarations(current);
+    if (declarations) {
+      levels.unshift(declarations);
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return Object.assign({}, ...levels);
+}
+
+function ownDeclarations(
+  owner: unknown,
+): Record<string, OperationDeclaration> | undefined {
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      owner as object,
+      operationDeclarations,
+    )
+  ) {
+    return undefined;
+  }
+  return (owner as Record<symbol, Record<string, OperationDeclaration>>)[
+    operationDeclarations
+  ];
+}
+
+function recordDeclaration(
+  owner: typeof BaseDef,
+  key: string,
+  declaration: OperationDeclaration,
+) {
+  let declarations = ownDeclarations(owner);
+  if (!declarations) {
+    declarations = {};
+    Object.defineProperty(owner, operationDeclarations, {
+      value: declarations,
+      configurable: true,
+      enumerable: false,
+      writable: false,
+    });
+  }
+  declarations[key] = declaration;
+}
+
+function isDefConstructor(target: unknown): target is typeof BaseDef {
+  return (
+    typeof target === 'function' &&
+    (target === BaseDef || target.prototype instanceof BaseDef)
+  );
+}
+
+function isSubclassOf(target: typeof BaseDef, def: typeof BaseDef): boolean {
+  return target === def || target.prototype instanceof def;
+}
+
+function assertOperationTarget(target: unknown, key: string): typeof BaseDef {
+  if (!isDefConstructor(target)) {
+    throw new Error(
+      `the @operation decorator can only be used on static properties of classes that extend BaseDef`,
+    );
+  }
+  if (isSubclassOf(target, FieldDef)) {
+    throw new Error(
+      `${declarationLabel(target, key)}: a field has no URL of its own, so it cannot carry operations — declare this on the card that contains the field`,
+    );
+  }
+  return target;
+}
+
+// A name that already resolves on the class would shadow, or be shadowed by,
+// whatever provides it. An inherited operation of the same name is the one
+// exception: that is how a subclass overrides it.
+function assertNameAvailable(owner: typeof BaseDef, key: string) {
+  if (!(key in owner)) {
+    return;
+  }
+  if (key in getOperations(owner)) {
+    return;
+  }
+  throw new Error(
+    `${declarationLabel(owner, key)}: "${key}" is already a static on this class, so it cannot name an operation`,
+  );
+}
+
+function assertValidDeclaration(
+  owner: typeof BaseDef,
+  key: string,
+  value: unknown,
+) {
+  let label = declarationLabel(owner, key);
+  if (!isPlainObject(value)) {
+    throw new Error(`${label}: an operation must be a declaration object`);
+  }
+  let declaration = value as Record<string, unknown>;
+  let base = declaration.base;
+  if (!isBaseOperationName(base)) {
+    throw new Error(
+      `${label}: \`base\` must name the built-in behavior this operation builds on — one of ${quoteList(BASE_OPERATIONS)}`,
+    );
+  }
+  // A file's metadata is content-derived and read-only, so it has no
+  // mutation surface for anything but `read` to reach.
+  if (base !== 'read' && isSubclassOf(owner, FileDef)) {
+    throw new Error(
+      `${label}: a file's metadata is read-only, so only \`base: 'read'\` operations can be declared on it`,
+    );
+  }
+  let clauseKeys = CLAUSE_KEYS[base];
+  let legalKeys = new Set<string>([...COMMON_DECLARATION_KEYS, ...clauseKeys]);
+  for (let declaredKey of Object.keys(declaration)) {
+    if (!legalKeys.has(declaredKey)) {
+      throw new Error(
+        `${label}: "${declaredKey}" is not a valid key for a "${base}" operation; valid keys are ${quoteList(
+          [...legalKeys].sort(),
+        )}`,
+      );
+    }
+  }
+  let paramNames = assertValidParamsSchema(label, declaration.params);
+  if (
+    declaration.optimistic !== undefined &&
+    typeof declaration.optimistic !== 'boolean'
+  ) {
+    throw new Error(`${label}: \`optimistic\` must be a boolean`);
+  }
+  if (declaration.input !== undefined) {
+    assertBxlProgram(label, 'input', declaration.input);
+  }
+  let usedClauses = clauseKeys.filter(
+    (clause) => declaration[clause] !== undefined,
+  );
+  if (declaration.transformations !== undefined) {
+    assertBxlProgram(label, 'transformations', declaration.transformations);
+    if (usedClauses.length > 0) {
+      throw new Error(
+        `${label}: a declaration expresses its work either with clauses (${quoteList(
+          usedClauses,
+        )}) or with a raw \`transformations\` program, not both`,
+      );
+    }
+  } else {
+    let required = REQUIRED_CLAUSE[base];
+    if (required !== undefined && declaration[required] === undefined) {
+      throw new Error(
+        `${label}: a "${base}" operation needs \`${required}\`, or a raw \`transformations\` program`,
+      );
+    }
+  }
+  assertValidClauses(label, base, declaration);
+  if (declaration.output !== undefined && !isPlainObject(declaration.output)) {
+    throw new Error(
+      `${label}: \`output\` must be a projection object or a bxl program`,
+    );
+  }
+  assertReferencesResolve(label, declaration, paramNames);
+}
+
+function assertValidClauses(
+  label: string,
+  base: BaseOperationName,
+  declaration: Record<string, unknown>,
+) {
+  if (declaration.append !== undefined) {
+    let append = declaration.append;
+    if (!isPlainObject(append)) {
+      throw new Error(
+        `${label}: \`append\` must be an object naming the field to append \`to\` and the \`value\` to append`,
+      );
+    }
+    assertOnlyKeys(label, 'append', append, ['to', 'value']);
+    if (typeof append.to !== 'string' || append.to.length === 0) {
+      throw new Error(
+        `${label}: \`append.to\` must name the collection field to append to`,
+      );
+    }
+    if (append.value === undefined) {
+      throw new Error(`${label}: \`append\` must carry a \`value\` to append`);
+    }
+  }
+  if (declaration.assert !== undefined) {
+    let assertion = declaration.assert;
+    if (!isPlainObject(assertion)) {
+      throw new Error(
+        `${label}: \`assert\` must be an object naming the collection that must stay \`unique\` and the value to key it \`by\``,
+      );
+    }
+    assertOnlyKeys(label, 'assert', assertion, ['unique', 'by', 'message']);
+    if (typeof assertion.unique !== 'string' || assertion.unique.length === 0) {
+      throw new Error(
+        `${label}: \`assert.unique\` must name the collection field that must not already hold the value`,
+      );
+    }
+    if (assertion.by === undefined) {
+      throw new Error(
+        `${label}: \`assert\` must carry a \`by\` value to key the uniqueness check on`,
+      );
+    }
+    if (
+      assertion.message !== undefined &&
+      typeof assertion.message !== 'string'
+    ) {
+      throw new Error(`${label}: \`assert.message\` must be a string`);
+    }
+  }
+  for (let clause of ['set', 'fill'] as const) {
+    let value = declaration[clause];
+    if (value === undefined) {
+      continue;
+    }
+    if (!isPlainObject(value) || Object.keys(value).length === 0) {
+      throw new Error(
+        `${label}: \`${clause}\` must be an object mapping field names to values`,
+      );
+    }
+  }
+  if (declaration.of !== undefined && typeof declaration.of !== 'function') {
+    throw new Error(
+      `${label}: \`of\` must be the card class to create, or a thunk returning it`,
+    );
+  }
+  if (base === 'query' && declaration.query !== undefined) {
+    if (!isPlainObject(declaration.query)) {
+      throw new Error(
+        `${label}: \`query\` must be an object with \`filter\`, \`sort\`, \`page\` and \`realms\``,
+      );
+    }
+    assertOnlyKeys(label, 'query', declaration.query, [
+      'filter',
+      'sort',
+      'page',
+      'realms',
+    ]);
+  }
+}
+
+function assertValidParamsSchema(label: string, schema: unknown): Set<string> {
+  if (schema === undefined) {
+    return new Set();
+  }
+  if (!isPlainObject(schema)) {
+    throw new Error(
+      `${label}: \`params\` must be an object mapping param names to a field class or linkTo(…)`,
+    );
+  }
+  let names = new Set<string>();
+  for (let [name, type] of Object.entries(schema)) {
+    if (isPlainObject(type)) {
+      if (typeof (type as { $linkTo?: unknown }).$linkTo !== 'function') {
+        throw new Error(
+          `${label}: param "${name}" must be a field class or linkTo(…)`,
+        );
+      }
+    } else if (typeof type !== 'function') {
+      throw new Error(
+        `${label}: param "${name}" must be a field class or linkTo(…)`,
+      );
+    }
+    names.add(name);
+  }
+  return names;
+}
+
+// Walks the declaration for typed references and validates each in place. A
+// reference to the payload only means something when the schema declares that
+// param, so an undeclared key is an authoring error caught here rather than a
+// runtime hole. References inside a raw program's text are BXL's to resolve.
+function assertReferencesResolve(
+  label: string,
+  declaration: Record<string, unknown>,
+  paramNames: Set<string>,
+) {
+  let seen = new WeakSet<object>();
+  let walk = (node: unknown, path: string) => {
+    if (node == null || typeof node !== 'object') {
+      return;
+    }
+    if (seen.has(node)) {
+      return;
+    }
+    seen.add(node);
+    if (isBxlMarker(node)) {
+      assertBxlProgram(label, path, node);
+      return;
+    }
+    if ('$ref' in node) {
+      assertValidReference(label, path, node, paramNames);
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach((entry, index) => walk(entry, `${path}[${index}]`));
+      return;
+    }
+    for (let [key, value] of Object.entries(node)) {
+      // The params schema holds field classes and linkTo markers rather than
+      // references, and is validated on its own terms.
+      if (path === '' && key === 'params') {
+        continue;
+      }
+      walk(value, path === '' ? key : `${path}.${key}`);
+    }
+  };
+  walk(declaration, '');
+}
+
+function assertValidReference(
+  label: string,
+  path: string,
+  node: object,
+  paramNames: Set<string>,
+) {
+  let reference = node as Record<string, unknown>;
+  switch (reference.$ref) {
+    case 'params': {
+      assertOnlyKeys(label, path, reference, ['$ref', 'key']);
+      let key = reference.key;
+      if (typeof key !== 'string' || key.length === 0) {
+        throw new Error(
+          `${label}: the params reference at \`${path}\` must name a param`,
+        );
+      }
+      if (!paramNames.has(key)) {
+        throw new Error(
+          `${label}: \`${path}\` references the param "${key}", which the \`params\` schema does not declare`,
+        );
+      }
+      return;
+    }
+    case 'actor':
+    case 'instance': {
+      assertOnlyKeys(label, path, reference, ['$ref', 'key']);
+      if (
+        reference.key !== undefined &&
+        (typeof reference.key !== 'string' || reference.key.length === 0)
+      ) {
+        throw new Error(
+          `${label}: the ${reference.$ref} reference at \`${path}\` must name a member, or none at all`,
+        );
+      }
+      return;
+    }
+    case 'card': {
+      assertOnlyKeys(label, path, reference, ['$ref', 'value']);
+      let value = reference.value;
+      if (typeof value === 'string') {
+        if (value.length === 0) {
+          throw new Error(
+            `${label}: the card reference at \`${path}\` must carry a card URL or a reference to one`,
+          );
+        }
+        return;
+      }
+      if (!isPlainObject(value) || !('$ref' in value)) {
+        throw new Error(
+          `${label}: the card reference at \`${path}\` must carry a card URL or a reference to one`,
+        );
+      }
+      assertValidReference(label, `${path}.value`, value, paramNames);
+      return;
+    }
+    default:
+      throw new Error(
+        `${label}: \`${path}\` is not a typed reference; build one with params(), actor(), instance() or card()`,
+      );
+  }
+}
+
+function assertBxlProgram(label: string, path: string, value: unknown) {
+  if (
+    !isBxlMarker(value) ||
+    typeof (value as BxlProgram).$bxl !== 'string' ||
+    (value as BxlProgram).$bxl.length === 0
+  ) {
+    throw new Error(
+      `${label}: \`${path}\` must be a program written with the bxl tag`,
+    );
+  }
+}
+
+function assertOnlyKeys(
+  label: string,
+  path: string,
+  node: object,
+  allowed: readonly string[],
+) {
+  for (let key of Object.keys(node)) {
+    if (!allowed.includes(key)) {
+      throw new Error(
+        `${label}: "${key}" is not a valid key for \`${path}\`; valid keys are ${quoteList(
+          allowed,
+        )}`,
+      );
+    }
+  }
+}
+
+function assertOptionalReferenceKey(kind: string, key: unknown) {
+  if (key === undefined) {
+    return;
+  }
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error(
+      `${kind}() takes the name of a member to read, or no argument at all`,
+    );
+  }
+}
+
+function isReferenceMarker(value: unknown): boolean {
+  return isPlainObject(value) && '$ref' in (value as object);
+}
+
+function isBxlMarker(value: unknown): boolean {
+  return isPlainObject(value) && '$bxl' in (value as object);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isBaseOperationName(value: unknown): value is BaseOperationName {
+  return (
+    typeof value === 'string' &&
+    (BASE_OPERATIONS as readonly string[]).includes(value)
+  );
+}
+
+function declarationLabel(owner: typeof BaseDef, key: string): string {
+  return `@operation "${key}" on ${owner.name || owner.displayName || 'card'}`;
+}
+
+function quoteList(values: readonly string[]): string {
+  return values.map((value) => `"${value}"`).join(', ');
+}

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -63,9 +63,13 @@ import {
 // The behaviors every declaration builds on. Which of them a def carries is
 // implied by the def type rather than written in author code — a `CardDef`
 // has all six, a `FileDef` only `read`, a `FieldDef` none — so
-// `getOperations` synthesizes them. A declaration *named* after a base op is
-// an author's override of it and takes its place, which is how a card
-// specializes its own `read` projection or `update` validation.
+// `getOperations` synthesizes them. A declaration *named* after a base op
+// takes its place: it specializes that behavior when it names the same
+// `base`, and rebinds the verb when it names another — a `delete` declared
+// on `transform` is a soft delete, so asking such a card to delete itself
+// archives it rather than removing it. The name is what a caller invokes and
+// `base` is the behavior that carries it out, so the two are read separately
+// and neither is inferred from the other.
 export const BASE_OPERATIONS = [
   'read',
   'create',
@@ -903,7 +907,7 @@ function assertValidClauses(
     let query = declaration.query;
     if (!isPlainObject(query) || Object.keys(query).length === 0) {
       throw new Error(
-        `${label}: \`query\` must be an object with at least one of \`filter\`, \`sort\`, \`page\` and \`realms\``,
+        `${label}: \`query\` must be an object with at least one of \`filter\`, \`sort\`, \`queryString\`, \`page\` and \`realms\``,
       );
     }
     assertOnlyKeys(label, 'query', query, [

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -502,12 +502,7 @@ function defConstructorFor(
 function ownDeclarations(
   owner: unknown,
 ): Record<string, OperationDeclaration> | undefined {
-  if (
-    !Object.prototype.hasOwnProperty.call(
-      owner as object,
-      operationDeclarations,
-    )
-  ) {
+  if (!hasOwn(owner as object, operationDeclarations)) {
     return undefined;
   }
   return (owner as Record<symbol, Record<string, OperationDeclaration>>)[
@@ -522,7 +517,10 @@ function recordDeclaration(
 ) {
   let declarations = ownDeclarations(owner);
   if (!declarations) {
-    declarations = {};
+    // A name-keyed store with no prototype: nothing an operation could be
+    // called is also an inherited member here, so a name can only ever add a
+    // key rather than reach something the store inherits.
+    declarations = Object.create(null) as Record<string, OperationDeclaration>;
     Object.defineProperty(owner, operationDeclarations, {
       value: declarations,
       configurable: true,
@@ -531,6 +529,10 @@ function recordDeclaration(
     });
   }
   declarations[key] = declaration;
+}
+
+function hasOwn(target: object, key: string | symbol): boolean {
+  return Object.prototype.hasOwnProperty.call(target, key);
 }
 
 function isDefConstructor(target: unknown): target is typeof BaseDef {
@@ -559,17 +561,22 @@ function assertOperationTarget(target: unknown, key: string): typeof BaseDef {
 }
 
 // A name that already resolves on the class would shadow, or be shadowed by,
-// whatever provides it. An inherited operation of the same name is the one
-// exception: that is how a subclass overrides it.
+// whatever provides it — a system static like `displayName`, or something a
+// class inherits from `Function.prototype`. An inherited operation of the
+// same name is the one exception: that is how a subclass overrides it. The
+// exemption is an own-property test, because an `in` test against the merged
+// record answers true for every `Object.prototype` member (`toString`,
+// `constructor`, `__proto__`) and would wave through exactly the names that
+// must not become operations.
 function assertNameAvailable(owner: typeof BaseDef, key: string) {
   if (!(key in owner)) {
     return;
   }
-  if (key in declaredOperations(owner)) {
+  if (hasOwn(declaredOperations(owner), key)) {
     return;
   }
   throw new Error(
-    `${declarationLabel(owner, key)}: "${key}" is already a static on this class, so it cannot name an operation`,
+    `${declarationLabel(owner, key)}: "${key}" already resolves on this class, so it cannot name an operation`,
   );
 }
 

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -51,7 +51,11 @@ import {
 // TypeScript requires a subclass's static to stay assignable to the one it
 // shadows, so an operation meant to be overridden with a differently-shaped
 // declaration is annotated `: OperationDeclaration` where it is first
-// declared; the override then keeps its own literal types.
+// declared; the override then keeps its own literal types. That annotation
+// costs the annotated name its payload type — `ParamsOf` reads the literal
+// schema — so it is worth writing only where a subclass really will reshape
+// the operation, and the override's own declaration is where the payload type
+// then comes from.
 // ============================================================================
 
 // The behaviors every declaration builds on. Which of them a def carries is
@@ -327,8 +331,15 @@ export type OperationDeclaration =
 
 // The operations declared on a def, read off the class type. Keyed by
 // operation name, so an invocation surface can be typed from the class alone.
+//
+// A declaration qualifies by its `base` still naming a base operation, which
+// is what `satisfies OperationDeclaration` (or an explicit annotation)
+// preserves. Written without either, `base` widens to `string` and the
+// declaration is indistinguishable from any other static that happens to
+// carry a `base` — so it is left out rather than sweeping unrelated statics
+// in alongside it.
 export type OperationsOf<Def> = {
-  [Name in keyof Def as Def[Name] extends { base: string }
+  [Name in keyof Def as Def[Name] extends { base: BaseOperationName }
     ? Name
     : never]: Def[Name];
 };
@@ -336,6 +347,13 @@ export type OperationsOf<Def> = {
 // The payload an operation accepts, derived from its declared `params`
 // schema: each entry becomes the value type of the field class that declares
 // it, and a `linkTo(…)` param becomes a card identity.
+//
+// This reads the literal schema, so it needs a declaration whose `params`
+// survived inference — `satisfies OperationDeclaration`, or nothing at all.
+// Annotating a declaration `: OperationDeclaration` widens `params` to the
+// schema type and erases the keys, leaving `Record<string, never>` here:
+// annotate only the operation a subclass has to reshape (see the header), and
+// read the payload type off the subclass's own declaration.
 export type ParamsOf<Declaration> = Declaration extends {
   params: infer Schema;
 }

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -741,9 +741,16 @@ function assertValidParamsSchema(label: string, schema: unknown): Set<string> {
           `${label}: param "${name}" must be a field class or linkTo(…)`,
         );
       }
-    } else if (typeof type !== 'function') {
+    } else if (!isFieldDefConstructor(type)) {
+      // A scalar param is typed by the field class that serializes it, so
+      // any other function — a card class, a thunk, an unrelated callable —
+      // would type the payload as something the endpoint cannot validate.
       throw new Error(
-        `${label}: param "${name}" must be a field class or linkTo(…)`,
+        `${label}: param "${name}" must be a field class or linkTo(…)${
+          isDefConstructor(type)
+            ? ', and a card or file identity is a linkTo(…) param'
+            : ''
+        }`,
       );
     }
     names.add(name);
@@ -751,18 +758,57 @@ function assertValidParamsSchema(label: string, schema: unknown): Set<string> {
   return names;
 }
 
-// Walks the declaration for typed references and validates each in place. A
-// reference to the payload only means something when the schema declares that
-// param, so an undeclared key is an authoring error caught here rather than a
-// runtime hole. References inside a raw program's text are BXL's to resolve.
+function isFieldDefConstructor(value: unknown): boolean {
+  return (
+    typeof value === 'function' &&
+    isSubclassOf(value as typeof BaseDef, FieldDef)
+  );
+}
+
+// Walks the declaration, validating each typed reference in place and holding
+// every other value to what a declaration can carry.
+//
+// A reference to the payload only means something when the schema declares
+// that param, so an undeclared key is an authoring error caught here rather
+// than a runtime hole. References inside a raw program's text are BXL's to
+// resolve.
+//
+// The rest is the plain-data invariant, enforced rather than assumed: a
+// declaration reaches the realm as JSON in a definition-cache entry, and
+// anything that does not survive that trip — `undefined`, a function, a
+// symbol, a bigint, a class instance whose fields JSON flattens away —
+// would leave the operation running against something other than what the
+// author wrote, silently. Classes are expected in exactly two slots: the def
+// a `create` names with `of`, and the def a query filters `on`.
 function assertReferencesResolve(
   label: string,
   declaration: Record<string, unknown>,
   paramNames: Set<string>,
 ) {
   let seen = new WeakSet<object>();
-  let walk = (node: unknown, path: string) => {
-    if (node == null || typeof node !== 'object') {
+  let walk = (node: unknown, path: string, defsAllowed: boolean) => {
+    if (node === null) {
+      return;
+    }
+    if (typeof node === 'function') {
+      if (defsAllowed) {
+        return;
+      }
+      throw new Error(
+        `${label}: \`${path}\` is a function; a declaration is data — name a run-time value with params(), actor(), instance() or card(), or a program with the bxl tag`,
+      );
+    }
+    if (typeof node !== 'object') {
+      if (typeof node === 'symbol' || typeof node === 'bigint') {
+        throw new Error(
+          `${label}: \`${path}\` is ${describeValue(node)}, which a declaration cannot carry`,
+        );
+      }
+      if (node === undefined) {
+        throw new Error(
+          `${label}: \`${path}\` is undefined; omit an optional key rather than declaring it as undefined`,
+        );
+      }
       return;
     }
     if (seen.has(node)) {
@@ -778,8 +824,17 @@ function assertReferencesResolve(
       return;
     }
     if (Array.isArray(node)) {
-      node.forEach((entry, index) => walk(entry, `${path}[${index}]`));
+      node.forEach((entry, index) =>
+        walk(entry, `${path}[${index}]`, defsAllowed),
+      );
       return;
+    }
+    if (!isPlainObject(node)) {
+      throw new Error(
+        `${label}: \`${path}\` is ${describeValue(
+          node,
+        )}; a declaration carries plain objects, arrays and primitives`,
+      );
     }
     for (let [key, value] of Object.entries(node)) {
       // The params schema holds field classes and linkTo markers rather than
@@ -787,10 +842,31 @@ function assertReferencesResolve(
       if (path === '' && key === 'params') {
         continue;
       }
-      walk(value, path === '' ? key : `${path}.${key}`);
+      walk(
+        value,
+        path === '' ? key : `${path}.${key}`,
+        defsAllowed || (path === '' && (key === 'of' || key === 'query')),
+      );
     }
   };
-  walk(declaration, '');
+  walk(declaration, '', false);
+}
+
+function describeValue(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (typeof value === 'symbol') {
+    return 'a symbol';
+  }
+  if (typeof value === 'bigint') {
+    return 'a bigint';
+  }
+  if (typeof value === 'function') {
+    return 'a function';
+  }
+  let name = (value as { constructor?: { name?: string } })?.constructor?.name;
+  return name ? `a ${name} instance` : 'a non-plain object';
 }
 
 function assertValidReference(
@@ -904,7 +980,14 @@ function isBxlMarker(value: unknown): boolean {
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  // Plain means plain: a `Date` serializes to a string and a `Map` to `{}`,
+  // so a class instance cannot stand in for a declaration, a clause or a
+  // marker without losing what it holds.
+  let proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 function isBaseOperationName(value: unknown): value is BaseOperationName {

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -261,7 +261,10 @@ export type OperationOutput =
 export interface QueryDeclaration {
   readonly filter?: OperationQueryValue;
   readonly sort?: OperationQueryValue;
-  readonly page?: { readonly size?: number; readonly cursor?: string };
+  // The realm pages by offset: `size` is the page length and `number` is the
+  // 0-based page. There is no cursor paging to declare — the index generation
+  // a request is pinned to is the server's to mint, not the author's.
+  readonly page?: { readonly size: number; readonly number?: number };
   readonly realms?: readonly string[];
 }
 
@@ -270,8 +273,8 @@ export type OperationQueryValue =
   | number
   | boolean
   | null
-  | BaseDefConstructor
-  | (() => BaseDefConstructor)
+  | LinkableDefConstructor
+  | (() => LinkableDefConstructor)
   | OperationReference
   | readonly OperationQueryValue[]
   | { readonly [key: string]: OperationQueryValue };
@@ -826,25 +829,28 @@ function assertValidClauses(
     if (query.page !== undefined) {
       if (!isPlainObject(query.page)) {
         throw new Error(
-          `${label}: \`query.page\` must be an object with \`size\` and \`cursor\``,
+          `${label}: \`query.page\` must be an object with \`size\` and an optional \`number\``,
         );
       }
-      assertOnlyKeys(label, 'query.page', query.page, ['size', 'cursor']);
+      assertOnlyKeys(label, 'query.page', query.page, ['size', 'number']);
+      // A page with no length pages nothing: the offset the realm computes is
+      // a multiple of `size`.
       let size = query.page.size;
-      if (
-        size !== undefined &&
-        (typeof size !== 'number' || !Number.isInteger(size) || size < 1)
-      ) {
+      if (typeof size !== 'number' || !Number.isInteger(size) || size < 1) {
         throw new Error(
           `${label}: \`query.page.size\` must be a positive integer`,
         );
       }
+      let pageNumber = query.page.number;
       if (
-        query.page.cursor !== undefined &&
-        (typeof query.page.cursor !== 'string' ||
-          query.page.cursor.length === 0)
+        pageNumber !== undefined &&
+        (typeof pageNumber !== 'number' ||
+          !Number.isInteger(pageNumber) ||
+          pageNumber < 0)
       ) {
-        throw new Error(`${label}: \`query.page.cursor\` must be a string`);
+        throw new Error(
+          `${label}: \`query.page.number\` must be a whole number, counting from 0`,
+        );
       }
     }
     if (query.realms !== undefined) {
@@ -955,10 +961,15 @@ function assertReferencesResolve(
         );
       }
       // A thunk defers its class past this point; one named directly is held
-      // to a kind a query can match or a create can mint.
-      if (isDefConstructor(node) && !isSubclassOf(node, CardDef)) {
+      // to a kind that has a type to name. A field is addressed through the
+      // card that contains it and has no type row of its own.
+      if (
+        isDefConstructor(node) &&
+        !isSubclassOf(node, CardDef) &&
+        !isSubclassOf(node, FileDef)
+      ) {
         throw new Error(
-          `${label}: \`${path}\` must be a card class — only a card has a type to name here`,
+          `${label}: \`${path}\` must be a card or file class — a field has no type of its own to name`,
         );
       }
       return;

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -1,3 +1,5 @@
+import { assertQuery, InvalidQueryError } from '@cardstack/runtime-common';
+
 import {
   BaseDef,
   CardDef,
@@ -258,9 +260,15 @@ export type OperationOutput =
 // code ref is derived when the declaration is lowered; a query that filters on
 // the very class it is declared on takes the thunk form, since the class
 // binding is not yet initialized while its own statics are being built.
+// The realm's query, restricted to what a saved search declares. `realm` in
+// the singular is left out because a declared query's scope is the fan-out
+// list; `asData` and `fields` are left out because a query operation answers
+// with entry rows, a different response shape than a data query.
 export interface QueryDeclaration {
   readonly filter?: OperationQueryValue;
   readonly sort?: OperationQueryValue;
+  // The full-text term, which a payload may supply.
+  readonly queryString?: string | ParamsReference | ActorReference;
   // The realm pages by offset: `size` is the page length and `number` is the
   // 0-based page. There is no cursor paging to declare — the index generation
   // a request is pinned to is the server's to mint, not the author's.
@@ -741,7 +749,80 @@ function assertValidDeclaration(
     );
   }
   assertReferencesResolve(label, declaration, paramNames);
+  if (base === 'query') {
+    assertQueryIsWellFormed(label, declaration.query);
+  }
 }
+
+// The realm's own validator, consulted as a second opinion on a declared
+// query.
+//
+// The placement rule in the walk above encodes where the filter grammar puts
+// a type, which means it has to stay in step with a grammar defined
+// elsewhere. This hands the query to `assertQuery` — that grammar's one
+// definition — with every def class swapped for a sentinel that reads as a
+// code ref where a type belongs and as a function everywhere else. The realm
+// therefore re-checks both the placement and the rest of the shape, so a
+// grammar this module has not kept up with surfaces here rather than at
+// invocation.
+//
+// Skipped when the query carries a typed reference: a reference stands in for
+// a value the realm types concretely — a `matches` string, an `in` array — so
+// before lowering resolves it, the realm would reject the shape it has.
+function assertQueryIsWellFormed(label: string, query: unknown) {
+  if (!isPlainObject(query) || holdsReference(query)) {
+    return;
+  }
+  try {
+    assertQuery(withTypeSentinels(query));
+  } catch (error) {
+    if (error instanceof InvalidQueryError) {
+      throw new Error(
+        `${label}: \`query\` is not a query the realm accepts — ${error.message}`,
+      );
+    }
+    throw error;
+  }
+}
+
+function holdsReference(node: unknown): boolean {
+  if (Array.isArray(node)) {
+    return node.some(holdsReference);
+  }
+  if (!isPlainObject(node)) {
+    return false;
+  }
+  if (hasOwn(node, '$ref') || hasOwn(node, '$bxl')) {
+    return true;
+  }
+  return Object.values(node).some(holdsReference);
+}
+
+// A def class stands in for the code ref lowering derives from it. The
+// sentinel satisfies the realm's code-ref check, which reads `module` and
+// `name`, while carrying a function as its first entry — the entry the
+// realm's JSON check reaches — so it is accepted exactly where a type belongs
+// and refused wherever a value does.
+function withTypeSentinels(node: unknown): unknown {
+  if (typeof node === 'function') {
+    return {
+      notJson: () => {},
+      module: TYPE_SLOT_SENTINEL,
+      name: TYPE_SLOT_SENTINEL,
+    };
+  }
+  if (Array.isArray(node)) {
+    return node.map(withTypeSentinels);
+  }
+  if (!isPlainObject(node)) {
+    return node;
+  }
+  return Object.fromEntries(
+    Object.entries(node).map(([key, value]) => [key, withTypeSentinels(value)]),
+  );
+}
+
+const TYPE_SLOT_SENTINEL = '$operation-type-slot';
 
 function assertValidClauses(
   label: string,
@@ -825,7 +906,24 @@ function assertValidClauses(
         `${label}: \`query\` must be an object with at least one of \`filter\`, \`sort\`, \`page\` and \`realms\``,
       );
     }
-    assertOnlyKeys(label, 'query', query, ['filter', 'sort', 'page', 'realms']);
+    assertOnlyKeys(label, 'query', query, [
+      'filter',
+      'sort',
+      'queryString',
+      'page',
+      'realms',
+    ]);
+    if (query.queryString !== undefined) {
+      let term = query.queryString;
+      if (
+        !(typeof term === 'string' && term.length > 0) &&
+        !isReferenceMarker(term)
+      ) {
+        throw new Error(
+          `${label}: \`query.queryString\` must be a search term, or a reference to one`,
+        );
+      }
+    }
     if (query.page !== undefined) {
       if (!isPlainObject(query.page)) {
         throw new Error(

--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -159,6 +159,11 @@ export function bxl(
   program: TemplateStringsArray,
   ...substitutions: unknown[]
 ): BxlProgram {
+  if (!Array.isArray(program) || !Array.isArray(program?.raw)) {
+    throw new Error(
+      `bxl is a template tag: write bxl\`…\` rather than calling it`,
+    );
+  }
   if (substitutions.length > 0) {
     throw new Error(
       `the bxl tag does not interpolate values; read the payload, the actor and the target inside the program with the params(), actor() and instance() builtins`,
@@ -187,6 +192,17 @@ export function linkTo<Def extends LinkableDefConstructor>(
   if (typeof def !== 'function') {
     throw new Error(
       `linkTo() takes a card class (or a thunk returning one, for a class declared later in the module)`,
+    );
+  }
+  // A thunk defers its class past this point; one named directly can be held
+  // to a kind that has a URL to link to.
+  if (
+    isDefConstructor(def) &&
+    !isSubclassOf(def, CardDef) &&
+    !isSubclassOf(def, FileDef)
+  ) {
+    throw new Error(
+      `linkTo() takes a card or file class — a link points at something with a URL`,
     );
   }
   return { $linkTo: def };
@@ -369,6 +385,11 @@ const REQUIRED_CLAUSE: Partial<Record<BaseOperationName, string>> = {
   query: 'query',
 };
 
+// Clauses that name a type rather than describe work. A raw program replaces
+// the work, so it does not replace these — a `create` driven by a program
+// still has to say what it creates.
+const TYPE_NAMING_KEYS: readonly string[] = ['of'];
+
 // Records a static declaration on the class it is declared on. Our decorators
 // are implemented by Babel, not TypeScript, so the signature differs from the
 // one TypeScript expects; a static-property decorator receives the
@@ -417,7 +438,7 @@ export function getOperations(
   classOrInstance: BaseDef | typeof BaseDef,
 ): Record<string, OperationDeclaration> {
   let owner = defConstructorFor(classOrInstance, 'getOperations');
-  let operations: Record<string, OperationDeclaration> = {};
+  let operations = emptyOperationRecord();
   for (let base of impliedOperations(owner)) {
     // A base operation with nothing declared on it is the declaration
     // `{ base }`; the cast is only because a union does not narrow from a
@@ -480,7 +501,15 @@ function declaredOperations(
     }
     current = Object.getPrototypeOf(current);
   }
-  return Object.assign({}, ...levels);
+  return Object.assign(emptyOperationRecord(), ...levels);
+}
+
+// A record with no prototype. Operations are addressed by name — the realm
+// dispatches one from a name that arrived over the wire — so a name-keyed map
+// must not answer to `toString`, `constructor` or `__proto__` with something
+// that is not an operation.
+function emptyOperationRecord(): Record<string, OperationDeclaration> {
+  return Object.create(null) as Record<string, OperationDeclaration>;
 }
 
 function defConstructorFor(
@@ -596,11 +625,16 @@ function assertValidDeclaration(
       `${label}: \`base\` must name the built-in behavior this operation builds on — one of ${quoteList(BASE_OPERATIONS)}`,
     );
   }
-  // A file's metadata is content-derived and read-only, so it has no
-  // mutation surface for anything but `read` to reach.
-  if (base !== 'read' && isSubclassOf(owner, FileDef)) {
+  // An author may only specialize a base operation the def type actually
+  // carries. Read from the same list `getOperations` synthesizes: only a card
+  // has a mutation surface, and a file's metadata is content-derived and
+  // read-only.
+  let implied = impliedOperations(owner);
+  if (!implied.includes(base)) {
     throw new Error(
-      `${label}: a file's metadata is read-only, so only \`base: 'read'\` operations can be declared on it`,
+      `${label}: this def type carries only ${quoteList(
+        implied,
+      )}, so it cannot declare a "${base}" operation`,
     );
   }
   let clauseKeys = CLAUSE_KEYS[base];
@@ -625,7 +659,8 @@ function assertValidDeclaration(
     assertBxlProgram(label, 'input', declaration.input);
   }
   let usedClauses = clauseKeys.filter(
-    (clause) => declaration[clause] !== undefined,
+    (clause) =>
+      declaration[clause] !== undefined && !TYPE_NAMING_KEYS.includes(clause),
   );
   if (declaration.transformations !== undefined) {
     assertBxlProgram(label, 'transformations', declaration.transformations);
@@ -711,23 +746,67 @@ function assertValidClauses(
       );
     }
   }
-  if (declaration.of !== undefined && typeof declaration.of !== 'function') {
-    throw new Error(
-      `${label}: \`of\` must be the card class to create, or a thunk returning it`,
-    );
-  }
-  if (base === 'query' && declaration.query !== undefined) {
-    if (!isPlainObject(declaration.query)) {
+  if (declaration.of !== undefined) {
+    if (typeof declaration.of !== 'function') {
       throw new Error(
-        `${label}: \`query\` must be an object with \`filter\`, \`sort\`, \`page\` and \`realms\``,
+        `${label}: \`of\` must be the card class to create, or a thunk returning it`,
       );
     }
-    assertOnlyKeys(label, 'query', declaration.query, [
-      'filter',
-      'sort',
-      'page',
-      'realms',
-    ]);
+    // A thunk cannot be resolved this early, but a def class named directly
+    // can be held to the kind a create can mint.
+    if (
+      isDefConstructor(declaration.of) &&
+      !isSubclassOf(declaration.of, CardDef)
+    ) {
+      throw new Error(
+        `${label}: \`of\` must be a card class — only a card can be created`,
+      );
+    }
+  }
+  if (base === 'query' && declaration.query !== undefined) {
+    let query = declaration.query;
+    if (!isPlainObject(query) || Object.keys(query).length === 0) {
+      throw new Error(
+        `${label}: \`query\` must be an object with at least one of \`filter\`, \`sort\`, \`page\` and \`realms\``,
+      );
+    }
+    assertOnlyKeys(label, 'query', query, ['filter', 'sort', 'page', 'realms']);
+    if (query.page !== undefined) {
+      if (!isPlainObject(query.page)) {
+        throw new Error(
+          `${label}: \`query.page\` must be an object with \`size\` and \`cursor\``,
+        );
+      }
+      assertOnlyKeys(label, 'query.page', query.page, ['size', 'cursor']);
+      let size = query.page.size;
+      if (
+        size !== undefined &&
+        (typeof size !== 'number' || !Number.isInteger(size) || size < 1)
+      ) {
+        throw new Error(
+          `${label}: \`query.page.size\` must be a positive integer`,
+        );
+      }
+      if (
+        query.page.cursor !== undefined &&
+        (typeof query.page.cursor !== 'string' ||
+          query.page.cursor.length === 0)
+      ) {
+        throw new Error(`${label}: \`query.page.cursor\` must be a string`);
+      }
+    }
+    if (query.realms !== undefined) {
+      let realms = query.realms;
+      if (
+        !Array.isArray(realms) ||
+        realms.length === 0 ||
+        realms.some((realm) => typeof realm !== 'string' || realm.length === 0)
+      ) {
+        throw new Error(
+          `${label}: \`query.realms\` must be a non-empty array of realm URLs`,
+        );
+      }
+    }
   }
 }
 
@@ -748,6 +827,7 @@ function assertValidParamsSchema(label: string, schema: unknown): Set<string> {
           `${label}: param "${name}" must be a field class or linkTo(…)`,
         );
       }
+      assertOnlyKeys(label, `params.${name}`, type, ['$linkTo']);
     } else if (!isFieldDefConstructor(type)) {
       // A scalar param is typed by the field class that serializes it, so
       // any other function — a card class, a thunk, an unrelated callable —
@@ -783,22 +863,30 @@ function isFieldDefConstructor(value: unknown): boolean {
 // The rest is the plain-data invariant, enforced rather than assumed: a
 // declaration reaches the realm as JSON in a definition-cache entry, and
 // anything that does not survive that trip — `undefined`, a function, a
-// symbol, a bigint, a class instance whose fields JSON flattens away —
-// would leave the operation running against something other than what the
-// author wrote, silently. Classes are expected in exactly two slots: the def
-// a `create` names with `of`, and the def a query filters `on`.
+// symbol, a bigint, a non-finite number, a class instance whose fields JSON
+// flattens away, a cycle JSON refuses outright — would leave the operation
+// running against something other than what the author wrote, silently.
+//
+// A def class is legal in exactly the two slots that name a type: the `of` a
+// `create` targets, and the `on` a query filters against (at any depth, since
+// filters nest). Naming those slots individually is what keeps a thunk from
+// being mistaken for a value everywhere else in a query — a function under
+// `eq` would lower to nothing and match every card instead of one.
 function assertReferencesResolve(
   label: string,
   declaration: Record<string, unknown>,
   paramNames: Set<string>,
 ) {
-  let seen = new WeakSet<object>();
-  let walk = (node: unknown, path: string, defsAllowed: boolean) => {
+  // The current DFS path, not a memo: a node is unwound on the way back out,
+  // so a cycle is caught while the same object legitimately appearing twice
+  // is validated in each place it appears.
+  let ancestors = new Set<object>();
+  let walk = (node: unknown, path: string, slot: SlotKind) => {
     if (node === null) {
       return;
     }
     if (typeof node === 'function') {
-      if (defsAllowed) {
+      if (slot.definitionAllowed) {
         return;
       }
       throw new Error(
@@ -816,12 +904,18 @@ function assertReferencesResolve(
           `${label}: \`${path}\` is undefined; omit an optional key rather than declaring it as undefined`,
         );
       }
+      if (typeof node === 'number' && !Number.isFinite(node)) {
+        throw new Error(
+          `${label}: \`${path}\` is ${node}, which serializes as null`,
+        );
+      }
       return;
     }
-    if (seen.has(node)) {
-      return;
+    if (ancestors.has(node)) {
+      throw new Error(
+        `${label}: \`${path}\` refers back to a value that contains it; a declaration is a tree`,
+      );
     }
-    seen.add(node);
     if (isBxlMarker(node)) {
       assertBxlProgram(label, path, node);
       return;
@@ -830,33 +924,48 @@ function assertReferencesResolve(
       assertValidReference(label, path, node, paramNames);
       return;
     }
-    if (Array.isArray(node)) {
-      node.forEach((entry, index) =>
-        walk(entry, `${path}[${index}]`, defsAllowed),
-      );
-      return;
-    }
-    if (!isPlainObject(node)) {
+    if (!Array.isArray(node) && !isPlainObject(node)) {
       throw new Error(
         `${label}: \`${path}\` is ${describeValue(
           node,
         )}; a declaration carries plain objects, arrays and primitives`,
       );
     }
-    for (let [key, value] of Object.entries(node)) {
-      // The params schema holds field classes and linkTo markers rather than
-      // references, and is validated on its own terms.
-      if (path === '' && key === 'params') {
-        continue;
-      }
-      walk(
-        value,
-        path === '' ? key : `${path}.${key}`,
-        defsAllowed || (path === '' && (key === 'of' || key === 'query')),
+    ancestors.add(node);
+    if (Array.isArray(node)) {
+      node.forEach((entry, index) =>
+        walk(entry, `${path}[${index}]`, {
+          definitionAllowed: false,
+          inQuery: slot.inQuery,
+        }),
       );
+    } else {
+      for (let [key, value] of Object.entries(node)) {
+        // The params schema holds field classes and linkTo markers rather
+        // than references, and is validated on its own terms.
+        if (path === '' && key === 'params') {
+          continue;
+        }
+        let inQuery = slot.inQuery || (path === '' && key === 'query');
+        walk(value, path === '' ? key : `${path}.${key}`, {
+          definitionAllowed:
+            (path === '' && key === 'of') || (inQuery && key === 'on'),
+          inQuery,
+        });
+      }
     }
+    ancestors.delete(node);
   };
-  walk(declaration, '', false);
+  walk(declaration, '', { definitionAllowed: false, inQuery: false });
+}
+
+// Where in a declaration the walk currently is, in the only two terms it
+// changes behavior on.
+interface SlotKind {
+  // This slot names a type, so a def class (or a thunk returning one) belongs.
+  definitionAllowed: boolean;
+  // Somewhere inside a `query`, where a nested `on` names a type.
+  inQuery: boolean;
 }
 
 function describeValue(value: unknown): string {
@@ -948,6 +1057,7 @@ function assertBxlProgram(label: string, path: string, value: unknown) {
       `${label}: \`${path}\` must be a program written with the bxl tag`,
     );
   }
+  assertOnlyKeys(label, path, value as object, ['$bxl']);
 }
 
 function assertOnlyKeys(

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -905,6 +905,17 @@ module('Integration | operations', function (hooks) {
         base: 'query',
         query: { filter: { on: Activity, eq: { status: 'open' } } },
       };
+      @operation static listEvery = {
+        base: 'query',
+        query: {
+          filter: {
+            every: [
+              { on: Activity, eq: { status: 'open' } },
+              { on: Activity, range: { views: { gt: 10 } } },
+            ],
+          },
+        },
+      };
       // A predicate holds field names, so a field genuinely called `on` is
       // data and survives.
       @operation static listRecent = {
@@ -924,6 +935,15 @@ module('Integration | operations', function (hooks) {
       ).filter.any[0].type,
       Activity,
       'a pure card-type filter names the class itself',
+    );
+    assert.strictEqual(
+      (
+        queryOf('listEvery') as unknown as {
+          filter: { every: { on: unknown }[] };
+        }
+      ).filter.every[0].on,
+      Activity,
+      'and `every` holds filter nodes the same way `any` does',
     );
     assert.strictEqual(
       (

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -389,7 +389,7 @@ module('Integration | operations', function (hooks) {
         }
         return Mutable;
       },
-      /metadata is read-only/,
+      /carries only "read"/,
       'file metadata is content-derived, so it has no mutation surface',
     );
   });
@@ -441,7 +441,50 @@ module('Integration | operations', function (hooks) {
     assert.deepEqual(
       Object.keys(getDeclaredOperations(Report)),
       ['addComment'],
-      'a name-keyed store holds operations and nothing it might inherit',
+      'a rejected name leaves the store working',
+    );
+    for (let inherited of [
+      'toString',
+      'constructor',
+      '__proto__',
+      'valueOf',
+      'hasOwnProperty',
+    ]) {
+      assert.false(
+        inherited in getOperations(Report),
+        `a name-keyed record does not answer for ${inherited}`,
+      );
+      assert.false(
+        inherited in getDeclaredOperations(Report),
+        `nor does the declared-only record answer for ${inherited}`,
+      );
+    }
+    assert.true(
+      'addComment' in getOperations(Report),
+      'while still answering for the operations it holds',
+    );
+    assert.true(
+      'read' in getOperations(Report),
+      'and for the base operations its def type carries',
+    );
+  });
+
+  test('the decorator installs the declaration on the class', function (assert) {
+    class Report extends CardDef {
+      @operation static addComment = {
+        base: 'transform',
+        params: { body: StringField },
+        append: { to: 'comments', value: { body: params('body') } },
+      };
+    }
+    // The static is what `OperationsOf` types off, and what makes the
+    // name-collision check see an inherited operation on a subclass override.
+    // A decorator that recorded the declaration without returning a `value`
+    // descriptor would leave every other assertion in this file passing.
+    assert.strictEqual(
+      Report.addComment as unknown,
+      getDeclaredOperations(Report).addComment as unknown,
+      'the class carries the very declaration the reader returns',
     );
   });
 
@@ -654,6 +697,204 @@ module('Integration | operations', function (hooks) {
     );
   });
 
+  test('a def class is legal only where a slot names a type', function (assert) {
+    class Activity extends CardDef {}
+    class Classroom extends CardDef {
+      @operation static listActivities = {
+        base: 'query',
+        // A filter nests, so `on` names a type at any depth — and the thunk
+        // form works there.
+        query: {
+          filter: { any: [{ on: () => Activity }], eq: { status: 'open' } },
+        },
+      };
+      @operation static makeActivity = {
+        base: 'create',
+        of: Activity,
+        params: { title: StringField },
+        // `of` names the type rather than the work, so it stands alongside a
+        // raw program instead of competing with it.
+        transformations: bxl`.title = params("title");`,
+      };
+    }
+    let declarations = getDeclaredOperations(Classroom);
+    assert.strictEqual(
+      (declarations.makeActivity as OperationsModule.CreateOperationDeclaration)
+        .of,
+      Activity,
+      'a program-driven create still names what it creates',
+    );
+    assert.strictEqual(
+      typeof (
+        (
+          declarations.listActivities as OperationsModule.QueryOperationDeclaration
+        ).query as { filter: { any: { on: unknown }[] } }
+      ).filter.any[0].on,
+      'function',
+      'and a nested filter still names its type',
+    );
+
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            query: {
+              filter: { on: Activity, eq: { owner: (() => 1) as never } },
+            },
+          };
+        }
+        return Report;
+      },
+      /is a function; a declaration is data/,
+      'but a function anywhere else in a query would lower to nothing',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static makeOne = {
+            base: 'create',
+            of: StringField as never,
+          };
+        }
+        return Report;
+      },
+      /must be a card class/,
+      'and only a card can be created',
+    );
+    assert.throws(
+      () => linkTo(StringField as never),
+      /card or file class/,
+      'while a link points at something that has a URL',
+    );
+  });
+
+  test('a shared value is checked in every slot it appears', function (assert) {
+    assert.throws(
+      () => {
+        let shared = { on: CardDef };
+        class Report extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            query: { filter: shared },
+            output: { leak: shared },
+          };
+        }
+        return Report;
+      },
+      /is a function; a declaration is data/,
+      'validation does not memoize, so it cannot depend on key order',
+    );
+  });
+
+  test('a declaration must be a tree of finite values', function (assert) {
+    assert.throws(
+      () => {
+        let value: Record<string, unknown> = { body: 'x' };
+        value.self = value;
+        class Report extends CardDef {
+          @operation static escalate = {
+            base: 'transform',
+            set: value as never,
+          };
+        }
+        return Report;
+      },
+      /refers back to a value that contains it/,
+      'a cycle would throw when the declaration is serialized, far from here',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static escalate = {
+            base: 'transform',
+            set: { score: NaN },
+          };
+        }
+        return Report;
+      },
+      /serializes as null/,
+      'and a non-finite number would quietly become null',
+    );
+  });
+
+  test('a marker carries only its own key', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static escalate = {
+            base: 'transform',
+            transformations: { $bxl: '.a = 1;', hook: () => 1 } as never,
+          };
+        }
+        return Report;
+      },
+      /is not a valid key/,
+      'a program marker is not a place to smuggle a value past the walk',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addActivity = {
+            base: 'transform',
+            params: { activity: { $linkTo: CardDef, junk: 1 } as never },
+            append: { to: 'activities', value: card(params('activity')) },
+          };
+        }
+        return Report;
+      },
+      /is not a valid key/,
+      'nor is a link param, which the reference walk skips',
+    );
+  });
+
+  test('a named query is checked for the shape a search needs', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static listSome = { base: 'query', query: {} };
+        }
+        return Report;
+      },
+      /at least one of/,
+      'a query with no query names no search',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            query: { filter: { on: CardDef }, page: { size: 0 } },
+          };
+        }
+        return Report;
+      },
+      /must be a positive integer/,
+      'a page size is a count',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            query: { filter: { on: CardDef }, realms: 'https://x/' as never },
+          };
+        }
+        return Report;
+      },
+      /non-empty array of realm URLs/,
+      'and realms is the fan-out list, not one realm',
+    );
+  });
+
+  test('the bxl tag reports being called as a function', function (assert) {
+    assert.throws(
+      () => (bxl as unknown as (parts: string[]) => unknown)(['.a = 1;']),
+      /template tag/,
+      'every reference constructor says what it wanted',
+    );
+  });
+
   test('getOperations rejects a target that is not a card definition', function (assert) {
     assert.throws(
       () => getOperations({} as never),
@@ -728,8 +969,16 @@ module('Integration | operations', function (hooks) {
       keyof OperationsModule.OperationsOf<typeof Report>
     >();
 
+    class Classroom extends CardDef {
+      @operation static addActivity = addActivity;
+    }
     assert.deepEqual(
-      Object.keys(addActivity.params),
+      Object.keys(
+        (
+          getDeclaredOperations(Classroom)
+            .addActivity as OperationsModule.TransformOperationDeclaration
+        ).params ?? {},
+      ),
       ['note', 'activity'],
       'a scalar param and a link param sit in the same schema',
     );

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -20,6 +20,7 @@ import type * as OperationsModule from '@cardstack/base/operations';
 let loader: Loader;
 let operation: (typeof OperationsModule)['operation'];
 let getOperations: (typeof OperationsModule)['getOperations'];
+let getDeclaredOperations: (typeof OperationsModule)['getDeclaredOperations'];
 let params: (typeof OperationsModule)['params'];
 let actor: (typeof OperationsModule)['actor'];
 let instance: (typeof OperationsModule)['instance'];
@@ -52,10 +53,19 @@ module('Integration | operations', function (hooks) {
 
   hooks.beforeEach(async function () {
     loader = getService('loader-service').loader;
-    ({ operation, getOperations, params, actor, instance, card, bxl, linkTo } =
-      await loader.import<typeof OperationsModule>(
-        '@cardstack/base/operations',
-      ));
+    ({
+      operation,
+      getOperations,
+      getDeclaredOperations,
+      params,
+      actor,
+      instance,
+      card,
+      bxl,
+      linkTo,
+    } = await loader.import<typeof OperationsModule>(
+      '@cardstack/base/operations',
+    ));
   });
 
   test('getOperations merges declarations up the prototype chain, subclass winning per name', function (assert) {
@@ -96,17 +106,32 @@ module('Integration | operations', function (hooks) {
     }
 
     assert.deepEqual(
-      Object.keys(getOperations(Report)).sort(),
+      Object.keys(getDeclaredOperations(Report)).sort(),
       ['addComment', 'escalate'],
       'a class sees the operations it declares',
     );
     assert.deepEqual(
-      Object.keys(getOperations(ExternalReport)).sort(),
+      Object.keys(getDeclaredOperations(ExternalReport)).sort(),
       ['addComment', 'escalate', 'listMine'],
       'a subclass sees its own operations and the ones it inherits',
     );
     assert.deepEqual(
-      getOperations(Report).escalate,
+      Object.keys(getOperations(ExternalReport)).sort(),
+      [
+        'addComment',
+        'create',
+        'delete',
+        'escalate',
+        'listMine',
+        'query',
+        'read',
+        'transform',
+        'update',
+      ],
+      'and reads them alongside the base operations its def type carries',
+    );
+    assert.deepEqual(
+      getDeclaredOperations(Report).escalate,
       {
         base: 'transform',
         transformations: { $bxl: '.status = "escalated";' },
@@ -140,10 +165,53 @@ module('Integration | operations', function (hooks) {
       getOperations(ExternalReport).escalate,
       'and reads the very declarations the class holds',
     );
+  });
+
+  test('the base operations a def type carries come back without being declared', function (assert) {
     assert.deepEqual(
       getOperations(CardDef),
+      {
+        read: { base: 'read' },
+        create: { base: 'create' },
+        update: { base: 'update' },
+        delete: { base: 'delete' },
+        query: { base: 'query' },
+        transform: { base: 'transform' },
+      },
+      'a card def carries all six, implied by the def type',
+    );
+    assert.deepEqual(
+      Object.keys(getDeclaredOperations(CardDef)),
+      [],
+      'none of which is written in author code',
+    );
+    assert.deepEqual(
+      getOperations(FileDef),
+      { read: { base: 'read' } },
+      "a file's metadata is read-only, so a file def carries only read",
+    );
+    assert.deepEqual(
+      getOperations(FieldDef),
       {},
-      'the built-in base operations are implied by the def type, not declared',
+      'a field has no URL, so nothing is invocable on one',
+    );
+
+    class Report extends CardDef {
+      // Specializing a base operation is a matter of declaring it by name.
+      @operation static read = {
+        base: 'read',
+        output: { title: true, comments: true },
+      } satisfies OperationsModule.OperationDeclaration;
+    }
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(getOperations(Report).read)),
+      { base: 'read', output: { title: true, comments: true } },
+      'the declaration takes the place of the base operation it names',
+    );
+    assert.deepEqual(
+      Object.keys(getOperations(Report)).sort(),
+      ['create', 'delete', 'query', 'read', 'transform', 'update'],
+      'and adds no name, because it is that base operation',
     );
   });
 
@@ -307,7 +375,7 @@ module('Integration | operations', function (hooks) {
       @operation static readRedacted = { base: 'read', output: { name: true } };
     }
     assert.deepEqual(
-      Object.keys(getOperations(Attachment)),
+      Object.keys(getDeclaredOperations(Attachment)),
       ['readRedacted'],
       'a read operation is declarable on a file definition',
     );
@@ -455,7 +523,7 @@ module('Integration | operations', function (hooks) {
   test('getOperations rejects a target that is not a card definition', function (assert) {
     assert.throws(
       () => getOperations({} as never),
-      /takes a class that extends BaseDef/,
+      /getOperations\(\) takes a class that extends BaseDef/,
       'operations hang off a definition, so a plain object reads none',
     );
   });
@@ -537,7 +605,7 @@ module('Integration | operations', function (hooks) {
       'the key a reference names is carried in the marker and in its type',
     );
     assert.deepEqual(
-      Object.keys(getOperations(Report)),
+      Object.keys(getDeclaredOperations(Report)),
       ['addComment'],
       'a declaration written against the exported types is recorded like any other',
     );

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -520,6 +520,106 @@ module('Integration | operations', function (hooks) {
     );
   });
 
+  test('a param is typed by a field class, and nothing else', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = {
+            base: 'transform',
+            params: { author: CardDef as never },
+            append: { to: 'comments', value: { author: params('author') } },
+          };
+        }
+        return Report;
+      },
+      /a card or file identity is a linkTo/,
+      'a card class types a link param, which is what linkTo declares',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = {
+            base: 'transform',
+            params: { body: (() => StringField) as never },
+            append: { to: 'comments', value: { body: params('body') } },
+          };
+        }
+        return Report;
+      },
+      /param "body" must be a field class or linkTo/,
+      'a scalar param takes the field class itself, not a thunk',
+    );
+  });
+
+  test('a declaration carries only what survives as data', function (assert) {
+    for (let [value, pattern, message] of [
+      [
+        () => 'escalated',
+        /is a function; a declaration is data/,
+        'a function would never reach the realm',
+      ],
+      [new Date(), /is a Date instance/, 'a date would flatten to a string'],
+      [
+        new Map(),
+        /is a Map instance/,
+        'a map would flatten to an empty object',
+      ],
+      [
+        undefined,
+        /omit an optional key rather than declaring it as undefined/,
+        'an undefined value would be dropped',
+      ],
+      [1n, /is a bigint/, 'a bigint cannot be serialized at all'],
+    ] as [never, RegExp, string][]) {
+      assert.throws(
+        () => {
+          class Report extends CardDef {
+            @operation static escalate = {
+              base: 'transform',
+              set: { status: value },
+            };
+          }
+          return Report;
+        },
+        pattern,
+        message,
+      );
+    }
+
+    class Activity extends CardDef {}
+    class Classroom extends CardDef {
+      // The two slots a def class is expected in: the type a create names,
+      // and the type a query filters on.
+      @operation static createActivity = {
+        base: 'create',
+        of: Activity,
+        params: { title: StringField },
+        fill: { title: params('title') },
+      };
+      @operation static listActivities = {
+        base: 'query',
+        query: { filter: { on: Activity, eq: { classroom: instance('id') } } },
+      };
+    }
+    let declarations = getOperations(Classroom);
+    assert.strictEqual(
+      (
+        declarations.createActivity as OperationsModule.CreateOperationDeclaration
+      ).of,
+      Activity,
+      'a create names the class it creates',
+    );
+    assert.strictEqual(
+      (
+        (
+          declarations.listActivities as OperationsModule.QueryOperationDeclaration
+        ).query as { filter: { on: unknown } }
+      ).filter.on,
+      Activity,
+      'and a query names the class it filters on',
+    );
+  });
+
   test('getOperations rejects a target that is not a card definition', function (assert) {
     assert.throws(
       () => getOperations({} as never),

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -406,8 +406,42 @@ module('Integration | operations', function (hooks) {
         }
         return Report;
       },
-      /is already a static on this class/,
+      /already resolves on this class/,
       'an operation name that shadows a system static is refused',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          // @ts-expect-error a declaration is not what Function#toString is
+          @operation static toString = { base: 'read' };
+        }
+        return Report;
+      },
+      /already resolves on this class/,
+      'nor one that shadows something every class inherits',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static __proto__ = { base: 'read' };
+        }
+        return Report;
+      },
+      /already resolves on this class/,
+      'and least of all a name that would reset a prototype instead of keying a map',
+    );
+
+    class Report extends CardDef {
+      @operation static addComment = {
+        base: 'transform',
+        params: { body: StringField },
+        append: { to: 'comments', value: { body: params('body') } },
+      };
+    }
+    assert.deepEqual(
+      Object.keys(getDeclaredOperations(Report)),
+      ['addComment'],
+      'a name-keyed store holds operations and nothing it might inherit',
     );
   });
 

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -706,7 +706,7 @@ module('Integration | operations', function (hooks) {
         // A filter nests, so `on` names a type at any depth — and the thunk
         // form works there.
         query: {
-          filter: { any: [{ on: () => Activity }], eq: { status: 'open' } },
+          filter: { any: [{ on: () => Activity, eq: { status: 'open' } }] },
         },
       };
       @operation static makeActivity = {

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -1,0 +1,545 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import type { Loader } from '@cardstack/runtime-common/loader';
+
+import { setupCardLogs, setupLocalIndexing } from '../helpers';
+import {
+  setupBaseRealm,
+  CardDef,
+  FieldDef,
+  FileDef,
+  StringField,
+  DateField,
+} from '../helpers/base-realm';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupRenderingTest } from '../helpers/setup';
+
+import type * as OperationsModule from '@cardstack/base/operations';
+
+let loader: Loader;
+let operation: (typeof OperationsModule)['operation'];
+let getOperations: (typeof OperationsModule)['getOperations'];
+let params: (typeof OperationsModule)['params'];
+let actor: (typeof OperationsModule)['actor'];
+let instance: (typeof OperationsModule)['instance'];
+let card: (typeof OperationsModule)['card'];
+let bxl: (typeof OperationsModule)['bxl'];
+let linkTo: (typeof OperationsModule)['linkTo'];
+
+// Compile-time assertions. The call does nothing at run time; it fails to
+// type-check unless the two types are identical, so the call is the assertion.
+type Identical<Left, Right> =
+  (<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2
+    ? true
+    : false;
+
+function expectTypeEquals<Expected, Actual>(
+  ..._assertion: Identical<Expected, Actual> extends true
+    ? []
+    : ['the two types are not identical']
+) {}
+
+module('Integration | operations', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupCardLogs(
+    hooks,
+    async () => await loader.import('@cardstack/base/card-api'),
+  );
+  setupLocalIndexing(hooks);
+  setupMockMatrix(hooks);
+
+  hooks.beforeEach(async function () {
+    loader = getService('loader-service').loader;
+    ({ operation, getOperations, params, actor, instance, card, bxl, linkTo } =
+      await loader.import<typeof OperationsModule>(
+        '@cardstack/base/operations',
+      ));
+  });
+
+  test('getOperations merges declarations up the prototype chain, subclass winning per name', function (assert) {
+    class Report extends CardDef {
+      @operation static addComment = {
+        base: 'transform',
+        params: { body: StringField },
+        append: {
+          to: 'comments',
+          value: { body: params('body'), author: actor() },
+        },
+      };
+      // Annotated rather than inferred: a subclass's static has to stay
+      // assignable to the one it shadows, and the override below is a
+      // differently-shaped declaration.
+      @operation static escalate: OperationsModule.OperationDeclaration = {
+        base: 'transform',
+        transformations: bxl`.status = "escalated";`,
+      };
+    }
+    class ExternalReport extends Report {
+      // Overrides the inherited declaration wholesale, by name. `satisfies`
+      // keeps `base` a literal, which is what makes the override assignable
+      // to the declaration it shadows.
+      @operation static escalate = {
+        base: 'transform',
+        params: { reason: StringField },
+        set: { status: 'escalated', escalationReason: params('reason') },
+      } satisfies OperationsModule.OperationDeclaration;
+      @operation static listMine = {
+        base: 'query',
+        // The thunk form: this class's binding is still uninitialized while
+        // its own statics are being built.
+        query: {
+          filter: { on: () => ExternalReport, eq: { author: actor('id') } },
+        },
+      };
+    }
+
+    assert.deepEqual(
+      Object.keys(getOperations(Report)).sort(),
+      ['addComment', 'escalate'],
+      'a class sees the operations it declares',
+    );
+    assert.deepEqual(
+      Object.keys(getOperations(ExternalReport)).sort(),
+      ['addComment', 'escalate', 'listMine'],
+      'a subclass sees its own operations and the ones it inherits',
+    );
+    assert.deepEqual(
+      getOperations(Report).escalate,
+      {
+        base: 'transform',
+        transformations: { $bxl: '.status = "escalated";' },
+      },
+      'the ancestor keeps its own declaration',
+    );
+
+    let overridden = getOperations(ExternalReport)
+      .escalate as OperationsModule.TransformOperationDeclaration;
+    assert.deepEqual(
+      Object.keys(overridden.params ?? {}),
+      ['reason'],
+      'the subclass declaration replaces the inherited one of the same name',
+    );
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(overridden.set)),
+      {
+        status: 'escalated',
+        escalationReason: { $ref: 'params', key: 'reason' },
+      },
+      'the overriding declaration is the one that comes back',
+    );
+
+    assert.deepEqual(
+      Object.keys(getOperations(new ExternalReport())).sort(),
+      Object.keys(getOperations(ExternalReport)).sort(),
+      'an instance reads the same operations as its class',
+    );
+    assert.strictEqual(
+      getOperations(new ExternalReport()).escalate,
+      getOperations(ExternalReport).escalate,
+      'and reads the very declarations the class holds',
+    );
+    assert.deepEqual(
+      getOperations(CardDef),
+      {},
+      'the built-in base operations are implied by the def type, not declared',
+    );
+  });
+
+  test('typed references are JSON-serializable markers', function (assert) {
+    class ClassroomActivity extends CardDef {}
+    class Classroom extends CardDef {
+      @operation static createActivity = {
+        base: 'create',
+        of: ClassroomActivity,
+        params: { title: StringField, dueOn: DateField },
+        fill: {
+          title: params('title'),
+          dueOn: params('dueOn'),
+          author: actor(),
+          classroom: instance('id'),
+        },
+      };
+      @operation static addActivity = {
+        base: 'transform',
+        params: { activity: linkTo(ClassroomActivity) },
+        append: { to: 'activities', value: card(params('activity')) },
+      };
+      @operation static addOwner = {
+        base: 'transform',
+        assert: {
+          unique: 'owners',
+          by: actor('id'),
+          message: 'This person already owns the classroom',
+        },
+        append: { to: 'owners', value: card('https://example.test/people/1') },
+      };
+    }
+
+    let declarations = getOperations(Classroom);
+    let createActivity =
+      declarations.createActivity as OperationsModule.CreateOperationDeclaration;
+    let addActivity =
+      declarations.addActivity as OperationsModule.TransformOperationDeclaration;
+    let addOwner =
+      declarations.addOwner as OperationsModule.TransformOperationDeclaration;
+
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(createActivity.fill)),
+      {
+        title: { $ref: 'params', key: 'title' },
+        dueOn: { $ref: 'params', key: 'dueOn' },
+        author: { $ref: 'actor' },
+        classroom: { $ref: 'instance', key: 'id' },
+      },
+      'params, actor and instance references survive JSON round-tripping',
+    );
+    assert.strictEqual(
+      createActivity.of,
+      ClassroomActivity,
+      'a create carries the class it creates',
+    );
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(addActivity.append)),
+      {
+        to: 'activities',
+        value: { $ref: 'card', value: { $ref: 'params', key: 'activity' } },
+      },
+      'a card reference carries the reference that resolves to the card',
+    );
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(addOwner.assert)),
+      {
+        unique: 'owners',
+        by: { $ref: 'actor', key: 'id' },
+        message: 'This person already owns the classroom',
+      },
+      'an assertion keys its uniqueness check on a reference',
+    );
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(bxl`assert(.status == "open"; "not open");`)),
+      { $bxl: 'assert(.status == "open"; "not open");' },
+      'a raw program is a marker carrying its source',
+    );
+  });
+
+  test('the bxl tag rejects interpolation', function (assert) {
+    let fieldName = 'status';
+    assert.throws(
+      () => bxl`.${fieldName} = "escalated";`,
+      /does not interpolate values/,
+      'a program reads the operation context through builtins, not spliced text',
+    );
+  });
+
+  test('the decorator rejects a target that is not a card definition', function (assert) {
+    assert.throws(
+      () => {
+        class NotADef {
+          @operation static addComment = { base: 'read' };
+        }
+        return NotADef;
+      },
+      /can only be used on static properties of classes that extend BaseDef/,
+      'a plain class cannot carry operations',
+    );
+  });
+
+  test('the decorator rejects a symbol operation name', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          // A computed key written as a bare identifier is compiled to that
+          // identifier's name, so a symbol only reaches the decorator from a
+          // key expression that is not an identifier. TypeScript wants a
+          // `unique symbol` for a computed class member, which this is not.
+          // @ts-expect-error the point of the case is the symbol that arrives
+          @operation static [Symbol.for('cardstack-test-operation')] = {
+            base: 'read',
+          };
+        }
+        return Report;
+      },
+      /only supports string operation names, not symbols/,
+      'an operation is addressed by name on the wire, so it needs a string',
+    );
+  });
+
+  test('the decorator rejects a declaration that is not an object', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = 'transform' as never;
+        }
+        return Report;
+      },
+      /must be a declaration object/,
+      'a declaration is plain data, not a value of some other kind',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment: never;
+        }
+        return Report;
+      },
+      /must be assigned a declaration object/,
+      'an operation with no declaration names no behavior at all',
+    );
+  });
+
+  test('a field cannot declare operations', function (assert) {
+    assert.throws(
+      () => {
+        class Comment extends FieldDef {
+          @operation static addReply = { base: 'read' };
+        }
+        return Comment;
+      },
+      /a field has no URL of its own/,
+      'field data is reached through the operations of the card that contains it',
+    );
+  });
+
+  test('a file definition can only declare read operations', function (assert) {
+    class Attachment extends FileDef {
+      @operation static readRedacted = { base: 'read', output: { name: true } };
+    }
+    assert.deepEqual(
+      Object.keys(getOperations(Attachment)),
+      ['readRedacted'],
+      'a read operation is declarable on a file definition',
+    );
+    assert.throws(
+      () => {
+        class Mutable extends FileDef {
+          @operation static rename = {
+            base: 'transform',
+            set: { name: 'renamed' },
+          };
+        }
+        return Mutable;
+      },
+      /metadata is read-only/,
+      'file metadata is content-derived, so it has no mutation surface',
+    );
+  });
+
+  test('the decorator rejects an operation name that is already a static', function (assert) {
+    assert.throws(
+      () => {
+        // TypeScript rejects the shadowing too (a static's type has to stay
+        // assignable to the one it shadows); the decorator is what catches a
+        // collision whose types happen to line up.
+        // @ts-expect-error an operation declaration is not a display name
+        class Report extends CardDef {
+          @operation static displayName = { base: 'read' };
+        }
+        return Report;
+      },
+      /is already a static on this class/,
+      'an operation name that shadows a system static is refused',
+    );
+  });
+
+  test('the decorator validates the declaration against its base operation', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = { base: 'append' as never };
+        }
+        return Report;
+      },
+      /must name the built-in behavior/,
+      'a declaration builds on one of the built-in behaviors',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = {
+            base: 'read',
+            append: { to: 'comments', value: 'hello' },
+          };
+        }
+        return Report;
+      },
+      /"append" is not a valid key for a "read" operation/,
+      'a clause is only legal on the base that can express it',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static createComment = {
+            base: 'create',
+            fill: { body: 'x' },
+          };
+        }
+        return Report;
+      },
+      /a "create" operation needs/,
+      'a create names the type it creates',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static escalate = {
+            base: 'transform',
+            set: { status: 'escalated' },
+            transformations: bxl`.status = "escalated";`,
+          };
+        }
+        return Report;
+      },
+      /either with clauses .* or with a raw/,
+      'the declarative clauses and a raw program are alternatives',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static escalate = {
+            base: 'transform',
+            transformations: '.status = "escalated";' as never,
+          };
+        }
+        return Report;
+      },
+      /must be a program written with the bxl tag/,
+      'a raw program comes from the bxl tag, not a bare string',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static listMine = { base: 'query' };
+        }
+        return Report;
+      },
+      /a "query" operation needs/,
+      'a named query is the query it saves',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = {
+            base: 'transform',
+            append: {
+              to: 'comments',
+              value: 'hello',
+              into: 'comments',
+            } as never,
+          };
+        }
+        return Report;
+      },
+      /"into" is not a valid key/,
+      'a clause accepts only the keys it is made of',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = {
+            base: 'transform',
+            append: {
+              to: 'comments',
+              value: { body: { $ref: 'payload' } },
+            } as never,
+          };
+        }
+        return Report;
+      },
+      /is not a typed reference/,
+      'a reference comes from one of the reference constructors',
+    );
+  });
+
+  test('getOperations rejects a target that is not a card definition', function (assert) {
+    assert.throws(
+      () => getOperations({} as never),
+      /takes a class that extends BaseDef/,
+      'operations hang off a definition, so a plain object reads none',
+    );
+  });
+
+  test('a params reference must name a declared param', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = {
+            base: 'transform',
+            params: { body: StringField },
+            append: { to: 'comments', value: { body: params('title') } },
+          };
+        }
+        return Report;
+      },
+      /references the param "title"/,
+      'the declared schema is the single source for what the payload carries',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = {
+            base: 'transform',
+            params: { body: 'string' as never },
+            append: { to: 'comments', value: { body: params('body') } },
+          };
+        }
+        return Report;
+      },
+      /param "body" must be a field class or linkTo/,
+      'a param names the field class that types it',
+    );
+  });
+
+  test('the declared params schema types the operation payload', function (assert) {
+    class ClassroomActivity extends CardDef {}
+    let addActivity = {
+      base: 'transform',
+      params: { note: StringField, activity: linkTo(ClassroomActivity) },
+      append: { to: 'activities', value: card(params('activity')) },
+    } satisfies OperationsModule.OperationDeclaration;
+
+    expectTypeEquals<
+      { note: string; activity: OperationsModule.LinkParamValue },
+      OperationsModule.ParamsOf<typeof addActivity>
+    >();
+    expectTypeEquals<
+      Record<string, never>,
+      OperationsModule.ParamsOf<{ base: 'delete' }>
+    >();
+
+    let bodyReference = params('body');
+    expectTypeEquals<
+      OperationsModule.ParamsReference<'body'>,
+      typeof bodyReference
+    >();
+
+    class Report extends CardDef {
+      @operation static addComment = {
+        base: 'transform',
+        params: { body: StringField },
+        append: { to: 'comments', value: { body: params('body') } },
+      } satisfies OperationsModule.OperationDeclaration;
+    }
+    expectTypeEquals<
+      'addComment',
+      keyof OperationsModule.OperationsOf<typeof Report>
+    >();
+
+    assert.deepEqual(
+      Object.keys(addActivity.params),
+      ['note', 'activity'],
+      'a scalar param and a link param sit in the same schema',
+    );
+    assert.deepEqual(
+      bodyReference,
+      { $ref: 'params', key: 'body' },
+      'the key a reference names is carried in the marker and in its type',
+    );
+    assert.deepEqual(
+      Object.keys(getOperations(Report)),
+      ['addComment'],
+      'a declaration written against the exported types is recorded like any other',
+    );
+  });
+});

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -988,8 +988,33 @@ module('Integration | operations', function (hooks) {
         }
         return Report;
       },
-      /must be a card class/,
-      'and a type slot names a card',
+      /must be a card or file class/,
+      'and a type slot names something that has a type of its own',
+    );
+  });
+
+  test('a declaration pins the page the realm implements', function (assert) {
+    class Activity extends CardDef {}
+    class Report extends CardDef {
+      @operation static listRecent = {
+        base: 'query',
+        query: {
+          filter: { type: Activity },
+          page: { size: 20, number: 1 },
+        },
+      };
+    }
+    assert.deepEqual(
+      JSON.parse(
+        JSON.stringify(
+          (
+            getDeclaredOperations(Report)
+              .listRecent as OperationsModule.QueryOperationDeclaration
+          ).query?.page,
+        ),
+      ),
+      { size: 20, number: 1 },
+      'a page is a length and a 0-based offset, which is how the realm pages',
     );
   });
 
@@ -1165,12 +1190,28 @@ module('Integration | operations', function (hooks) {
         /`query.page` must be an object/,
       ],
       [
-        'query.page.cursor',
+        'query.page with no size',
         {
           base: 'query',
-          query: { filter: { type: CardDef }, page: { cursor: '' } },
+          query: { filter: { type: CardDef }, page: { number: 1 } },
         },
-        /`query.page.cursor` must be a string/,
+        /`query.page.size` must be a positive integer/,
+      ],
+      [
+        'query.page.number below zero',
+        {
+          base: 'query',
+          query: { filter: { type: CardDef }, page: { size: 10, number: -1 } },
+        },
+        /`query.page.number` must be a whole number/,
+      ],
+      [
+        'cursor is not a page key',
+        {
+          base: 'query',
+          query: { filter: { type: CardDef }, page: { size: 10, cursor: 'x' } },
+        },
+        /"cursor" is not a valid key for `query.page`/,
       ],
       [
         'a params reference with a non-string key',

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -865,7 +865,7 @@ module('Integration | operations', function (hooks) {
         class Report extends CardDef {
           @operation static listSome = {
             base: 'query',
-            query: { filter: { on: CardDef }, page: { size: 0 } },
+            query: { filter: { type: CardDef }, page: { size: 0 } },
           };
         }
         return Report;
@@ -878,13 +878,179 @@ module('Integration | operations', function (hooks) {
         class Report extends CardDef {
           @operation static listSome = {
             base: 'query',
-            query: { filter: { on: CardDef }, realms: 'https://x/' as never },
+            query: { filter: { type: CardDef }, realms: 'https://x/' as never },
           };
         }
         return Report;
       },
       /non-empty array of realm URLs/,
       'and realms is the fan-out list, not one realm',
+    );
+  });
+
+  test('a query names a type only where the filter grammar has one', function (assert) {
+    class Activity extends CardDef {}
+    class Classroom extends CardDef {
+      // `type` is how the realm spells a pure card-type filter; `on` anchors a
+      // filter that carries a predicate. Both nest through `any`/`every`/`not`,
+      // and a sort entry names the type its `by` path is rooted in.
+      @operation static listAll = {
+        base: 'query',
+        query: {
+          filter: { any: [{ type: Activity }, { not: { type: Activity } }] },
+          sort: [{ by: 'title', on: Activity }],
+        },
+      };
+      @operation static listOpen = {
+        base: 'query',
+        query: { filter: { on: Activity, eq: { status: 'open' } } },
+      };
+      // A predicate holds field names, so a field genuinely called `on` is
+      // data and survives.
+      @operation static listRecent = {
+        base: 'query',
+        query: { filter: { on: Activity, range: { on: { gt: 1 } } } },
+      };
+    }
+    let declarations = getDeclaredOperations(Classroom);
+    let queryOf = (name: string) =>
+      (declarations[name] as OperationsModule.QueryOperationDeclaration)
+        .query as Record<string, never>;
+    assert.strictEqual(
+      (
+        queryOf('listAll') as unknown as {
+          filter: { any: { type: unknown }[] };
+        }
+      ).filter.any[0].type,
+      Activity,
+      'a pure card-type filter names the class itself',
+    );
+    assert.strictEqual(
+      (
+        queryOf('listAll') as unknown as {
+          sort: { on: unknown }[];
+        }
+      ).sort[0].on,
+      Activity,
+      'and so does a sort entry',
+    );
+    assert.deepEqual(
+      JSON.parse(
+        JSON.stringify(
+          (queryOf('listRecent') as unknown as { filter: { range: unknown } })
+            .filter.range,
+        ),
+      ),
+      { on: { gt: 1 } },
+      'a field named `on` under a predicate is data, not a type slot',
+    );
+
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            query: { filter: { eq: { on: Activity, status: 'open' } } },
+          };
+        }
+        return Report;
+      },
+      /`query.filter.eq.on` is a function/,
+      'a class under a predicate would lower to nothing and match everything',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            query: { filter: { on: StringField as never, eq: { a: 1 } } },
+          };
+        }
+        return Report;
+      },
+      /must be a card class/,
+      'and a type slot names a card',
+    );
+  });
+
+  test('a create names what it creates whichever form its work takes', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static makeOne = {
+            base: 'create',
+            transformations: bxl`.title = "x";`,
+          } as never;
+        }
+        return Report;
+      },
+      /needs `of` to name what it creates/,
+      'a program computes fields without saying what kind of card to create',
+    );
+  });
+
+  test('a marker is identified by a key of its own', function (assert) {
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static escalate = {
+            base: 'transform',
+            // Inherited rather than own, so it serializes as `{}`.
+            set: { author: Object.create({ $ref: 'actor' }) as never },
+          };
+        }
+        return Report;
+      },
+      /a declaration carries plain objects, arrays and primitives/,
+      'a reference reached through a prototype is not a reference',
+    );
+    assert.throws(
+      () => {
+        let reference: Record<string, unknown> = { $ref: 'card' };
+        reference.value = reference;
+        class Report extends CardDef {
+          @operation static escalate = {
+            base: 'transform',
+            set: { owner: reference as never },
+          };
+        }
+        return Report;
+      },
+      /refers back to a value that contains it/,
+      'and a reference that contains itself is refused, not recursed into',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addComment = {
+            base: 'transform',
+            params: { body: StringField },
+            append: {
+              to: 'comments',
+              value: {
+                body: { $ref: 'params', key: 'body', extra: 1 } as never,
+              },
+            },
+          };
+        }
+        return Report;
+      },
+      /"extra" is not a valid key/,
+      'a reference marker carries only what its constructor puts there',
+    );
+    assert.throws(
+      () => {
+        class Report extends CardDef {
+          @operation static addActivity = {
+            base: 'transform',
+            params: { activity: { $linkTo: StringField } as never },
+            append: { to: 'activities', value: card(params('activity')) },
+          };
+        }
+        return Report;
+      },
+      /links to a card or file class/,
+      'a hand-written link marker is held to what linkTo requires',
     );
   });
 
@@ -970,19 +1136,19 @@ module('Integration | operations', function (hooks) {
       ],
       [
         'query with an unknown key',
-        { base: 'query', query: { filter: { on: CardDef }, junk: 1 } },
+        { base: 'query', query: { filter: { type: CardDef }, junk: 1 } },
         /"junk" is not a valid key for `query`/,
       ],
       [
         'query.page not an object',
-        { base: 'query', query: { filter: { on: CardDef }, page: 10 } },
+        { base: 'query', query: { filter: { type: CardDef }, page: 10 } },
         /`query.page` must be an object/,
       ],
       [
         'query.page.cursor',
         {
           base: 'query',
-          query: { filter: { on: CardDef }, page: { cursor: '' } },
+          query: { filter: { type: CardDef }, page: { cursor: '' } },
         },
         /`query.page.cursor` must be a string/,
       ],

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -6,6 +6,7 @@ import type { Loader } from '@cardstack/runtime-common/loader';
 import { setupCardLogs, setupLocalIndexing } from '../helpers';
 import {
   setupBaseRealm,
+  cardAPI,
   CardDef,
   FieldDef,
   FileDef,
@@ -895,7 +896,201 @@ module('Integration | operations', function (hooks) {
     );
   });
 
+  test('every declaration guard reports what it wanted', function (assert) {
+    let rejected: [string, unknown, RegExp][] = [
+      [
+        'optimistic',
+        { base: 'read', optimistic: 'yes' },
+        /`optimistic` must be a boolean/,
+      ],
+      [
+        'input',
+        { base: 'read', input: '.a = 1;' },
+        /`input` must be a program written with the bxl tag/,
+      ],
+      [
+        'output',
+        { base: 'read', output: 'title' },
+        /`output` must be a projection object or a bxl program/,
+      ],
+      [
+        'append not an object',
+        { base: 'transform', append: 'comments' },
+        /`append` must be an object naming the field/,
+      ],
+      [
+        'append.to empty',
+        { base: 'transform', append: { to: '', value: 1 } },
+        /`append.to` must name the collection field/,
+      ],
+      [
+        'append with no value',
+        { base: 'transform', append: { to: 'comments' } },
+        /`append` must carry a `value` to append/,
+      ],
+      [
+        'assert not an object',
+        { base: 'transform', assert: 'unique' },
+        /`assert` must be an object naming the collection/,
+      ],
+      [
+        'assert.unique empty',
+        { base: 'transform', assert: { unique: '', by: 1 } },
+        /`assert.unique` must name the collection field/,
+      ],
+      [
+        'assert with no by',
+        { base: 'transform', assert: { unique: 'owners' } },
+        /`assert` must carry a `by` value/,
+      ],
+      [
+        'assert.message',
+        { base: 'transform', assert: { unique: 'o', by: 1, message: 2 } },
+        /`assert.message` must be a string/,
+      ],
+      [
+        'set empty',
+        { base: 'transform', set: {} },
+        /`set` must be an object mapping field names to values/,
+      ],
+      [
+        'fill empty',
+        { base: 'create', of: CardDef, fill: {} },
+        /`fill` must be an object mapping field names to values/,
+      ],
+      [
+        'of not a function',
+        { base: 'create', of: 'Activity' },
+        /`of` must be the card class to create/,
+      ],
+      [
+        'query not an object',
+        { base: 'query', query: 'everything' },
+        /`query` must be an object with at least one of/,
+      ],
+      [
+        'query with an unknown key',
+        { base: 'query', query: { filter: { on: CardDef }, junk: 1 } },
+        /"junk" is not a valid key for `query`/,
+      ],
+      [
+        'query.page not an object',
+        { base: 'query', query: { filter: { on: CardDef }, page: 10 } },
+        /`query.page` must be an object/,
+      ],
+      [
+        'query.page.cursor',
+        {
+          base: 'query',
+          query: { filter: { on: CardDef }, page: { cursor: '' } },
+        },
+        /`query.page.cursor` must be a string/,
+      ],
+      [
+        'a params reference with a non-string key',
+        {
+          base: 'transform',
+          params: { body: StringField },
+          set: { x: { $ref: 'params', key: 1 } },
+        },
+        /must name a param/,
+      ],
+      [
+        'an actor reference with an empty key',
+        { base: 'transform', set: { x: { $ref: 'actor', key: '' } } },
+        /must name a member, or none at all/,
+      ],
+      [
+        'a card reference with a non-reference value',
+        { base: 'transform', set: { x: { $ref: 'card', value: 1 } } },
+        /must carry a card URL or a reference to one/,
+      ],
+    ];
+    for (let [name, declaration, pattern] of rejected) {
+      assert.throws(
+        () => {
+          class Report extends CardDef {
+            @operation static candidate = declaration as never;
+          }
+          return Report;
+        },
+        pattern,
+        `a declaration is refused for ${name}`,
+      );
+    }
+  });
+
+  test('every reference constructor reports what it wanted', function (assert) {
+    let rejected: [string, () => unknown, RegExp][] = [
+      [
+        'params with no name',
+        () => params(''),
+        /takes the name of a param declared/,
+      ],
+      [
+        'params with a non-string',
+        () => params(1 as never),
+        /takes the name of a param declared/,
+      ],
+      [
+        'card with no URL',
+        () => card(''),
+        /takes a card URL or a typed reference to one/,
+      ],
+      [
+        'card with a non-reference',
+        () => card(1 as never),
+        /takes a card URL or a typed reference to one/,
+      ],
+      [
+        'linkTo with a non-class',
+        () => linkTo('Activity' as never),
+        /takes a card class/,
+      ],
+      [
+        'actor with an empty key',
+        () => actor(''),
+        /takes the name of a member to read, or no argument at all/,
+      ],
+      [
+        'instance with a non-string key',
+        () => instance(1 as never),
+        /takes the name of a member to read, or no argument at all/,
+      ],
+    ];
+    for (let [name, build, pattern] of rejected) {
+      assert.throws(build, pattern, `${name} is refused`);
+    }
+  });
+
+  test('a def with no mutation surface carries only read', function (assert) {
+    class Bare extends cardAPI.BaseDef {}
+    assert.deepEqual(
+      getOperations(Bare),
+      { read: { base: 'read' } },
+      'read is the one operation every addressable def shares',
+    );
+    assert.throws(
+      () => {
+        class Mutable extends cardAPI.BaseDef {
+          @operation static escalate = {
+            base: 'transform',
+            set: { status: 'escalated' },
+          };
+        }
+        return Mutable;
+      },
+      /carries only "read"/,
+      'and a def that carries no mutation base cannot declare one',
+    );
+  });
+
   test('getOperations rejects a target that is not a card definition', function (assert) {
+    assert.throws(
+      () => getDeclaredOperations({} as never),
+      /getDeclaredOperations\(\) takes a class that extends BaseDef/,
+      'each reader names itself in its own error',
+    );
     assert.throws(
       () => getOperations({} as never),
       /getOperations\(\) takes a class that extends BaseDef/,
@@ -968,6 +1163,23 @@ module('Integration | operations', function (hooks) {
       'addComment',
       keyof OperationsModule.OperationsOf<typeof Report>
     >();
+
+    // A static that merely carries a string `base` is not an operation.
+    class Themed extends CardDef {
+      static theme = { base: 'dark', accent: '#fff' };
+      @operation static ping = {
+        base: 'read',
+      } satisfies OperationsModule.OperationDeclaration;
+    }
+    expectTypeEquals<
+      'ping',
+      keyof OperationsModule.OperationsOf<typeof Themed>
+    >();
+    assert.deepEqual(
+      Object.keys(getDeclaredOperations(Themed)),
+      ['ping'],
+      'and the reader agrees with the type at run time',
+    );
 
     class Classroom extends CardDef {
       @operation static addActivity = addActivity;

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -1018,6 +1018,75 @@ module('Integration | operations', function (hooks) {
     );
   });
 
+  test('a declared query is checked against the realm grammar itself', function (assert) {
+    class Activity extends CardDef {}
+    class Report extends CardDef {
+      @operation static search = {
+        base: 'query',
+        params: { term: StringField },
+        query: {
+          filter: { type: Activity },
+          // A payload may supply the full-text term.
+          queryString: params('term'),
+        },
+      };
+    }
+    assert.strictEqual(
+      (
+        (
+          getDeclaredOperations(Report)
+            .search as OperationsModule.QueryOperationDeclaration
+        ).query as { queryString: { $ref: string } }
+      ).queryString.$ref,
+      'params',
+      'a query carrying a reference is left to the placement rule',
+    );
+
+    // With no reference to stand in for a concrete value, the realm's own
+    // validator sees the query — so a shape it would reject at invocation is
+    // rejected where the class is defined.
+    assert.throws(
+      () => {
+        class Listing extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            // An `any` element is a filter node, so it needs a predicate.
+            query: { filter: { any: [{ on: Activity }] } },
+          };
+        }
+        return Listing;
+      },
+      /is not a query the realm accepts/,
+      'a filter node with no predicate is not a filter',
+    );
+    assert.throws(
+      () => {
+        class Listing extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            query: { filter: { type: Activity }, sort: [{ by: 'title' }] },
+          };
+        }
+        return Listing;
+      },
+      /is not a query the realm accepts/,
+      'and a sort by a card field names the type it is rooted in',
+    );
+    assert.throws(
+      () => {
+        class Listing extends CardDef {
+          @operation static listSome = {
+            base: 'query',
+            query: { filter: { type: Activity }, queryString: 42 as never },
+          };
+        }
+        return Listing;
+      },
+      /`query.queryString` must be a search term/,
+      'a full-text term is a string, or a reference to one',
+    );
+  });
+
   test('a create names what it creates whichever form its work takes', function (assert) {
     assert.throws(
       () => {

--- a/packages/host/tests/integration/operations-test.ts
+++ b/packages/host/tests/integration/operations-test.ts
@@ -214,6 +214,25 @@ module('Integration | operations', function (hooks) {
       ['create', 'delete', 'query', 'read', 'transform', 'update'],
       'and adds no name, because it is that base operation',
     );
+
+    class Archivable extends CardDef {
+      // A base operation's name is the verb a caller invokes, so a
+      // declaration by that name may carry it out with another behavior.
+      @operation static delete = {
+        base: 'transform',
+        set: { archived: true },
+      } satisfies OperationsModule.OperationDeclaration;
+    }
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(getOperations(Archivable).delete)),
+      { base: 'transform', set: { archived: true } },
+      'a delete declared on transform is a soft delete',
+    );
+    assert.deepEqual(
+      Object.keys(getOperations(Archivable)).sort(),
+      ['create', 'delete', 'query', 'read', 'transform', 'update'],
+      'which stands in for the removal rather than beside it',
+    );
   });
 
   test('typed references are JSON-serializable markers', function (assert) {


### PR DESCRIPTION
## Background and Goal

An operation is a named, reusable action on a card — "add a comment", "invite a guardian", "create an activity for this classroom". Authors declare one as plain data rather than as JavaScript, so the realm can lower it to canonical base-operation data plus BXL and run it without evaluating any card code.

This PR adds `@cardstack/base/operations`: the `@operation` decorator, the `getOperations` / `getDeclaredOperations` readers, the typed reference constructors (`params`, `actor`, `instance`, `card`, the `bxl` tag, `linkTo`), and the declaration types. It is additive and self-contained — nothing reads the declarations yet, so `packages/base` gains one file and no existing module changes behavior.

```ts
import { operation, params, actor } from '@cardstack/base/operations';
import StringField from 'https://cardstack.com/base/string';

class ExternalReport extends CardDef {
  @operation static addComment = {
    base: 'transform',
    params: { body: StringField },
    append: { to: 'comments', value: { body: params('body'), author: actor() } },
  } satisfies OperationDeclaration;
}
```

## Where to start

- `packages/base/operations.ts` — the module header states the contract. Then the two entry points: `operation`, the decorator that validates and records; and `getOperations`, the read path. Everything after them is validation, and the comments on `BASE_OPERATIONS`, `REQUIRED_CLAUSE` and the two readers carry the invariant each one offers a consumer.
- `packages/host/tests/integration/operations-test.ts` — merge and override semantics, the implied base operations, marker shapes under `JSON.stringify`, every guard, and the type-level assertions for the `params` typing.

## Key decisions and non-obvious mechanics

- **`getOperations` returns every operation pertinent to the def**: the base operations its def type implies — all six for a card def, `read` for a file def (whose metadata is content-derived and read-only), none for a field def (whose instances have no URL) — merged with the author's declarations, where a declaration takes the place of the base operation it names. A synthesized entry is the bare `{ base }`, because the base operations are the executors and what a plain `create` or `query` needs travels with the invocation rather than the declaration. `getDeclaredOperations` is the authored-only view, and the one to lower from: its entries all went through the decorator, so a clause the base requires is present.
- **A base operation's name is the verb; its `base` is what carries the verb out.** A declaration named after a base operation specializes that behavior when it names the same `base` — a card's own `read` projection or `update` validation — and rebinds the verb when it names another: a `delete` declared on `transform` is a soft delete, so every caller asking that card to delete itself archives it instead. A dispatcher therefore reads name and `base` separately rather than inferring one from the other.
- **Declarations live on the class under a symbol, per class**, merged base-most-first up the constructor chain so a subclass overrides inherited names wholesale — the same shape as `getScreenshots`. Both readers return a record with **no prototype**: an operation is dispatched by a name that arrived over the wire, and a record backed by `Object.prototype` answers `toString`, `constructor` and `__proto__` with something that is not an operation.
- **The plain-data invariant is enforced, not assumed.** A declaration reaches the realm as JSON in a definition-cache entry, so the walk refuses anything that would not survive the trip: a function, `undefined`, a symbol, a bigint, a non-finite number, a class instance, a cycle. A def class is legal only where the position names a type — the `of` a create targets, a filter's `on` or `type` at any nesting depth, and the `on` a sort entry roots its path in — and only a card or file class, since a field has no type row of its own to name. That precision is what stops a thunk being read as a *value* under `eq`, where it would lower to nothing and leave a saved search matching every card instead of one.
- **A declared query is also checked against the query grammar's own definition.** The placement rule above encodes where the realm's filter grammar puts a type, which means it has to stay in step with a grammar defined elsewhere. So the query is handed to `assertQuery` — that grammar's single definition — with every def class swapped for a sentinel that reads as a code ref where a type belongs and as a function everywhere else, and the realm re-checks both the placement and the rest of the shape. A query the realm would refuse is refused at class-definition time rather than at invocation. The second opinion is skipped for a query carrying a typed reference, since a reference stands in for a value the realm types concretely — a `matches` string, an `in` array — and only lowering resolves it.
- **`QueryDeclaration` is the realm's query narrowed to what a saved search states**: `filter`, `sort`, a `queryString` a payload may supply, `realms` as the fan-out list, and offset paging — `size` with a 0-based `number`. There is no cursor to declare, since the index generation a request is pinned to is the server's to mint. `realm` in the singular is left out because the fan-out list is the scope; `asData` and `fields` are left out because a query operation answers with entry rows, a different response shape than a data query.
- **Validation happens at class-definition time**: the target (a `BaseDef` subclass, never a `FieldDef`), the name (a string that does not already resolve on the class, unless it names an inherited operation), and the declaration — a base the def type actually carries, read from the same list `getOperations` synthesizes so the two cannot drift; only the keys that base can express; a well-formed `params` schema; and declarative clauses or a raw program. `of` names the type rather than the work, so it stands alongside a program rather than competing with it.
- **A static-property decorator has to return a descriptor carrying `value`.** With an `initializer` left in place, the decorator transform defers the field to instance construction — where a static never runs — and the property never appears on the class.
- **The `bxl` tag takes no substitutions.** `params()`, `actor()` and `instance()` are BXL builtins that read the operation context, so a program reads the payload and the actor directly; splicing values into program text would be a second, unchecked path into it.
- **Typing follows the `satisfies OperationDeclaration` idiom**, which type-checks the declaration in place and keeps the literal types `OperationsOf` and `ParamsOf` read. Overriding an inherited operation needs the inherited one annotated `: OperationDeclaration`, since TypeScript requires a subclass's static to stay assignable to what it shadows — and that annotation costs the annotated name its payload type, so it is worth writing only where a subclass really will reshape the operation.
- **The module is plain TypeScript with no template**, so it lands as `operations.ts` alongside its non-component siblings (`searchable.ts`, `field-support.ts`); the `@cardstack/base/operations` import specifier is unaffected by the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eB3iLWGiptT9zMeKta6c4