### PR TITLE
Stop the matrix harness rendering the skills realm during its test run

### DIFF
--- a/packages/matrix/support/isolated-realm-server.ts
+++ b/packages/matrix/support/isolated-realm-server.ts
@@ -482,6 +482,26 @@ export async function startServer({
     `--userIndexCount=1`,
     `--highPriorityCount=2`,
 
+    // The skills realm's boot index would otherwise spawn a prerender_html job
+    // covering ~900 files, which takes longer than the test run it is meant to
+    // precede. Nothing waits for it: the readiness gate below asks whether the
+    // `indexing:<realm>` queue lane is clear, and this work lives in
+    // `prerender-html:<realm>`, so the gate releases while the render is still
+    // going. It then holds an all-priority worker for the length of the suite,
+    // competing with the realms the specs themselves create — which is felt as
+    // timeouts in specs that wait on a publish or an index.
+    //
+    // Skipping it is what makes the absence legible. A render that overruns the
+    // suite leaves the HTML partly written, by an amount that depends on how
+    // the run was scheduled, so a spec needing a rendered skill card passes or
+    // fails on timing. With no render at all it fails every time, which is a
+    // result worth acting on. The realm is still fully indexed before any spec
+    // runs; only its prerendered HTML is absent.
+    //
+    // Not applied to base: base's boot render is far smaller, and its cards are
+    // what most rendered surfaces here are built from.
+    `--skipPrerenderHtmlRealm=https://localhost:4205/skills/`,
+
     `--fromUrl='https://localhost:4205/test/'`,
     `--toUrl='https://localhost:4205/test/'`,
   ];
@@ -751,7 +771,12 @@ export async function startServer({
 
   // `ready` above only means the realm server is listening with its realms
   // mounted — the boot-time from-scratch index of those realms (test + skills +
-  // base, ~600 files) is still running on the single indexing worker. Any realm
+  // base, ~600 files) is still running on the single indexing worker.
+  //
+  // Scope, because the log line below reads as a stronger claim than it is:
+  // `_readiness-check` gates on the realm's `indexing:<realm>` queue lane. The
+  // separate `prerender-html:<realm>` lane is invisible to it, so this waits
+  // for a realm to be indexed, never for its HTML to be rendered. Any realm
   // a test creates while that boot index is in flight queues behind it, so its
   // `_create-realm` can take 30-100s to return and blows the per-test
   // create-workspace waits (and cascades into publish/registration test
@@ -780,7 +805,8 @@ export async function startServer({
   }
   console.log(
     `realm server: boot index settled ${Date.now() - bootIndexStart}ms after ` +
-      `ready (gated on _readiness-check before starting tests)`,
+      `ready (gated on _readiness-check before starting tests; ` +
+      `covers indexing, not prerender-html)`,
   );
 
   let server = new IsolatedRealmServer(

--- a/packages/realm-server/tests/prerender-html-reconcile-test.ts
+++ b/packages/realm-server/tests/prerender-html-reconcile-test.ts
@@ -55,8 +55,9 @@ module(basename(import.meta.filename), function (hooks) {
     },
   });
 
-  function runReconcile() {
+  function runReconcile(skipPrerenderHtmlRealms?: string[]) {
     return prerenderHtmlReconcile({
+      skipPrerenderHtmlRealms,
       reportStatus: () => {},
       log: logger('prerender-html-reconcile-test'),
       dbAdapter,
@@ -485,6 +486,61 @@ module(basename(import.meta.filename), function (hooks) {
       (await prerenderHtmlJobs(realmURL)).length,
       0,
       'no repair job is enqueued for a bot-owned realm',
+    );
+  });
+
+  // A realm configured to render no HTML has every row permanently unrendered,
+  // which reads here exactly like residue worth repairing. Without the
+  // exclusion this sweep re-enqueues, at whole-realm size, the very render the
+  // configuration exists to prevent — and it runs hourly, so a long-lived
+  // process gets there eventually.
+  test('skips a realm configured not to render HTML', async function (assert) {
+    const realmURL = 'http://example.com/no-render/';
+    await seedOwner(realmURL);
+    await seedRealmGeneration(realmURL, 5);
+    for (let name of ['mango', 'vanGogh']) {
+      await seedIndexRow({
+        url: `${realmURL}${name}.json`,
+        realmURL,
+        generation: 5,
+      });
+    }
+
+    assert.deepEqual(
+      await runReconcile([realmURL]),
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
+      'the configured realm is left unrendered',
+    );
+    assert.strictEqual(
+      (await prerenderHtmlJobs(realmURL)).length,
+      0,
+      'no repair job is enqueued for a realm configured not to render',
+    );
+
+    // The same rows, with the realm no longer configured off, are exactly what
+    // the sweep is for — so the assertion above is about the configuration and
+    // not about the rows being unrepairable.
+    assert.deepEqual(
+      await runReconcile(),
+      { realmsRepaired: 1, urlsEnqueued: 2, realmsInBackoff: 0 },
+      'the same rows are repaired once the realm is not configured off',
+    );
+  });
+
+  test('a configured realm is matched regardless of a trailing slash', async function (assert) {
+    const realmURL = 'http://example.com/slash/';
+    await seedOwner(realmURL);
+    await seedRealmGeneration(realmURL, 5);
+    await seedIndexRow({
+      url: `${realmURL}mango.json`,
+      realmURL,
+      generation: 5,
+    });
+
+    assert.deepEqual(
+      await runReconcile([realmURL.replace(/\/$/, '')]),
+      { realmsRepaired: 0, urlsEnqueued: 0, realmsInBackoff: 0 },
+      'a value written without the trailing slash still matches',
     );
   });
 

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -138,6 +138,7 @@ let {
   migrateDB,
   prerendererUrl,
   serviceName = 'worker',
+  skipPrerenderHtmlRealm: skipPrerenderHtmlRealms = [],
 } = yargs(process.argv.slice(2))
   .usage('Start worker manager')
   .options({
@@ -190,6 +191,11 @@ let {
       description:
         'Traefik service name for registration in branch mode (default: worker)',
       type: 'string',
+    },
+    skipPrerenderHtmlRealm: {
+      description:
+        'Realm URL whose from-scratch index must not spawn the follow-on prerender_html job. Repeatable. A test-harness affordance: the realm ends up indexed but never rendered, so anything reading its prerendered HTML sees nothing at all rather than something late. No deployment sets this.',
+      type: 'array',
     },
   })
   .parseSync();
@@ -812,6 +818,9 @@ async function startWorker(
       `--prerendererUrl=${prerendererUrl}`,
       `--priority=${priority}`,
       ...(opts?.indexJobsOnly ? [`--indexJobsOnly`] : []),
+      ...skipPrerenderHtmlRealms.map(
+        (realmURL) => `--skipPrerenderHtmlRealm=${realmURL}`,
+      ),
       ...flattenDeep(
         urlMappings.map(([from, to]) => [
           `--fromUrl='${from instanceof URL ? from.href : from}'`,

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -85,6 +85,7 @@ let {
   migrateDB,
   prerendererUrl,
   indexJobsOnly = false,
+  skipPrerenderHtmlRealm: skipPrerenderHtmlRealms = [],
 } = yargs(process.argv.slice(2))
   .usage('Start worker')
   .options({
@@ -123,12 +124,21 @@ let {
         'When set, the worker only registers (and therefore only claims) indexing job types, making it a dedicated index lane that other job types cannot occupy',
       type: 'boolean',
     },
+    skipPrerenderHtmlRealm: {
+      description:
+        'Realm URL whose from-scratch index must not spawn the follow-on prerender_html job. Repeatable. A test-harness affordance: the realm ends up indexed but never rendered, so anything reading its prerendered HTML sees nothing at all rather than something late. No deployment sets this.',
+      type: 'array',
+    },
   })
   .parseSync();
 
 log.info(
   `starting worker with pid ${process.pid} and priority ${priority}${
     indexJobsOnly ? ' (index jobs only)' : ''
+  }${
+    skipPrerenderHtmlRealms.length
+      ? `, not spawning prerender_html for ${skipPrerenderHtmlRealms.join(', ')}`
+      : ''
   }`,
 );
 
@@ -216,6 +226,7 @@ let autoMigrate = migrateDB || undefined;
     prerenderer,
     createPrerenderAuth,
     indexJobsOnly,
+    skipPrerenderHtmlRealms: skipPrerenderHtmlRealms.map(String),
     mediaCacheAdapter: createMediaCacheAdapterFromEnv(),
   });
 

--- a/packages/runtime-common/jobs/prerender-html.ts
+++ b/packages/runtime-common/jobs/prerender-html.ts
@@ -212,6 +212,27 @@ export async function publishedHtmlHasCaughtUp(
 // publishes: per-URL update-wins merge, max generation/priority/timeout.
 // Callers fire-and-forget — an index pass must never block on, or fail
 // with, its prerender enqueue; a missed enqueue self-heals on the next pass.
+// Whether `realmURL` is configured to render no HTML.
+//
+// A realm's identity in a job is whichever of its `--fromUrl` / `--toUrl` pair
+// that job carries, and the two are not interchangeable across realms — one
+// bootstrap realm's jobs name its external URL while another's name its source
+// URL. So the configured value has to be written to match, and a trailing
+// slash is the one difference not worth making someone debug.
+//
+// Both the spawn site on a from-scratch index and the reconcile sweep consult
+// this: a realm that renders nothing has every row permanently unrendered, and
+// to the sweep that is indistinguishable from residue worth repairing.
+export function skipsPrerenderHtml(
+  realmURL: string,
+  skipPrerenderHtmlRealms: string[] | undefined,
+): boolean {
+  let normalize = (url: string) => (url.endsWith('/') ? url : `${url}/`);
+  return (skipPrerenderHtmlRealms ?? []).some(
+    (configured) => normalize(configured) === normalize(realmURL),
+  );
+}
+
 export async function enqueuePrerenderHtmlJob(
   queuePublisher: QueuePublisher,
   {

--- a/packages/runtime-common/tasks/index.ts
+++ b/packages/runtime-common/tasks/index.ts
@@ -38,6 +38,10 @@ export interface TaskArgs {
   // The MediaCache's object store. Optional: a worker process without one
   // configured still registers media-cache jobs, whose tasks then no-op.
   mediaCacheAdapter?: MediaCacheAdapter;
+  // Realms whose from-scratch index must not spawn the follow-on
+  // `prerender_html` job. A test harness affordance, empty everywhere else —
+  // see `--skipPrerenderHtmlRealm` in realm-server/worker.ts for what it costs.
+  skipPrerenderHtmlRealms?: string[];
   getReader(fetch: typeof global.fetch, realmURL: string): Reader;
   getAuthedFetch(args: WorkerArgs): Promise<typeof globalThis.fetch>;
   createPrerenderAuth(userId: string, permissions: RealmPermissions): string;

--- a/packages/runtime-common/tasks/indexer.ts
+++ b/packages/runtime-common/tasks/indexer.ts
@@ -340,6 +340,11 @@ registerQueueJobDefinition({
   coalesce: chooseFromScratchCoalesceDecision,
 });
 
+function sameRealm(a: string, b: string): boolean {
+  let normalize = (url: string) => (url.endsWith('/') ? url : `${url}/`);
+  return normalize(a) === normalize(b);
+}
+
 const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
   log,
   reportStatus,
@@ -354,6 +359,7 @@ const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
   virtualNetwork,
   queuePublisher,
   createPrerenderAuth,
+  skipPrerenderHtmlRealms,
 }) =>
   async function (args) {
     let { jobInfo, realmUsername, realmURL } = args;
@@ -385,6 +391,22 @@ const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
       // the prerender enqueue. Fires as soon as the invalidation set is
       // known, so HTML rendering can start concurrently with the pass.
       onInvalidationsReady: ({ changes, generation, loaderEpoch }) => {
+        // Compared with a trailing slash forced on both sides. A realm's
+        // identity here is whichever of its `--fromUrl` / `--toUrl` pair its
+        // jobs carry — skills' index job names `https://…:4205/skills/` while
+        // base's names `https://cardstack.com/base/` — so the value has to be
+        // written to match, and a slash is the one difference not worth making
+        // someone debug.
+        if (skipPrerenderHtmlRealms?.some((url) => sameRealm(url, realmURL))) {
+          // Configured off for this realm. Says so out loud: a realm whose
+          // HTML never renders reads, from every other vantage point, exactly
+          // like one whose render is merely slow.
+          log.info(
+            `${jobIdentity(jobInfo)} not spawning prerender_html for ${realmURL}: ` +
+              `the realm is listed in --skipPrerenderHtmlRealm`,
+          );
+          return;
+        }
         enqueuePrerenderHtmlJob(queuePublisher, {
           realmURL,
           realmUsername,

--- a/packages/runtime-common/tasks/indexer.ts
+++ b/packages/runtime-common/tasks/indexer.ts
@@ -20,7 +20,10 @@ import {
   INCREMENTAL_INDEX_JOB_TIMEOUT_SEC,
   prerenderSpawnedPriority,
 } from '../jobs/indexing.ts';
-import { enqueuePrerenderHtmlJob } from '../jobs/prerender-html.ts';
+import {
+  enqueuePrerenderHtmlJob,
+  skipsPrerenderHtml,
+} from '../jobs/prerender-html.ts';
 import type { Stats, IndexPhaseTimings } from '../worker.ts';
 
 export { fromScratchIndex, incrementalIndex };
@@ -340,11 +343,6 @@ registerQueueJobDefinition({
   coalesce: chooseFromScratchCoalesceDecision,
 });
 
-function sameRealm(a: string, b: string): boolean {
-  let normalize = (url: string) => (url.endsWith('/') ? url : `${url}/`);
-  return normalize(a) === normalize(b);
-}
-
 const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
   log,
   reportStatus,
@@ -391,13 +389,7 @@ const fromScratchIndex: Task<FromScratchArgs, FromScratchResult> = ({
       // the prerender enqueue. Fires as soon as the invalidation set is
       // known, so HTML rendering can start concurrently with the pass.
       onInvalidationsReady: ({ changes, generation, loaderEpoch }) => {
-        // Compared with a trailing slash forced on both sides. A realm's
-        // identity here is whichever of its `--fromUrl` / `--toUrl` pair its
-        // jobs carry — skills' index job names `https://…:4205/skills/` while
-        // base's names `https://cardstack.com/base/` — so the value has to be
-        // written to match, and a slash is the one difference not worth making
-        // someone debug.
-        if (skipPrerenderHtmlRealms?.some((url) => sameRealm(url, realmURL))) {
+        if (skipsPrerenderHtml(realmURL, skipPrerenderHtmlRealms)) {
           // Configured off for this realm. Says so out loud: a realm whose
           // HTML never renders reads, from every other vantage point, exactly
           // like one whose render is merely slow.

--- a/packages/runtime-common/tasks/prerender-html-reconcile.ts
+++ b/packages/runtime-common/tasks/prerender-html-reconcile.ts
@@ -10,7 +10,10 @@ import {
   type QueueCoalesceContext,
   type QueueCoalesceDecision,
 } from '../queue.ts';
-import { enqueuePrerenderHtmlJob } from '../jobs/prerender-html.ts';
+import {
+  enqueuePrerenderHtmlJob,
+  skipsPrerenderHtml,
+} from '../jobs/prerender-html.ts';
 import { FROM_SCRATCH_JOB_TIMEOUT_SEC } from './indexer.ts';
 import {
   fetchRealmGenerations,
@@ -78,7 +81,13 @@ registerQueueJobDefinition({
 const prerenderHtmlReconcile: Task<
   PrerenderHtmlReconcileArgs,
   PrerenderHtmlReconcileResult
-> = ({ dbAdapter, queuePublisher, reportStatus, log }) =>
+> = ({
+  dbAdapter,
+  queuePublisher,
+  reportStatus,
+  log,
+  skipPrerenderHtmlRealms,
+}) =>
   async function (args) {
     let { jobInfo } = args;
     reportStatus(jobInfo, 'start');
@@ -115,6 +124,17 @@ const prerenderHtmlReconcile: Task<
     let urlsEnqueued = 0;
     let realmsInBackoff = 0;
     for (let [realmURL, urls] of plan) {
+      // A realm configured to render no HTML has every row permanently
+      // unrendered, which is indistinguishable here from residue worth
+      // repairing — `ph.url IS NULL` is the first staleness condition. Without
+      // this the sweep would re-enqueue on every tick the very render the
+      // configuration exists to prevent, at whole-realm size.
+      if (skipsPrerenderHtml(realmURL, skipPrerenderHtmlRealms)) {
+        log.debug(
+          `${jobIdentity(jobInfo)} prerender-html reconcile: skipping realm configured not to render: ${realmURL} (${urls.length} unrendered url(s))`,
+        );
+        continue;
+      }
       // Render as the realm's owner, mirroring how an index pass spawns the
       // prerender job. Realms owned only by a bot (`realm/…`) are re-enqueued
       // by the deploy-time from-scratch reindex, so their residue self-heals on

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -161,6 +161,7 @@ export class Worker {
   #reportRealmEvent: ((event: RealmEventContent) => void) | undefined;
   #realmServerMatrixUsername;
   #indexJobsOnly: boolean;
+  #skipPrerenderHtmlRealms: string[];
   #mediaCacheAdapter: MediaCacheAdapter | undefined;
   #createPrerenderAuth: (
     userId: string,
@@ -182,6 +183,7 @@ export class Worker {
     prerenderer,
     createPrerenderAuth,
     indexJobsOnly,
+    skipPrerenderHtmlRealms,
     mediaCacheAdapter,
   }: {
     indexWriter: IndexWriter;
@@ -199,6 +201,7 @@ export class Worker {
     // When true, register handlers only for INDEX_JOB_TYPES so this worker
     // is a dedicated indexing lane — see INDEX_JOB_TYPES above.
     indexJobsOnly?: boolean;
+    skipPrerenderHtmlRealms?: string[];
     // The MediaCache object store, absent when the process has none
     // configured (media-cache tasks then no-op).
     mediaCacheAdapter?: MediaCacheAdapter;
@@ -221,6 +224,7 @@ export class Worker {
     this.#prerenderer = prerenderer;
     this.#createPrerenderAuth = createPrerenderAuth;
     this.#indexJobsOnly = indexJobsOnly ?? false;
+    this.#skipPrerenderHtmlRealms = skipPrerenderHtmlRealms ?? [];
     this.#mediaCacheAdapter = mediaCacheAdapter;
   }
 
@@ -247,6 +251,7 @@ export class Worker {
       reportRealmEvent: this.reportRealmEvent.bind(this),
       createPrerenderAuth: this.#createPrerenderAuth,
       mediaCacheAdapter: this.#mediaCacheAdapter,
+      skipPrerenderHtmlRealms: this.#skipPrerenderHtmlRealms,
     };
 
     let registrations: Record<string, () => Promise<unknown> | unknown> = {


### PR DESCRIPTION
The matrix isolated server cold-boots three realms, and the skills realm's from-scratch index spawns a follow-on prerender_html job covering ~900 files. That render takes about ten minutes — longer than the suite it precedes.

Nothing waits for it. The harness gates on each realm's `_readiness-check`, whose only cross-process check asks whether the `indexing:<realm>` queue lane is clear; the render lives in `prerender-html:<realm>` and is invisible to it. On main run 34247222879 the gate released 77ms after ready and logged the boot index as settled, while skills' render ran from 15:57:24 to 16:07:42 against a test window of 15:58:03 to 16:07:44 — an overlap of 9m39s out of 9m41s. It holds an all-priority worker throughout, competing with the realms the specs create, which is what the publish-wait timeouts in host-mode.spec.ts have been feeling.

This was hidden until base's index moved to the user-initiated tier. Base was previously served by the same pool in arrival order, behind skills' render, so waiting for base incidentally waited for skills as well. The skills gate itself never covered that lane.

Workers gain `--skipPrerenderHtmlRealm`, repeatable, naming realms whose from-scratch index must not spawn the render. It is threaded the way `--indexJobsOnly` already is, and no deployment sets it. The matrix harness sets it for skills.

Skipping rather than waiting is the point: a render that overruns the suite leaves the HTML partly written by an amount that depends on scheduling, so a spec needing a rendered skill card passes or fails on timing. With no render at all it fails every time. The realm is still fully indexed before any spec runs. Base is left alone — its render is far smaller and its cards underpin most rendered surfaces here.

Realm identity in a job is whichever of the `--fromUrl` / `--toUrl` pair it carries, and the two bootstrap realms disagree about which: skills' jobs name `https://localhost:4205/skills/` while base's name `https://cardstack.com/base/`. The comparison forces a trailing slash on both sides, the worker logs the realms it will skip at startup, and the task logs each skip, so a value that matches nothing is visible rather than silently inert.

The readiness gate's comment and log line said "boot index settled" without qualification. Both now say what the gate covers.

CS-12709.