### PR TITLE
Move theme custom CSS variables onto the per-scheme variable field

### DIFF
--- a/packages/base/Theme/boxel-brand-guide.json
+++ b/packages/base/Theme/boxel-brand-guide.json
@@ -127,7 +127,41 @@
         "secondaryForeground": "var(--boxel-light, #FFFFFF)",
         "destructiveForeground": "#F8FAFC",
         "sidebarAccentForeground": "#0F172A",
-        "sidebarPrimaryForeground": "#0F172A"
+        "sidebarPrimaryForeground": "#0F172A",
+        "customCssVariables": [
+          {
+            "name": "sp-1",
+            "value": "var(--spacing)"
+          },
+          {
+            "name": "sp-2",
+            "value": "calc(var(--spacing) * 2)"
+          },
+          {
+            "name": "sp-3",
+            "value": "calc(var(--spacing) * 3)"
+          },
+          {
+            "name": "sp-4",
+            "value": "calc(var(--spacing) * 4)"
+          },
+          {
+            "name": "sp-6",
+            "value": "calc(var(--spacing) * 6)"
+          },
+          {
+            "name": "sp-8",
+            "value": "calc(var(--spacing) * 8)"
+          },
+          {
+            "name": "sp-12",
+            "value": "calc(var(--spacing) * 12)"
+          },
+          {
+            "name": "sp-16",
+            "value": "calc(var(--spacing) * 16)"
+          }
+        ]
       },
       "motionLanguage": "# Animation Physics: Mass Without Bounce\n\n**Elements have weight. Transitions have purpose.**\n\nWhile playful brands embrace elastic easing and overshoot, Box Elements move with industrial precision. Think heavy machinery that's perfectly calibrated\u2014smooth motion, hard stops, no wobble.\n\n## Motion Principles\n\n**1. Parallax Scrolling**  \nAs content scrolls, the background grid moves at 0.5x speed while foreground boxes move at 1x. This subtle depth cue makes flat UI feel spatially aware without requiring shadow-heavy 3D effects.\n\n**2. The Curtain Wipe**  \nPage transitions use solid color blocks (Teal or Lime) that slide up to cover the entire viewport before revealing new content. It's like a film cut, not a fade. This reinforces the Box Element's \"bounded space\" metaphor\u2014the screen itself is just another box.\n\n**3. No Bounce, Ever**  \nEasing functions use `cubic-bezier(0.2, 0, 0.2, 1)` (smooth deceleration to hard stop). No spring physics. No elastic snapback. When a Box Element arrives, it *arrives*. This communicates stability and precision.\n\n**4. Stagger Reveals**  \nWhen multiple boxes appear (e.g., loading a dashboard), they cascade in with 40ms delays between each. Not simultaneous. Not random. Ordered and predictable\u2014like watching a terminal compile output.\n\n**The whimsy:** Motion isn't decoration. It's information about system state. A drawer that slides open tells you where it came from. A box that fades in tells you nothing. Be opinionated about physics.",
       "technicalSpecs": "# Implementation Standards\n\n**How Box Elements get built.**\n\n## Border System\n\n- **Width:** Always `1px`. Never 2px. Never 0.5px.\n- **Color (Light):** `#E2E8F0` (nearly invisible)\n- **Color (Dark):** `#333333` (slightly brighter than container)\n- **Style:** Solid. No dashed, dotted, or gradient borders.\n\n## Border Radius\n\n- **Standard:** `0.625rem` (10px)\n- **Override:** Only for specific micro-components like Data Pills, which may use proportional radius at smaller scales\n- **Sharp corners:** Reserved for deliberate \"raw code\" contexts (e.g., syntax highlighting blocks)\n\n## Grid System\n\n- **Column count:** 12 (fluid)\n- **Gutter:** 24px (3\u00d7 base spacing unit)\n- **Visible grid:** Optional background pattern at `opacity: 0.1`\u20142px dots with 20px spacing\n- **Breakpoints:** 640px \u00b7 768px \u00b7 1024px \u00b7 1280px \u00b7 1536px\n\n## Glassmorphism Effects\n\nFor floating elements that need to maintain context:\n\n```css\nbackdrop-filter: blur(12px);\nbackground: rgba(255, 255, 255, 0.8); /* light mode */\nbackground: rgba(30, 30, 30, 0.8); /* dark mode */\n```\n\nUse sparingly. Primarily for sticky headers and modal overlays where seeing the grid beneath adds clarity.\n\n## Z-Index Hierarchy\n\n- **Base grid:** 0\n- **Box Elements:** 1\n- **Interactive elements (hover):** 2\n- **Floating panels:** 10\n- **Tooltips:** 100\n- **Modals:** 1000\n\nNo arbitrary values. If you need a new layer, define it in the system.\n\n## Shadow Protocol\n\n**Light mode:**  \nMinimal shadows for separation: `0 1px 2px 0 rgb(0 0 0 / 0.05)`\n\n**Dark mode:**  \nAlmost no shadows\u2014rely on luminance contrast instead. If shadow is needed: `0 1px 2px 0 rgb(0 0 0 / 0.5)`\n\n**Spec truth:** If implementation requires documentation longer than the code itself, simplify the system.",
@@ -241,41 +275,7 @@
       "historicalContext": null,
       "materialVocabulary": "# Materiality Without Skeuomorphism\n\n**Digital materials that feel real\u2014not realistic.**\n\nBoxel's material language draws from high-end productivity tools: the textured matte of a Leica camera, the precision of a Muji notebook, the honest surfaces of a ThinkPad keyboard.\n\n## Light Mode: Precision Paper\n\nIn light mode, Box Elements exist on a subtle grey surface (`#F8F7FA`) that mimics premium bond paper under soft office lighting. Shadows are minimal\u2014just enough to separate the white box from the neutral canvas. We're not simulating physical paper; we're capturing the *feeling* of working with quality materials.\n\n**Shadow strategy:** `0 1px 2px 0 rgb(0 0 0 / 0.05)`  \nBarely there. A whisper of separation.\n\n## Dark Mode: Matte Carbon\n\nIn dark mode, we embrace the flat dashboard aesthetic. No heavy shadows\u2014instead, we use **luminance contrast** to define layers. A `#1E1E1E` box on a `#0F0F0F` surface creates separation through brightness, not through simulated lighting.\n\nBorders become slightly *brighter* than their containers (`#333333` on `#1E1E1E`), creating a subtle glow effect that maintains the Box Element's structural legibility in low-light conditions.\n\n**The whimsy:** Dark mode isn't just inverted light mode. It's a different material state\u2014like switching from paper to carbon fiber. Same structural logic, different tactile presence.",
       "componentVocabulary": "# Standard Box Element Patterns\n\n**Reusable primitives for interface composition.**\n\n## The Mini-Card\n\nA compact Box Element (typically 240\u00d7120px) that displays a single data entity: a file, a transaction, a user, a metric. Contains:\n\n- **Corner label** (Mono, uppercase): Entity type or ID\n- **Primary content** (Sans, medium): The key value or name\n- **Metadata strip** (Mono, muted): Timestamp, status, or secondary info\n\nUse case: Dashboard tiles, file browsers, transaction logs.\n\n## The Toolbar\n\nA horizontal strip of square interaction boxes (32\u00d732px minimum). Each button is its own Box Element with a 1px border. No background fill on default state\u2014fill with Teal on hover, Lime on active.\n\nButtons sit edge-to-edge with no gap, creating a continuous bar. Think: the ribbon interface from Office, but with personality.\n\n## The Data Pill\n\nA tiny rounded tag (height: 20px, padding: 4px 8px) using Mono font. Border radius matches the base `0.625rem` but at smaller scale looks more pill-like. Used for status indicators (`ACTIVE`, `PENDING`), categories, or filter chips.\n\nKey distinction: Pills are *inline* elements. They live within other boxes, not as standalone containers.\n\n## The Splitter\n\nA draggable 1px border between two Box Elements that lets users resize their workspace. On hover, expands to 3px and shifts to Teal. Cursor becomes `col-resize` or `row-resize`.\n\nThis component makes the Box Element's promise literal: users can reshape the boundaries of their interface.\n\n**Component truth:** Every UI element should be composable. If you can't nest it or arrange it in a grid, it's not a Box Element\u2014it's an exception. Minimize exceptions.",
-      "applicationScenarios": "# Context-Specific Box Element Usage\n\n**Same primitives, different densities.**\n\n## Complex Dashboards\n\n**Goal:** Display hundreds of data points without overwhelming cognition.\n\n**Strategy:**  \n- Use Mini-Cards in masonry grids (irregular heights OK, but snap to the 4px grid)\n- Mono font for all metadata\u2014creates scannable rhythm\n- Compact spacing (`0.5rem` gaps between boxes)\n- Corner labels for quick entity identification\n- Color only for status (Teal = selected, Lime = accent/highlight, Red = error)\n\n**Result:** Information density that feels organized, not chaotic. Think Bloomberg Terminal meets Apple Notes.\n\n## Code/Logic Editors\n\n**Goal:** Make complex logic visually parseable.\n\n**Strategy:**  \n- Dark mode default (reduces eye strain during long sessions)\n- Syntax highlighting using brand colors: Teal for functions, Lime for strings, Purple for keywords\n- Visible 1px borders between code blocks\n- Line numbers in Mono font along left gutter\n- Box Elements for each function/class definition\n\n**Result:** Code becomes modular and visual. New developers can understand structure at a glance.\n\n## Mobile Interfaces\n\n**Goal:** Maintain Box Element logic on small screens.\n\n**Strategy:**  \n- Collapse multi-column grids to single column\n- Maintain 1px borders and `0.625rem` radius (looks great even at phone scale)\n- Full-width Box Elements (edge-to-edge within safe area)\n- Increase tap target size to 44px minimum while keeping visual element compact inside\n- Stackable panels with Splitters for user-controlled density\n\n**Result:** Mobile doesn't feel like a compromised desktop. It feels like a *touch-optimized Box Element system*.\n\n**Scenario truth:** If your design system breaks when you change screen size or use case, it's not a system\u2014it's a collection of one-off solutions. Box Elements scale because their rules scale.",
-      "customCssVariables": [
-        {
-          "name": "sp-1",
-          "value": "var(--spacing)"
-        },
-        {
-          "name": "sp-2",
-          "value": "calc(var(--spacing) * 2)"
-        },
-        {
-          "name": "sp-3",
-          "value": "calc(var(--spacing) * 3)"
-        },
-        {
-          "name": "sp-4",
-          "value": "calc(var(--spacing) * 4)"
-        },
-        {
-          "name": "sp-6",
-          "value": "calc(var(--spacing) * 6)"
-        },
-        {
-          "name": "sp-8",
-          "value": "calc(var(--spacing) * 8)"
-        },
-        {
-          "name": "sp-12",
-          "value": "calc(var(--spacing) * 12)"
-        },
-        {
-          "name": "sp-16",
-          "value": "calc(var(--spacing) * 16)"
-        }
-      ]
+      "applicationScenarios": "# Context-Specific Box Element Usage\n\n**Same primitives, different densities.**\n\n## Complex Dashboards\n\n**Goal:** Display hundreds of data points without overwhelming cognition.\n\n**Strategy:**  \n- Use Mini-Cards in masonry grids (irregular heights OK, but snap to the 4px grid)\n- Mono font for all metadata\u2014creates scannable rhythm\n- Compact spacing (`0.5rem` gaps between boxes)\n- Corner labels for quick entity identification\n- Color only for status (Teal = selected, Lime = accent/highlight, Red = error)\n\n**Result:** Information density that feels organized, not chaotic. Think Bloomberg Terminal meets Apple Notes.\n\n## Code/Logic Editors\n\n**Goal:** Make complex logic visually parseable.\n\n**Strategy:**  \n- Dark mode default (reduces eye strain during long sessions)\n- Syntax highlighting using brand colors: Teal for functions, Lime for strings, Purple for keywords\n- Visible 1px borders between code blocks\n- Line numbers in Mono font along left gutter\n- Box Elements for each function/class definition\n\n**Result:** Code becomes modular and visual. New developers can understand structure at a glance.\n\n## Mobile Interfaces\n\n**Goal:** Maintain Box Element logic on small screens.\n\n**Strategy:**  \n- Collapse multi-column grids to single column\n- Maintain 1px borders and `0.625rem` radius (looks great even at phone scale)\n- Full-width Box Elements (edge-to-edge within safe area)\n- Increase tap target size to 44px minimum while keeping visual element compact inside\n- Stackable panels with Splitters for user-controlled density\n\n**Result:** Mobile doesn't feel like a compromised desktop. It feels like a *touch-optimized Box Element system*.\n\n**Scenario truth:** If your design system breaks when you change screen size or use case, it's not a system\u2014it's a collection of one-off solutions. Box Elements scale because their rules scale."
     }
   }
 }

--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -31,6 +31,7 @@ import {
   sanitizeHtmlSafe,
   eq,
   CssVariableEntry,
+  type CssRuleMap,
 } from '@cardstack/boxel-ui/helpers';
 
 import { cardTypeDisplayName } from '@cardstack/runtime-common';
@@ -54,6 +55,10 @@ import {
   ResetButton,
   ThemeDashboardEmptyState,
 } from './default-templates/theme-dashboard';
+
+// `customCssVariables` lives on ThemeVarField, one list per color scheme;
+// re-exported for cards that import it from the brand guide.
+export { CustomCssVariable } from './structured-theme-variables';
 
 const sharedBrandVarsMap: Record<string, string> = {
   '--primary': '--brand-primary',
@@ -438,76 +443,70 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
                     </div>
                   {{/if}}
                 {{else if (eq section.id 'custom-css')}}
-                  {{#if this.editMode}}
-                    <@fields.customCssVariables />
-                  {{else}}
-                    <p class='brand-guide-vars-description'>These variables are
-                      all of the custom CSS properties for usage by this theme
-                      only.</p>
-                    <div
-                      class='brand-guide-vars-box brand-guide-custom-css-block'
-                    >
-                      <CopyButton
-                        class='brand-guide-custom-css-block-copy-button'
-                        @textToCopy={{this.customCssVarsBlock}}
-                      />
-                      <dl class='brand-guide-vars'>
-                        {{#each this.paletteVarEntries as |entry|}}
-                          <dt class='var-row' data-test-brand-guide-palette-var>
-                            <code
-                              data-test-brand-guide-palette-var-name
-                            >{{entry.varName}}</code>
-                          </dt>
-                          <dd
-                            class='color-entry var-row'
-                            data-test-brand-guide-palette-swatch
-                          >
-                            <Swatch
-                              class='color-swatch-mini'
-                              @color={{entry.color.value}}
-                              @style='round'
-                            />
-                          </dd>
-                        {{/each}}
-                        {{#each this.customCssVarEntries as |entry|}}
-                          <dt class='var-row' data-test-brand-guide-css-var>
-                            <code
-                              data-test-brand-guide-css-var-name
-                            >{{entry.name}}</code>
-                          </dt>
-                          <dd class='var-row'>
-                            <code
-                              class='css-var-value'
-                              data-test-brand-guide-css-var-value
-                            >{{entry.value}}</code>
-                          </dd>
-                        {{/each}}
-                        {{#each this.brandImageAttachmentVarEntries as |entry|}}
-                          <dt
-                            class='var-row'
-                            data-test-brand-guide-image-attachment-var
-                          >
-                            <code
-                              data-test-brand-guide-image-attachment-varname
-                            >{{entry.varName}}</code>
-                          </dt>
-                          <dd
-                            class='var-row brand-image-attachment-var-dd'
-                            data-test-brand-guide-image-attachment-url
-                          >
-                            <img
-                              src={{entry.url}}
-                              alt={{entry.altText}}
-                              class='brand-image-attachment-thumb-mini'
-                            />
-                            <code
-                              class='css-var-value'
-                            >url({{entry.url}})</code>
-                          </dd>
-                        {{/each}}
-                      </dl>
-                    </div>
-                  {{/if}}
+                  <p class='brand-guide-vars-description'>These variables are
+                    all of the custom CSS properties for usage by this theme
+                    only.</p>
+                  <div
+                    class='brand-guide-vars-box brand-guide-custom-css-block'
+                  >
+                    <CopyButton
+                      class='brand-guide-custom-css-block-copy-button'
+                      @textToCopy={{this.customCssVarsBlock}}
+                    />
+                    <dl class='brand-guide-vars'>
+                      {{#each this.paletteVarEntries as |entry|}}
+                        <dt class='var-row' data-test-brand-guide-palette-var>
+                          <code
+                            data-test-brand-guide-palette-var-name
+                          >{{entry.varName}}</code>
+                        </dt>
+                        <dd
+                          class='color-entry var-row'
+                          data-test-brand-guide-palette-swatch
+                        >
+                          <Swatch
+                            class='color-swatch-mini'
+                            @color={{entry.color.value}}
+                            @style='round'
+                          />
+                        </dd>
+                      {{/each}}
+                      {{#each this.customCssVarEntries as |entry|}}
+                        <dt class='var-row' data-test-brand-guide-css-var>
+                          <code
+                            data-test-brand-guide-css-var-name
+                          >{{entry.name}}</code>
+                        </dt>
+                        <dd class='var-row'>
+                          <code
+                            class='css-var-value'
+                            data-test-brand-guide-css-var-value
+                          >{{entry.value}}</code>
+                        </dd>
+                      {{/each}}
+                      {{#each this.brandImageAttachmentVarEntries as |entry|}}
+                        <dt
+                          class='var-row'
+                          data-test-brand-guide-image-attachment-var
+                        >
+                          <code
+                            data-test-brand-guide-image-attachment-varname
+                          >{{entry.varName}}</code>
+                        </dt>
+                        <dd
+                          class='var-row brand-image-attachment-var-dd'
+                          data-test-brand-guide-image-attachment-url
+                        >
+                          <img
+                            src={{entry.url}}
+                            alt={{entry.altText}}
+                            class='brand-image-attachment-thumb-mini'
+                          />
+                          <code class='css-var-value'>url({{entry.url}})</code>
+                        </dd>
+                      {{/each}}
+                    </dl>
+                  </div>
                 {{else if (eq section.id 'import-css')}}
                   {{! the cardInfo editor in the header owns the name and
                   description, so the importer only handles CSS here }}
@@ -977,16 +976,19 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
   ];
 
   private get sectionsWithContent() {
-    // the Card Container CSS reference and the UI component samples are
-    // display-only, so they stay out of the editor; every other field is
-    // editable whether or not it has content
+    // the Card Container CSS reference, the UI component samples, the fonts
+    // reference and the custom CSS listing are display-only, so they stay out
+    // of the editor — custom variables are edited in the variable block they
+    // belong to, under Brand Palette; every other field is editable whether or
+    // not it has content
     if (this.editMode) {
       return orderEditSections(
         this.sections.filter(
           (section) =>
             section.id !== 'card-container-css' &&
             section.id !== 'ui-components' &&
-            section.id !== 'fonts',
+            section.id !== 'fonts' &&
+            section.id !== 'custom-css',
         ),
         this.hasThemeCss,
       );
@@ -1101,15 +1103,26 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
     return lines.join('\n');
   }
 
+  // The listing shows what the previewed scheme actually resolves to: dark
+  // mode inherits every light-mode token it does not itself override, the
+  // same way the generated `:root` / `.dark` blocks cascade.
   private get customCssVarEntries() {
-    if (!entriesToCssRuleMap || !this.args.model?.customCssVariables?.length) {
-      return [];
+    let rules = this.customCssRulesFor(this.isDarkMode);
+    return [...rules.entries()].map(([name, value]) => ({ name, value }));
+  }
+
+  private customCssRulesFor(isDarkMode: boolean): CssRuleMap {
+    let rules: CssRuleMap = new Map(
+      this.args.model?.rootVariables?.customCssRuleMap,
+    );
+    if (!isDarkMode) {
+      return rules;
     }
-    let rules = entriesToCssRuleMap(this.args.model?.customCssVariables);
-    return [...rules.entries()].map(([name, value]) => ({
-      name: buildCssVariableName(name),
-      value,
-    }));
+    for (let [name, value] of this.args.model?.darkModeVariables
+      ?.customCssRuleMap ?? []) {
+      rules.set(name, value);
+    }
+    return rules;
   }
 
   private get brandImageAttachmentVarEntries() {
@@ -1123,10 +1136,12 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
   }
 
   private get hasCustomVariables() {
-    // unnamed palette entries emit no variables, so they must not count
+    // unnamed palette entries emit no variables, so they must not count;
+    // a token defined in either color scheme gives the section content, so
+    // toggling the preview mode never makes it appear or disappear
     return Boolean(
       this.paletteVarEntries.length ||
-      this.customCssVarEntries.length ||
+      this.customCssRulesFor(true).size ||
       this.brandImageAttachmentVarEntries.length,
     );
   }
@@ -1192,32 +1207,6 @@ export class CompoundColorField extends FieldDef {
       </div>
       <style scoped>
         .compound-color-edit {
-          display: grid;
-          grid-template-columns: 1fr 1fr;
-          gap: var(--boxel-sp-sm);
-        }
-      </style>
-    </template>
-  };
-}
-
-export class CustomCssVariable extends FieldDef {
-  static displayName = 'Custom CSS Variable';
-  @field name = contains(StringField);
-  @field value = contains(StringField);
-
-  static edit = class Edit extends Component<typeof this> {
-    <template>
-      <div class='custom-css-variable-edit'>
-        <FieldContainer @label='Variable Name' @vertical={{true}}>
-          <@fields.name />
-        </FieldContainer>
-        <FieldContainer @label='Value' @vertical={{true}}>
-          <@fields.value />
-        </FieldContainer>
-      </div>
-      <style scoped>
-        .custom-css-variable-edit {
           display: grid;
           grid-template-columns: 1fr 1fr;
           gap: var(--boxel-sp-sm);
@@ -1368,15 +1357,6 @@ export default class BrandGuide extends DetailedStyleRef {
       if (!brandRules.has(varName)) brandRules.set(varName, `url(${url})`);
     }
 
-    // add custom CSS variables
-    for (let cssVar of this.customCssVariables ?? []) {
-      let name = cssVar.name?.trim();
-      let value = cssVar.value?.trim();
-      if (!name || !value) continue;
-      let varName = buildCssVariableName(name);
-      if (!brandRules.has(varName)) brandRules.set(varName, value);
-    }
-
     if (!brandRules.size) {
       return;
     }
@@ -1447,12 +1427,6 @@ export default class BrandGuide extends DetailedStyleRef {
   @field typography = contains(ThemeTypographyField);
   @field markUsage = contains(BrandLogo);
   @field brandImageAttachments = containsMany(CompoundImageField);
-  @field customCssVariables = containsMany(CustomCssVariable);
-
-  protected resetCssFields() {
-    super.resetCssFields();
-    this.customCssVariables = [];
-  }
 
   // CSS Variables computed from field entries
   @field cssVariables = contains(CSSField, {

--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -41,7 +41,11 @@ import BrandFunctionalPalette, {
 } from './brand-functional-palette';
 import BrandLogo from './brand-logo';
 import { mergeRuleMaps, orderEditSections } from './structured-theme';
-import { ThemeTypographyField } from './structured-theme-variables';
+import {
+  CustomCssVariable,
+  ThemeTypographyField,
+  customCssRuleMapFor,
+} from './structured-theme-variables';
 import DetailedStyleRef from './detailed-style-reference';
 import {
   ThemeDashboard,
@@ -58,7 +62,7 @@ import {
 
 // `customCssVariables` lives on ThemeVarField, one list per color scheme;
 // re-exported for cards that import it from the brand guide.
-export { CustomCssVariable } from './structured-theme-variables';
+export { CustomCssVariable };
 
 const sharedBrandVarsMap: Record<string, string> = {
   '--primary': '--brand-primary',
@@ -1112,9 +1116,11 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
   }
 
   private customCssRulesFor(isDarkMode: boolean): CssRuleMap {
-    let rules: CssRuleMap = new Map(
-      this.args.model?.rootVariables?.customCssRuleMap,
-    );
+    let rules: CssRuleMap = new Map(this.args.model?.legacyCustomCssRuleMap);
+    for (let [name, value] of this.args.model?.rootVariables
+      ?.customCssRuleMap ?? []) {
+      rules.set(name, value);
+    }
     if (!isDarkMode) {
       return rules;
     }
@@ -1427,6 +1433,29 @@ export default class BrandGuide extends DetailedStyleRef {
   @field typography = contains(ThemeTypographyField);
   @field markUsage = contains(BrandLogo);
   @field brandImageAttachments = containsMany(CompoundImageField);
+  // Superseded by the per-scheme lists on `rootVariables` and
+  // `darkModeVariables`. Declared so a document written against the card-level
+  // list keeps its tokens: card-api drops an attribute with no matching field
+  // when deserializing, which would erase them from the document on its next
+  // save. Remove once no realm holds a brand guide carrying this attribute.
+  @field customCssVariables = containsMany(CustomCssVariable, {
+    description:
+      'Superseded by `customCssVariables` on `rootVariables` and `darkModeVariables`, where a token can differ per color scheme. Read for existing documents only; enter new tokens on the variable block.',
+  });
+
+  // Read as light-mode tokens, from where they cascade into dark mode. They
+  // are never merged into the dark block, so a legacy token cannot overwrite
+  // a value the dark block computes for itself.
+  get legacyCustomCssRuleMap(): CssRuleMap | undefined {
+    return customCssRuleMapFor(this.customCssVariables);
+  }
+
+  protected resetCssFields() {
+    super.resetCssFields();
+    if (this.customCssVariables?.length) {
+      this.customCssVariables = [];
+    }
+  }
 
   // CSS Variables computed from field entries
   @field cssVariables = contains(CSSField, {
@@ -1498,6 +1527,7 @@ export default class BrandGuide extends DetailedStyleRef {
         ].filter(([, v]) => v) as [string, string][],
       );
       let rootRules = mergeRuleMaps(
+        this.legacyCustomCssRuleMap,
         this.calculatedRules(),
         brandRules,
         rootMarkAliases,

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -1004,6 +1004,25 @@ export class CustomCssVariable extends FieldDef {
   };
 }
 
+// Names are dasherized so `motionFast` and `motion-fast` land on the same
+// variable, matching how the declared fields derive their names.
+export function customCssRuleMapFor(
+  entries?: CustomCssVariable[] | null,
+): CssRuleMap | undefined {
+  if (!entriesToCssRuleMap || !entries?.length) {
+    return;
+  }
+  let rules: CssRuleMap = new Map();
+  for (let [name, value] of entriesToCssRuleMap(entries).entries()) {
+    let variableName = buildCssVariableName(name);
+    if (!variableName) {
+      continue;
+    }
+    rules.set(variableName, value);
+  }
+  return rules.size ? rules : undefined;
+}
+
 export default class ThemeVarField extends FieldDef {
   static displayName = 'Structured Theme Variables';
 
@@ -1517,23 +1536,8 @@ export default class ThemeVarField extends FieldDef {
     ];
   }
 
-  // Names are dasherized so `motionFast` and `motion-fast` land on the same
-  // variable, matching how the declared fields derive their names.
   get customCssRuleMap(): CssRuleMap | undefined {
-    if (!entriesToCssRuleMap || !this.customCssVariables?.length) {
-      return;
-    }
-    let rules: CssRuleMap = new Map();
-    for (let [name, value] of entriesToCssRuleMap(
-      this.customCssVariables,
-    ).entries()) {
-      let variableName = buildCssVariableName(name);
-      if (!variableName) {
-        continue;
-      }
-      rules.set(variableName, value);
-    }
-    return rules.size ? rules : undefined;
+    return customCssRuleMapFor(this.customCssVariables);
   }
 
   get cssRuleMap(): CssRuleMap | undefined {

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -1,18 +1,25 @@
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
 import { schedule } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 import { modifier } from 'ember-modifier';
 
 import {
+  BoxelInput,
+  Button,
   CopyButton,
   FieldContainer,
+  IconButton,
   Pill,
   Swatch,
   Tooltip,
 } from '@cardstack/boxel-ui/components';
+import { IconPlus, IconTrash } from '@cardstack/boxel-ui/icons';
 import {
   buildCssVariableName,
   entriesToCssRuleMap,
   markdownEscape,
+  not,
   sanitizeHtmlSafe,
   type CssVariableEntry,
   type CssRuleMap,
@@ -21,6 +28,7 @@ import {
 import {
   field,
   contains,
+  containsMany,
   Component,
   FieldDef,
   getFields,
@@ -28,6 +36,8 @@ import {
   type BaseDefComponent,
   type BoxComponent,
 } from './card-api';
+
+import { PermissionsConsumer } from './field-component';
 
 import ColorField from './color';
 import CSSValueField from './css-value';
@@ -48,6 +58,9 @@ const COLOR_VALUE_INPUT_HELP =
   'Use CSS color values such as hex (#ff00ff), rgb(...), hsl(...), or okhcl(...).';
 
 export const DEFAULT_THEME_SCALE = '1.333';
+
+// ThemeVarField fields that do not each stand for one CSS variable
+const NON_VARIABLE_FIELDS = ['customCssVariables'];
 
 const TYPESCALE_OPTIONS = [
   { value: '1.067', label: 'Minor Second (1.067)' },
@@ -589,6 +602,20 @@ export class FontPreviews extends GlimmerComponent<{
 }
 
 class Embedded extends Component<typeof ThemeVarField> {
+  // The contract tokens render as swatches from `fieldGroups`; a theme's own
+  // tokens hold arbitrary values, so they are listed as name/value text.
+  private get customVariables() {
+    return [...(this.args.model?.customCssRuleMap?.entries() ?? [])].map(
+      ([name, value]) => ({ name, value }),
+    );
+  }
+
+  private get customVariablesCssBlock() {
+    return this.customVariables
+      .map(({ name, value }) => `${name}: ${value};`)
+      .join('\n');
+  }
+
   <template>
     {{#each @model.fieldGroups as |group|}}
       <h4 class='field-group-title'>{{group.title}}</h4>
@@ -597,8 +624,89 @@ class Embedded extends Component<typeof ThemeVarField> {
       {{/if}}
       <FieldGrid class='field-group-grid' @fields={{group.fields}} />
     {{/each}}
+    {{#if this.customVariables.length}}
+      <section class='theme-custom-vars' data-test-theme-custom-vars-list>
+        <h4 class='field-group-title'>Custom Variables</h4>
+        <p class='field-group-description'>The CSS properties this theme defines
+          itself, beyond the contract tokens above.</p>
+        <div class='theme-custom-vars-box'>
+          <CopyButton
+            class='theme-custom-vars-copy-button'
+            @textToCopy={{this.customVariablesCssBlock}}
+          />
+          <dl class='theme-custom-vars-list'>
+            {{#each this.customVariables as |entry|}}
+              <dt class='theme-custom-var-row' data-test-theme-custom-var>
+                <code data-test-theme-custom-var-name>{{entry.name}}</code>
+              </dt>
+              <dd class='theme-custom-var-row'>
+                <code
+                  class='theme-custom-var-value'
+                  data-test-theme-custom-var-value
+                >{{entry.value}}</code>
+              </dd>
+            {{/each}}
+          </dl>
+        </div>
+      </section>
+    {{/if}}
     <style scoped>
       @layer baseComponent {
+        .theme-custom-vars {
+          /* own container so the stacked layout keys off this list's width */
+          container: theme-custom-vars / inline-size;
+          margin-bottom: var(--boxel-sp-2xl);
+        }
+        .theme-custom-vars-box {
+          position: relative;
+          background-color: var(--card);
+          color: var(--card-foreground);
+          border: 1px solid var(--border);
+          border-radius: var(--boxel-border-radius);
+          padding: var(--boxel-sp);
+        }
+        .theme-custom-vars-copy-button {
+          position: absolute;
+          top: var(--boxel-sp-xs);
+          right: var(--boxel-sp-xs);
+        }
+        .theme-custom-vars-list {
+          display: grid;
+          grid-template-columns: max-content 1fr;
+          gap: var(--boxel-sp-xs) var(--boxel-sp-lg);
+          margin: 0;
+          font-size: var(--boxel-font-size-sm);
+        }
+        @container theme-custom-vars (width <= 400px) {
+          /* stack the name over its value so long names do not overflow */
+          .theme-custom-vars-list {
+            grid-template-columns: 1fr;
+          }
+        }
+        .theme-custom-vars-list dt {
+          font-weight: 600;
+        }
+        .theme-custom-vars-list dd {
+          margin: 0;
+          min-width: 0;
+        }
+        .theme-custom-var-row {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: var(--boxel-sp-xs);
+          min-width: 0;
+        }
+        .theme-custom-vars-list code {
+          font-family: var(
+            --font-mono,
+            var(--boxel-monospace-font-family, monospace)
+          );
+          font-size: 0.9em;
+        }
+        .theme-custom-var-value {
+          color: var(--muted-foreground);
+        }
         .field-group-title {
           margin-block: var(--boxel-sp);
           color: var(--muted-foreground);
@@ -865,6 +973,35 @@ class FieldGrid extends GlimmerComponent<{
       }
     </style>
   </template>
+}
+
+// A theme's own token (e.g. a motion or shape constant) that has no declared
+// field on ThemeVarField. It stays out of `cssVariableFields`, so the
+// declared-field machinery never sees it, and is emitted via `cssRuleMap`.
+export class CustomCssVariable extends FieldDef {
+  static displayName = 'Custom CSS Variable';
+  @field name = contains(StringField);
+  @field value = contains(StringField);
+
+  static edit = class Edit extends Component<typeof this> {
+    <template>
+      <div class='custom-css-variable-edit'>
+        <FieldContainer @label='Variable Name' @vertical={{true}}>
+          <@fields.name />
+        </FieldContainer>
+        <FieldContainer @label='Value' @vertical={{true}}>
+          <@fields.value />
+        </FieldContainer>
+      </div>
+      <style scoped>
+        .custom-css-variable-edit {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: var(--boxel-sp-sm);
+        }
+      </style>
+    </template>
+  };
 }
 
 export default class ThemeVarField extends FieldDef {
@@ -1212,14 +1349,23 @@ export default class ThemeVarField extends FieldDef {
   @field shadowInset = contains(CSSValueField, {
     description: 'Inset shadow for sunken wells and inputs.',
   });
+  @field customCssVariables = containsMany(CustomCssVariable, {
+    description:
+      "The theme's own CSS variables, for tokens that have no declared field (e.g. motion and shape constants). Each color scheme carries its own list, so a token whose value is the same in both belongs in the light-mode list alone, from where it cascades into dark mode.",
+  });
 
+  // Only the declared variable fields: `customCssVariables` is a list of
+  // name/value pairs rather than a single variable, so it is excluded here and
+  // handled by `customCssRuleMap`.
   get cssVariableFields(): CssVariableFieldEntry[] | undefined {
     let fields = getFields(this);
     if (!fields) {
       return;
     }
 
-    let fieldNames = Object.keys(fields)?.sort();
+    let fieldNames = Object.keys(fields)
+      ?.filter((fieldName) => !NON_VARIABLE_FIELDS.includes(fieldName))
+      ?.sort();
     if (!fieldNames?.length) {
       return;
     }
@@ -1371,11 +1517,39 @@ export default class ThemeVarField extends FieldDef {
     ];
   }
 
+  // Names are dasherized so `motionFast` and `motion-fast` land on the same
+  // variable, matching how the declared fields derive their names.
+  get customCssRuleMap(): CssRuleMap | undefined {
+    if (!entriesToCssRuleMap || !this.customCssVariables?.length) {
+      return;
+    }
+    let rules: CssRuleMap = new Map();
+    for (let [name, value] of entriesToCssRuleMap(
+      this.customCssVariables,
+    ).entries()) {
+      let variableName = buildCssVariableName(name);
+      if (!variableName) {
+        continue;
+      }
+      rules.set(variableName, value);
+    }
+    return rules.size ? rules : undefined;
+  }
+
   get cssRuleMap(): CssRuleMap | undefined {
     if (!entriesToCssRuleMap) {
       return;
     }
-    return entriesToCssRuleMap(this.cssVariableFields);
+    let rules = entriesToCssRuleMap(this.cssVariableFields);
+    // a declared field wins a name collision: it is the structured value the
+    // rest of the theme machinery reads
+    for (let [name, value] of this.customCssRuleMap?.entries() ?? []) {
+      if (rules.has(name)) {
+        continue;
+      }
+      rules.set(name, value);
+    }
+    return rules;
   }
 
   static edit = class Edit extends Component<typeof ThemeVarField> {
@@ -1428,6 +1602,27 @@ export default class ThemeVarField extends FieldDef {
         { label: 'Inset', value: m.shadowInset },
       ].filter((s) => s.value);
     }
+
+    private setName = (entry: CustomCssVariable, name: string) => {
+      entry.name = name;
+    };
+
+    private setValue = (entry: CustomCssVariable, value: string) => {
+      entry.value = value;
+    };
+
+    private addVariable = () => {
+      this.args.model.customCssVariables = [
+        ...(this.args.model.customCssVariables ?? []),
+        new CustomCssVariable(),
+      ];
+    };
+
+    private removeVariable = (entry: CustomCssVariable) => {
+      this.args.model.customCssVariables = (
+        this.args.model.customCssVariables ?? []
+      ).filter((candidate) => candidate !== entry);
+    };
 
     private get fontStack() {
       if (!this.args.model) {
@@ -2236,6 +2431,68 @@ export default class ThemeVarField extends FieldDef {
             </FieldContainer>
           </div>
         </section>
+
+        <section class='theme-var-edit-section' data-test-theme-custom-vars>
+          <h4 class='theme-var-edit-heading'>Custom Variables</h4>
+          <p class='theme-var-edit-hint'>
+            Tokens this theme defines itself, such as motion and shape
+            constants. A value entered here applies to this color scheme only; a
+            token whose value is the same in both belongs in the light-mode list
+            alone, from where it cascades into dark mode.
+          </p>
+          {{! a plural field nested in another field gets no built-in editor
+            (see contains-many-component's shouldRenderEditor), so the rows are
+            ours to render }}
+          <PermissionsConsumer as |permissions|>
+            {{#if @model.customCssVariables.length}}
+              <ul class='theme-var-custom-list'>
+                {{#each @model.customCssVariables as |entry index|}}
+                  <li class='theme-var-custom-row'>
+                    <FieldContainer @label='Variable Name' @vertical={{true}}>
+                      <BoxelInput
+                        @value={{entry.name}}
+                        @onInput={{fn this.setName entry}}
+                        @disabled={{not permissions.canWrite}}
+                        data-test-custom-css-variable-name={{index}}
+                      />
+                    </FieldContainer>
+                    <FieldContainer @label='Value' @vertical={{true}}>
+                      <BoxelInput
+                        @value={{entry.value}}
+                        @onInput={{fn this.setValue entry}}
+                        @disabled={{not permissions.canWrite}}
+                        data-test-custom-css-variable-value={{index}}
+                      />
+                    </FieldContainer>
+                    {{#if permissions.canWrite}}
+                      <IconButton
+                        @icon={{IconTrash}}
+                        @width='18'
+                        @height='18'
+                        class='theme-var-custom-remove'
+                        aria-label='Remove custom variable'
+                        {{on 'click' (fn this.removeVariable entry)}}
+                        data-test-remove-custom-css-variable={{index}}
+                      />
+                    {{/if}}
+                  </li>
+                {{/each}}
+              </ul>
+            {{/if}}
+            {{#if permissions.canWrite}}
+              <Button
+                class='theme-var-custom-add'
+                @kind='secondary'
+                @size='small'
+                {{on 'click' this.addVariable}}
+                data-test-add-custom-css-variable
+              >
+                <IconPlus width='12' height='12' role='presentation' />
+                Add Variable
+              </Button>
+            {{/if}}
+          </PermissionsConsumer>
+        </section>
       </div>
       <style scoped>
         .theme-var-edit {
@@ -2280,6 +2537,30 @@ export default class ThemeVarField extends FieldDef {
           margin: 0;
           font-size: var(--boxel-font-size-sm);
           color: var(--muted-foreground, var(--boxel-400));
+        }
+        .theme-var-custom-list {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+        }
+        .theme-var-custom-row {
+          display: grid;
+          grid-template-columns: 1fr 1fr auto;
+          align-items: end;
+          gap: var(--boxel-sp-sm);
+        }
+        .theme-var-custom-remove {
+          --icon-color: var(--muted-foreground, var(--boxel-400));
+          margin-bottom: var(--boxel-sp-5xs);
+        }
+        .theme-var-custom-add {
+          align-self: start;
+          display: inline-flex;
+          align-items: center;
+          gap: var(--boxel-sp-4xs);
         }
         .theme-var-typescale-preview {
           display: flex;
@@ -2347,22 +2628,18 @@ export default class ThemeVarField extends FieldDef {
   static embedded: BaseDefComponent = Embedded;
 
   // CS-10787: emit a bulleted list of populated CSS variables — each entry
-  // is the CSS variable name paired with its value in inline code. Empty
-  // slots are skipped.
+  // is the CSS variable name paired with its value in inline code. Reads the
+  // rule map rather than the declared fields, so the theme's own custom tokens
+  // are summarized too; empty slots normalize away.
   static markdown = class Markdown extends Component<typeof ThemeVarField> {
     get text() {
-      let model = this.args.model;
-      if (!model) {
-        return '';
-      }
-      let entries = model.cssVariableFields ?? [];
-      if (!entries.length) {
+      let rules = this.args.model?.cssRuleMap;
+      if (!rules?.size) {
         return '';
       }
       let rows: string[] = [];
-      for (let { name, value } of entries) {
-        if (!value) continue;
-        rows.push(`- ${markdownEscape(name ?? '')}: \`${value}\``);
+      for (let [name, value] of rules.entries()) {
+        rows.push(`- ${markdownEscape(name)}: \`${value}\``);
       }
       return rows.join('\n');
     }

--- a/packages/base/structured-theme.gts
+++ b/packages/base/structured-theme.gts
@@ -9,6 +9,7 @@ import {
 import {
   eq,
   buildCssGroups,
+  buildCssVariableName,
   generateCssVariables,
   googleFontImportsFor,
   parseCssGroups,
@@ -29,6 +30,7 @@ import {
   type BaseDefComponent,
 } from './card-api';
 import ThemeVarField, {
+  CustomCssVariable,
   ThemeTypographyField,
 } from './structured-theme-variables';
 import {
@@ -96,7 +98,10 @@ export const withPreviewNavSection = (
   return [{ id: 'preview', navTitle: 'Preview' }, ...sections];
 };
 
-// Applies parsed CSS rules back onto the card fields for editing.
+// Applies parsed CSS rules back onto the card fields for editing. A property
+// with no declared field is kept as a custom variable rather than dropped:
+// the theme's CSS export emits those, so discarding them on import would lose
+// a token on every round trip.
 export const applyCssRulesToField = (
   field: ThemeVarField | undefined,
   rules: CssRuleMap | undefined,
@@ -111,17 +116,45 @@ export const applyCssRulesToField = (
   const lookup = new Map<string, string>(
     cssFields.map((f) => [f.cssVariableName, f.fieldName]),
   );
+  const custom = [...(field.customCssVariables ?? [])];
+  const customIndex = new Map<string, CustomCssVariable>(
+    custom.map((entry) => [buildCssVariableName(entry.name), entry]),
+  );
+  let customChanged = false;
   for (let [property, value] of rules.entries()) {
     const fieldName = lookup.get(property);
-    if (!fieldName) {
+    if (fieldName) {
+      (field as any)[fieldName] = value;
       continue;
     }
-    (field as any)[fieldName] = value;
+    const existing = customIndex.get(property);
+    if (existing) {
+      existing.value = value;
+      customChanged = true;
+      continue;
+    }
+    // stored without the `--` prefix, the convention the field's editor uses
+    let entry = new CustomCssVariable({
+      name: property.replace(/^--/, ''),
+      value,
+    });
+    custom.push(entry);
+    customIndex.set(property, entry);
+    customChanged = true;
+  }
+  if (customChanged) {
+    field.customCssVariables = custom;
   }
 };
 
 const resetCssVariables = (field: ThemeVarField | undefined) => {
-  let cssFields = field?.cssVariableFields;
+  if (!field) {
+    return;
+  }
+  if (field.customCssVariables?.length) {
+    field.customCssVariables = [];
+  }
+  let cssFields = field.cssVariableFields;
   if (!cssFields?.length) {
     return;
   }
@@ -492,11 +525,10 @@ export default class StructuredTheme extends Theme {
           parts.push(rows.join('\n'));
         }
       }
-      let rootEntries = model.rootVariables?.cssVariableFields ?? [];
+      let rootRules = model.rootVariables?.cssRuleMap;
       let rootRows: string[] = [];
-      for (let { name, value } of rootEntries) {
-        if (!value) continue;
-        rootRows.push(`- ${markdownEscape(name ?? '')}: \`${value}\``);
+      for (let [name, value] of rootRules ?? []) {
+        rootRows.push(`- ${markdownEscape(name)}: \`${value}\``);
       }
       if (rootRows.length) {
         parts.push('## Root Variables');

--- a/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
@@ -9,6 +9,7 @@ import { setupBaseRealm } from '../../helpers/base-realm';
 import { renderCard } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
 
+import type * as BrandFunctionalPaletteModule from '@cardstack/base/brand-functional-palette';
 import type * as BrandGuideModule from '@cardstack/base/brand-guide';
 import type * as StructuredThemeVarsModule from '@cardstack/base/structured-theme-variables';
 
@@ -19,8 +20,9 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
   let loader: Loader;
   let BrandGuide: typeof BrandGuideModule.default;
   let CompoundColorField: typeof BrandGuideModule.CompoundColorField;
-  let CustomCssVariable: typeof BrandGuideModule.CustomCssVariable;
+  let CustomCssVariable: typeof StructuredThemeVarsModule.CustomCssVariable;
   let ThemeVarField: typeof StructuredThemeVarsModule.default;
+  let BrandFunctionalPalette: typeof BrandFunctionalPaletteModule.default;
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
     loader = getService('loader-service').loader;
@@ -29,10 +31,14 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
     );
     BrandGuide = brandGuideModule.default;
     CompoundColorField = brandGuideModule.CompoundColorField;
-    CustomCssVariable = brandGuideModule.CustomCssVariable;
-    ThemeVarField = (
-      await loader.import<typeof StructuredThemeVarsModule>(
-        '@cardstack/base/structured-theme-variables',
+    let themeVarsModule = await loader.import<typeof StructuredThemeVarsModule>(
+      '@cardstack/base/structured-theme-variables',
+    );
+    CustomCssVariable = themeVarsModule.CustomCssVariable;
+    ThemeVarField = themeVarsModule.default;
+    BrandFunctionalPalette = (
+      await loader.import<typeof BrandFunctionalPaletteModule>(
+        '@cardstack/base/brand-functional-palette',
       )
     ).default;
   });
@@ -45,9 +51,11 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
       .doesNotExist('hidden when no custom variables or palette entries exist');
 
     let cardWithVars = new BrandGuide({
-      customCssVariables: [
-        new CustomCssVariable({ name: 'spacing-sm', value: '0.5rem' }),
-      ],
+      rootVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: 'spacing-sm', value: '0.5rem' }),
+        ],
+      }),
     });
     await renderCard(loader, cardWithVars, 'isolated');
     assert
@@ -67,12 +75,14 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
 
   test('custom CSS variable names are normalized and values are rendered, with incomplete entries filtered out', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
-      customCssVariables: [
-        new CustomCssVariable({ name: '', value: 'should-be-hidden' }),
-        new CustomCssVariable({ name: 'noValue', value: '' }),
-        new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif' }),
-        new CustomCssVariable({ name: 'spacing', value: '1.5rem' }),
-      ],
+      rootVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: '', value: 'should-be-hidden' }),
+          new CustomCssVariable({ name: 'noValue', value: '' }),
+          new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif' }),
+          new CustomCssVariable({ name: 'spacing', value: '1.5rem' }),
+        ],
+      }),
     });
     await renderCard(loader, card, 'isolated');
 
@@ -100,10 +110,13 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
 
   test('custom-css section is hidden when all entries have missing name or value', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
-      customCssVariables: [
-        new CustomCssVariable({ name: 'noValue', value: '' }),
-        new CustomCssVariable({ name: '', value: 'noName' }),
-      ],
+      rootVariables: new ThemeVarField({
+        background: '#f6e6ee',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'noValue', value: '' }),
+          new CustomCssVariable({ name: '', value: 'noName' }),
+        ],
+      }),
     });
     await renderCard(loader, card, 'isolated');
 
@@ -134,10 +147,12 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
 
   test('trailing semicolons in custom CSS variable values are stripped in display and copy block', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
-      customCssVariables: [
-        new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif;' }),
-        new CustomCssVariable({ name: 'spacing', value: '1.5rem;;' }),
-      ],
+      rootVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif;' }),
+          new CustomCssVariable({ name: 'spacing', value: '1.5rem;;' }),
+        ],
+      }),
     });
     await renderCard(loader, card, 'isolated');
 
@@ -168,11 +183,13 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
 
   test('customCssVariables appear in computed cssVariables with normalized names, empty-name entries excluded', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
-      customCssVariables: [
-        new CustomCssVariable({ name: '', value: 'should-be-excluded' }),
-        new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif' }),
-        new CustomCssVariable({ name: 'spacingSm', value: '0.5rem' }),
-      ],
+      rootVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: '', value: 'should-be-excluded' }),
+          new CustomCssVariable({ name: 'myFont', value: 'Georgia, serif' }),
+          new CustomCssVariable({ name: 'spacingSm', value: '0.5rem' }),
+        ],
+      }),
     });
     await renderCard(loader, card, 'isolated');
 
@@ -188,6 +205,71 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
     assert.notOk(
       css.includes('should-be-excluded'),
       'entry with empty name is excluded from cssVariables',
+    );
+  });
+
+  test('each color scheme carries its own custom variable values', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      rootVariables: new ThemeVarField({
+        background: '#ffffff',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+          new CustomCssVariable({ name: 'shapeRadius', value: '0.5rem' }),
+        ],
+      }),
+      darkModeVariables: new ThemeVarField({
+        background: '#000000',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '200ms' }),
+        ],
+      }),
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let css = card.cssVariables ?? '';
+    let root = css.slice(css.indexOf(':root'), css.indexOf('.dark'));
+    let dark = css.slice(css.indexOf('.dark'));
+    assert.true(
+      root.includes('--motion-fast: 100ms'),
+      `expected the light-mode value in :root: ${root}`,
+    );
+    assert.true(
+      dark.includes('--motion-fast: 200ms'),
+      `expected the dark-mode value in .dark: ${dark}`,
+    );
+    assert.true(
+      root.includes('--shape-radius: 0.5rem'),
+      'a token set only in the light scheme is emitted in :root',
+    );
+    assert.false(
+      dark.includes('--shape-radius'),
+      'it is not repeated in .dark, where it cascades in from :root',
+    );
+  });
+
+  test('a custom variable never overwrites the computed value of the other color scheme', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      functionalPalette: new BrandFunctionalPalette({
+        light: '#ffffff',
+        dark: '#000000',
+      }),
+      rootVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: 'foreground', value: '#ff0000' }),
+        ],
+      }),
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let css = card.cssVariables ?? '';
+    let dark = css.slice(css.indexOf('.dark'));
+    assert.true(
+      css.slice(0, css.indexOf('.dark')).includes('--foreground: #ff0000'),
+      `expected the light-mode entry to hold the custom value: ${css}`,
+    );
+    assert.true(
+      dark.includes('--foreground: #ffffff'),
+      `expected .dark to keep the value computed from the functional palette: ${dark}`,
     );
   });
 

--- a/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
@@ -273,6 +273,54 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
     );
   });
 
+  test('a card-level custom variable list written before the per-scheme lists keeps emitting', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      rootVariables: new ThemeVarField({ background: '#ffffff' }),
+      darkModeVariables: new ThemeVarField({ background: '#000000' }),
+      customCssVariables: [
+        new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let css = card.cssVariables ?? '';
+    let root = css.slice(css.indexOf(':root'), css.indexOf('.dark'));
+    let dark = css.slice(css.indexOf('.dark'));
+    assert.true(
+      root.includes('--motion-fast: 100ms'),
+      `expected the legacy token in :root: ${root}`,
+    );
+    assert.false(
+      dark.includes('--motion-fast'),
+      'it is not repeated in .dark, where it cascades in from :root',
+    );
+    assert
+      .dom('[data-test-brand-guide-css-var-name]')
+      .hasText('--motion-fast', 'and it is still listed on the card');
+  });
+
+  test('a variable block entry wins over a card-level entry of the same name', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      rootVariables: new ThemeVarField({
+        background: '#ffffff',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '250ms' }),
+        ],
+      }),
+      customCssVariables: [
+        new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let css = card.cssVariables ?? '';
+    assert.true(
+      css.includes('--motion-fast: 250ms'),
+      `expected the variable block value to win: ${css}`,
+    );
+    assert.false(css.includes('100ms'), 'the card-level value is not emitted');
+  });
+
   test('palette entries render var names and swatches, filtering entries missing name or value', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
       brandColorPalette: [

--- a/packages/host/tests/integration/components/brand-guide-edit-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-edit-test.gts
@@ -19,7 +19,7 @@ module('Integration | brand-guide | edit view', function (hooks) {
   let loader: Loader;
   let BrandGuide: typeof BrandGuideModule.default;
   let CompoundColorField: typeof BrandGuideModule.CompoundColorField;
-  let CustomCssVariable: typeof BrandGuideModule.CustomCssVariable;
+  let CustomCssVariable: typeof StructuredThemeVarsModule.CustomCssVariable;
   let ThemeVarField: typeof StructuredThemeVarsModule.default;
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
@@ -29,12 +29,11 @@ module('Integration | brand-guide | edit view', function (hooks) {
     );
     BrandGuide = brandGuideModule.default;
     CompoundColorField = brandGuideModule.CompoundColorField;
-    CustomCssVariable = brandGuideModule.CustomCssVariable;
-    ThemeVarField = (
-      await loader.import<typeof StructuredThemeVarsModule>(
-        '@cardstack/base/structured-theme-variables',
-      )
-    ).default;
+    let themeVarsModule = await loader.import<typeof StructuredThemeVarsModule>(
+      '@cardstack/base/structured-theme-variables',
+    );
+    CustomCssVariable = themeVarsModule.CustomCssVariable;
+    ThemeVarField = themeVarsModule.default;
   });
 
   function renderedSectionIds(element: Element) {
@@ -52,7 +51,6 @@ module('Integration | brand-guide | edit view', function (hooks) {
       'typography',
       'mark-usage',
       'brand-image-attachments',
-      'custom-css',
       'visual-dna',
       'inspirations',
       'import-css',
@@ -68,6 +66,11 @@ module('Integration | brand-guide | edit view', function (hooks) {
     assert
       .dom('[data-test-brand-guide-section="card-container-css"]')
       .doesNotExist();
+    assert
+      .dom('[data-test-brand-guide-section="custom-css"]')
+      .doesNotExist(
+        'the custom css listing is display-only: its editors live in the variable blocks',
+      );
     assert.dom('[data-test-import-theme]').exists();
     assert.dom('[data-test-reset]').exists();
   });
@@ -77,9 +80,11 @@ module('Integration | brand-guide | edit view', function (hooks) {
       brandColorPalette: [
         new CompoundColorField({ name: 'brand-blue', value: '#0050ff' }),
       ],
-      customCssVariables: [
-        new CustomCssVariable({ name: 'spacing-sm', value: '0.5rem' }),
-      ],
+      rootVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: 'spacing-sm', value: '0.5rem' }),
+        ],
+      }),
     });
     await renderCard(loader, card, 'edit');
 
@@ -87,8 +92,10 @@ module('Integration | brand-guide | edit view', function (hooks) {
       .dom('[data-test-brand-guide-section="brand-palette"] input')
       .exists('brand color palette entries are editable');
     assert
-      .dom('[data-test-brand-guide-section="custom-css"] input')
-      .exists('custom CSS variables are editable');
+      .dom(
+        '[data-test-brand-guide-section="brand-palette"] [data-test-theme-custom-vars] input',
+      )
+      .exists('custom CSS variables are editable within the variable block');
     assert
       .dom('[data-test-brand-guide-css-var]')
       .doesNotExist('read-only custom CSS listing is not rendered in edit');
@@ -126,20 +133,32 @@ module('Integration | brand-guide | edit view', function (hooks) {
     assert.dom('[data-test-theme-nav] [data-test-mode]').exists();
   });
 
-  test('reset clears custom css variables along with the theme variables', async function (this: RenderingTestContext, assert) {
+  test('reset clears custom css variables in both color schemes along with the theme variables', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
-      rootVariables: new ThemeVarField({ background: '#f6e6ee' }),
-      customCssVariables: [
-        new CustomCssVariable({ name: 'spacingSm', value: '0.5rem' }),
-      ],
+      rootVariables: new ThemeVarField({
+        background: '#f6e6ee',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'spacingSm', value: '0.5rem' }),
+        ],
+      }),
+      darkModeVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: 'spacingSm', value: '0.75rem' }),
+        ],
+      }),
     });
     await renderCard(loader, card, 'edit');
 
     await click('[data-test-reset]');
     assert.strictEqual(
-      card.customCssVariables.length,
+      card.rootVariables.customCssVariables.length,
       0,
-      'custom css variables are cleared',
+      'light-mode custom css variables are cleared',
+    );
+    assert.strictEqual(
+      card.darkModeVariables.customCssVariables.length,
+      0,
+      'dark-mode custom css variables are cleared',
     );
     assert.notOk(
       card.rootVariables?.background,
@@ -149,9 +168,11 @@ module('Integration | brand-guide | edit view', function (hooks) {
 
   test('isolated view has no importer or reset button', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
-      customCssVariables: [
-        new CustomCssVariable({ name: 'spacing-sm', value: '0.5rem' }),
-      ],
+      rootVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: 'spacing-sm', value: '0.5rem' }),
+        ],
+      }),
     });
     await renderCard(loader, card, 'isolated');
 

--- a/packages/host/tests/integration/components/brand-guide-edit-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-edit-test.gts
@@ -166,6 +166,19 @@ module('Integration | brand-guide | edit view', function (hooks) {
     );
   });
 
+  test('reset clears a card-level custom variable list too', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      rootVariables: new ThemeVarField({ background: '#f6e6ee' }),
+      customCssVariables: [
+        new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+      ],
+    });
+    await renderCard(loader, card, 'edit');
+
+    await click('[data-test-reset]');
+    assert.strictEqual(card.customCssVariables.length, 0);
+  });
+
   test('isolated view has no importer or reset button', async function (this: RenderingTestContext, assert) {
     let card = new BrandGuide({
       rootVariables: new ThemeVarField({

--- a/packages/host/tests/integration/components/field-markdown-domain-test.gts
+++ b/packages/host/tests/integration/components/field-markdown-domain-test.gts
@@ -69,6 +69,7 @@ module('Integration | field markdown domain', function (hooks) {
   let StructuredTheme: typeof StructuredThemeModule.default;
   let ThemeVarField: typeof StructuredThemeVarsModule.default;
   let ThemeTypographyField: typeof StructuredThemeVarsModule.ThemeTypographyField;
+  let CustomCssVariable: typeof StructuredThemeVarsModule.CustomCssVariable;
   let TextFileDef: typeof TextFileDefModule.TextFileDef;
   let TsFileDef: typeof TsFileDefModule.TsFileDef;
   let TypographyField: typeof TypographyFieldModule.default;
@@ -129,6 +130,7 @@ module('Integration | field markdown domain', function (hooks) {
       '@cardstack/base/structured-theme-variables',
     );
     ThemeVarField = themeVarsModule.default;
+    CustomCssVariable = themeVarsModule.CustomCssVariable;
     ThemeTypographyField = themeVarsModule.ThemeTypographyField;
     TextFileDef = (
       await loader.import<typeof TextFileDefModule>(
@@ -338,6 +340,9 @@ module('Integration | field markdown domain', function (hooks) {
       vars: new ThemeVarField({
         background: '#fff',
         foreground: '#000',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+        ],
       }),
     });
     await renderCard(loader, card, 'isolated');
@@ -352,6 +357,10 @@ module('Integration | field markdown domain', function (hooks) {
     assert.true(
       text.includes('- \\-\\-foreground: `#000`'),
       `expected foreground entry in: ${text}`,
+    );
+    assert.true(
+      text.includes('- \\-\\-motion\\-fast: `100ms`'),
+      `expected the custom variable entry in: ${text}`,
     );
     // Unpopulated fields (e.g. primary) should be omitted.
     assert.false(
@@ -611,6 +620,9 @@ module('Integration | field markdown domain', function (hooks) {
       }),
       rootVariables: new ThemeVarField({
         background: '#fff',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+        ],
       }),
     });
     await renderCard(loader, card, 'markdown');
@@ -642,6 +654,10 @@ module('Integration | field markdown domain', function (hooks) {
     assert.true(
       text.includes('\\-\\-background'),
       `expected root var entry in: ${text}`,
+    );
+    assert.true(
+      text.includes('\\-\\-motion\\-fast: `100ms`'),
+      `expected the custom variable entry in: ${text}`,
     );
   });
 });

--- a/packages/host/tests/integration/structured-theme-test.gts
+++ b/packages/host/tests/integration/structured-theme-test.gts
@@ -1,5 +1,6 @@
 import {
   click,
+  fillIn,
   settled,
   waitUntil,
   type RenderingTestContext,
@@ -8,8 +9,13 @@ import {
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
+import {
+  PermissionsContextName,
+  type Permissions,
+} from '@cardstack/runtime-common';
 import type { Loader } from '@cardstack/runtime-common';
 
+import { provideConsumeContext } from '../helpers';
 import { setupBaseRealm } from '../helpers/base-realm';
 import { renderCard } from '../helpers/render-component';
 import { setupRenderingTest } from '../helpers/setup';
@@ -203,6 +209,7 @@ module('Integration | structured-theme', function (hooks) {
   let StructuredTheme: typeof StructuredThemeModule.default;
   let ThemeVarField: typeof StructuredThemeVarsModule.default;
   let ThemeTypographyField: typeof StructuredThemeVarsModule.ThemeTypographyField;
+  let CustomCssVariable: typeof StructuredThemeVarsModule.CustomCssVariable;
   let TypographyField: typeof TypographyFieldModule.default;
 
   hooks.beforeEach(async function () {
@@ -217,6 +224,7 @@ module('Integration | structured-theme', function (hooks) {
     );
     ThemeVarField = themeVarsModule.default;
     ThemeTypographyField = themeVarsModule.ThemeTypographyField;
+    CustomCssVariable = themeVarsModule.CustomCssVariable;
     TypographyField = (
       await loader.import<typeof TypographyFieldModule>(
         '@cardstack/base/typography',
@@ -400,6 +408,43 @@ module('Integration | structured-theme', function (hooks) {
     }
   });
 
+  test('the isolated preview lists the custom variables of the previewed color scheme', async function (this: RenderingTestContext, assert) {
+    let loader: Loader = getService('loader-service').loader;
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({
+        background: '#ffffff',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+          new CustomCssVariable({ name: '', value: 'no name' }),
+        ],
+      }),
+      darkModeVariables: new ThemeVarField({}),
+    });
+    await renderCard(loader, card, 'isolated');
+    await settled();
+
+    assert
+      .dom('[data-test-theme-custom-var]')
+      .exists({ count: 1 }, 'an entry with no name emits no variable to list');
+    assert.dom('[data-test-theme-custom-var-name]').hasText('--motion-fast');
+    assert.dom('[data-test-theme-custom-var-value]').hasText('100ms');
+    assert
+      .dom('[data-test-theme-custom-vars-list] [data-test-boxel-copy-button]')
+      .exists('the list can be copied as a CSS block');
+  });
+
+  test('the isolated preview omits the custom variables list when the theme defines none', async function (this: RenderingTestContext, assert) {
+    let loader: Loader = getService('loader-service').loader;
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({ background: '#ffffff' }),
+      darkModeVariables: new ThemeVarField({}),
+    });
+    await renderCard(loader, card, 'isolated');
+    await settled();
+
+    assert.dom('[data-test-theme-custom-vars-list]').doesNotExist();
+  });
+
   test('unset variables in the isolated preview show the value they inherit from the Boxel defaults', async function (this: RenderingTestContext, assert) {
     let loader: Loader = getService('loader-service').loader;
     let card = new StructuredTheme({
@@ -531,6 +576,153 @@ module('Integration | structured-theme', function (hooks) {
     assert.false(
       css.includes('sample-text'),
       'sample text is not emitted as a variable',
+    );
+  });
+
+  test('setCss keeps properties with no declared field as custom variables', function (assert) {
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({}),
+      darkModeVariables: new ThemeVarField({}),
+    });
+    assert.true(
+      card.setCss(`:root {
+  --background: #ffffff;
+  --motion-fast: 100ms;
+}
+.dark {
+  --background: #000000;
+  --motion-fast: 200ms;
+}`),
+    );
+    assert.strictEqual(card.rootVariables.background, '#ffffff');
+    assert.deepEqual(
+      card.rootVariables.customCssVariables.map(({ name, value }) => [
+        name,
+        value,
+      ]),
+      [['motion-fast', '100ms']],
+      'the unrecognized property survives the import instead of being dropped',
+    );
+    assert.deepEqual(
+      card.darkModeVariables.customCssVariables.map(({ name, value }) => [
+        name,
+        value,
+      ]),
+      [['motion-fast', '200ms']],
+      'each color scheme keeps its own value for the same token',
+    );
+    let css = card.cssVariables ?? '';
+    assert.true(
+      css.includes('--motion-fast: 100ms'),
+      `expected the light-mode value in: ${css}`,
+    );
+    assert.true(
+      css.includes('--motion-fast: 200ms'),
+      `expected the dark-mode value in: ${css}`,
+    );
+  });
+
+  test('a re-imported custom variable is updated in place rather than duplicated', function (assert) {
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+        ],
+      }),
+      darkModeVariables: new ThemeVarField({}),
+    });
+    card.setCss(':root { --motion-fast: 300ms; --shape-radius: 0.5rem; }');
+    assert.deepEqual(
+      card.rootVariables.customCssVariables.map(({ name, value }) => [
+        name,
+        value,
+      ]),
+      [
+        ['motionFast', '300ms'],
+        ['shape-radius', '0.5rem'],
+      ],
+      'the existing entry takes the new value and the new token is appended',
+    );
+  });
+
+  test('resetCss clears the custom variables of both color schemes', function (assert) {
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({
+        background: '#ffffff',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '100ms' }),
+        ],
+      }),
+      darkModeVariables: new ThemeVarField({
+        customCssVariables: [
+          new CustomCssVariable({ name: 'motionFast', value: '200ms' }),
+        ],
+      }),
+    });
+    card.resetCss();
+    assert.strictEqual(card.rootVariables.customCssVariables.length, 0);
+    assert.strictEqual(card.darkModeVariables.customCssVariables.length, 0);
+    assert.strictEqual(card.rootVariables.background, null);
+    assert.notOk(card.cssVariables, 'no variables are left to emit');
+  });
+
+  test('a declared field wins a name collision with a custom variable', function (assert) {
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({
+        background: '#ffffff',
+        customCssVariables: [
+          new CustomCssVariable({ name: 'background', value: '#ff0000' }),
+        ],
+      }),
+      darkModeVariables: new ThemeVarField({}),
+    });
+    let css = card.cssVariables ?? '';
+    assert.true(
+      css.includes('--background: #ffffff'),
+      `expected the declared field value in: ${css}`,
+    );
+    assert.false(css.includes('#ff0000'), 'the custom entry is not emitted');
+  });
+  test('custom variables can be added, edited and removed in the theme editor', async function (this: RenderingTestContext, assert) {
+    let permissions: Permissions = { canWrite: true, canRead: true };
+    provideConsumeContext(PermissionsContextName, permissions);
+    let loader: Loader = getService('loader-service').loader;
+    let card = new StructuredTheme({
+      rootVariables: new ThemeVarField({ background: '#ffffff' }),
+      darkModeVariables: new ThemeVarField({}),
+    });
+    await renderCard(loader, card, 'edit');
+
+    assert
+      .dom('[data-test-custom-css-variable-name="0"]')
+      .doesNotExist('no rows before a variable is added');
+
+    await click('[data-test-add-custom-css-variable]');
+    await fillIn('[data-test-custom-css-variable-name="0"]', 'motionFast');
+    await fillIn('[data-test-custom-css-variable-value="0"]', '100ms');
+
+    assert.deepEqual(
+      card.rootVariables.customCssVariables.map(({ name, value }) => [
+        name,
+        value,
+      ]),
+      [['motionFast', '100ms']],
+      'the typed name and value reach the model',
+    );
+    assert.true(
+      (card.cssVariables ?? '').includes('--motion-fast: 100ms'),
+      `expected the token in the generated CSS: ${card.cssVariables}`,
+    );
+
+    await click('[data-test-remove-custom-css-variable="0"]');
+    assert.strictEqual(
+      card.rootVariables.customCssVariables.length,
+      0,
+      'the row is removed from the model',
+    );
+    assert.false(
+      (card.cssVariables ?? '').includes('--motion-fast'),
+      'and stops being emitted',
     );
   });
 });


### PR DESCRIPTION
`customCssVariables` lives on `ThemeVarField` instead of on the brand guide card: a `containsMany` of `{name, value}` pairs for tokens the contract has no field for, such as motion and shape constants.

Each variable block carries its own list, so a token can take a different value per color scheme, and one entered only in the light-mode list cascades into dark mode like any unset field. Emission goes through the block's `cssRuleMap`, so custom tokens reach `:root` and `.dark` by the same path as declared values and never cross between blocks — a custom token can no longer displace the value the brand guide's dark block computes from the functional palette. A declared field wins a name collision.

One field holding many variables can't sit in `cssVariableFields`, which maps one field to one variable, so a sibling `customCssRuleMap` handles it and the three behaviors keyed off `cssVariableFields` are wired in explicitly:

- **`setCss`** keeps a pasted property with no declared field, so an import and the CSS export round-trip the same set; a property matching an existing entry updates it in place
- **`resetCss`** clears both blocks' lists
- **The markdown/LLM summaries** read the rule map, so a theme's own tokens reach the agent

Nested plural fields get no built-in editor (`contains-many-component`'s `shouldRenderEditor` declines when the owner is a `FieldDef`), so `ThemeVarField`'s edit template renders the rows: name/value inputs with add and remove, gated on `PermissionsConsumer`. Read-only, it lists the tokens as text with a copy button, since arbitrary values can't be swatches. The brand guide's Custom CSS section keeps its own listing and stays out of the editor.

The seeded `Theme/boxel-brand-guide.json` moves its eight `sp-*` entries under `rootVariables`.

## Tests

Per-scheme values and cascade; a custom token never overwrites the other scheme's computed value; a declared field wins a collision; `setCss` retention and in-place update; `resetCss` clearing both schemes; the editor's add/edit/remove reaching the model and generated CSS; the isolated listing; and the markdown summaries.

Closes https://linear.app/cardstack/issue/CS-12722/move-customcssvariables-from-brandguide-to-themevarfield

🤖 Generated with [Claude Code](https://claude.com/claude-code)
