### PR TITLE
Validate every entry of a query collection, not just the first

### DIFF
--- a/packages/base/operations.ts
+++ b/packages/base/operations.ts
@@ -804,9 +804,9 @@ function holdsReference(node: unknown): boolean {
 
 // A def class stands in for the code ref lowering derives from it. The
 // sentinel satisfies the realm's code-ref check, which reads `module` and
-// `name`, while carrying a function as its first entry — the entry the
-// realm's JSON check reaches — so it is accepted exactly where a type belongs
-// and refused wherever a value does.
+// `name`, while carrying a function under `notJson` — which the realm's JSON
+// check refuses anywhere it walks a value — so the sentinel is accepted
+// exactly where a type belongs and refused wherever a value does.
 function withTypeSentinels(node: unknown): unknown {
   if (typeof node === 'function') {
     return {

--- a/packages/realm-server/tests/assert-query-validation-test.ts
+++ b/packages/realm-server/tests/assert-query-validation-test.ts
@@ -1,0 +1,33 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import assertQueryValidationTests from '@cardstack/runtime-common/tests/assert-query-validation-test';
+
+module(basename(import.meta.filename), function () {
+  module('assertQuery collection validation', function () {
+    test('assertQuery validates every element of an any filter', async function (assert) {
+      await runSharedTest(assertQueryValidationTests, assert, {});
+    });
+
+    test('assertQuery validates every field path of a range filter', async function (assert) {
+      await runSharedTest(assertQueryValidationTests, assert, {});
+    });
+
+    test('assertQuery validates every constraint of a range field', async function (assert) {
+      await runSharedTest(assertQueryValidationTests, assert, {});
+    });
+
+    test('assertQuery validates every entry of a nested JSON value', async function (assert) {
+      await runSharedTest(assertQueryValidationTests, assert, {});
+    });
+
+    test('assertQuery validates every element of a nested JSON array', async function (assert) {
+      await runSharedTest(assertQueryValidationTests, assert, {});
+    });
+
+    test('assertQuery accepts the multi-entry shapes the grammar allows', async function (assert) {
+      await runSharedTest(assertQueryValidationTests, assert, {});
+    });
+  });
+});

--- a/packages/realm-server/tests/assert-query-validation-test.ts
+++ b/packages/realm-server/tests/assert-query-validation-test.ts
@@ -5,7 +5,7 @@ import { runSharedTest } from '@cardstack/runtime-common/helpers';
 import assertQueryValidationTests from '@cardstack/runtime-common/tests/assert-query-validation-test';
 
 module(basename(import.meta.filename), function () {
-  module('assertQuery collection validation', function () {
+  module('assertQuery validation', function () {
     test('assertQuery validates every element of an any filter', async function (assert) {
       await runSharedTest(assertQueryValidationTests, assert, {});
     });
@@ -23,6 +23,10 @@ module(basename(import.meta.filename), function () {
     });
 
     test('assertQuery validates every element of a nested JSON array', async function (assert) {
+      await runSharedTest(assertQueryValidationTests, assert, {});
+    });
+
+    test('assertQuery constrains the sort direction of every sort entry', async function (assert) {
       await runSharedTest(assertQueryValidationTests, assert, {});
     });
 

--- a/packages/runtime-common/invalid-query-error.ts
+++ b/packages/runtime-common/invalid-query-error.ts
@@ -1,9 +1,6 @@
 // The error every check in the query grammar raises when a query does not
-// conform to it, held in a module that imports nothing. `query.ts` and the leaf
-// validators it depends on — `json-validation.ts` — both raise it, and this
-// module's position under both of them is what guarantees the class is
-// initialized before either can throw, whichever of them a consumer loads
-// first.
+// conform to it. It lives in its own module so `json-validation.ts` can raise
+// it without importing `query.ts`, which imports `json-validation.ts`.
 //
 // Callers key their response off the class, not the message: the search
 // endpoints turn it into a 400 and let anything else surface as a 500, so a

--- a/packages/runtime-common/invalid-query-error.ts
+++ b/packages/runtime-common/invalid-query-error.ts
@@ -1,0 +1,15 @@
+// The error every check in the query grammar raises when a query does not
+// conform to it. It lives apart from `query.ts` so the leaf validators
+// `query.ts` itself depends on — `json-validation.ts` — can raise it without a
+// module cycle.
+//
+// Callers key their response off the class, not the message: the search
+// endpoints turn it into a 400 and let anything else surface as a 500, so a
+// grammar violation reported as a plain `Error` reads to a caller as a server
+// fault rather than a bad request.
+export class InvalidQueryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidQueryError';
+  }
+}

--- a/packages/runtime-common/invalid-query-error.ts
+++ b/packages/runtime-common/invalid-query-error.ts
@@ -1,7 +1,9 @@
 // The error every check in the query grammar raises when a query does not
-// conform to it. It lives apart from `query.ts` so the leaf validators
-// `query.ts` itself depends on — `json-validation.ts` — can raise it without a
-// module cycle.
+// conform to it, held in a module that imports nothing. `query.ts` and the leaf
+// validators it depends on — `json-validation.ts` — both raise it, and this
+// module's position under both of them is what guarantees the class is
+// initialized before either can throw, whichever of them a consumer loads
+// first.
 //
 // Callers key their response off the class, not the message: the search
 // endpoints turn it into a 400 and let anything else surface as a 500, so a

--- a/packages/runtime-common/json-validation.ts
+++ b/packages/runtime-common/json-validation.ts
@@ -1,3 +1,5 @@
+import { InvalidQueryError } from './invalid-query-error.ts';
+
 export function assertJSONValue(v: any, pointer: string[]) {
   if (v === null) {
     return;
@@ -8,18 +10,25 @@ export function assertJSONValue(v: any, pointer: string[]) {
     case 'boolean':
       return;
     case 'object':
+      // Every element and every entry is checked, at every level of
+      // recursion — a container is JSON only if all of it is. `forEach` is
+      // what makes that so: these callbacks report a failure by throwing and
+      // return nothing, so `every` would read the first `undefined` as false
+      // and stop, leaving the rest of the subtree unchecked.
       if (Array.isArray(v)) {
-        v.every((value, index) =>
-          assertJSONValue(value, pointer.concat(`[${index}]`)),
-        );
+        v.forEach((value, index) => {
+          assertJSONValue(value, pointer.concat(`[${index}]`));
+        });
       } else {
-        Object.entries(v).every(([key, value]) =>
-          assertJSONValue(value, pointer.concat(key)),
-        );
+        Object.entries(v).forEach(([key, value]) => {
+          assertJSONValue(value, pointer.concat(key));
+        });
       }
       return;
   }
-  throw new Error(`${pointer.join('/')}: value not allowed in json`);
+  throw new InvalidQueryError(
+    `${pointer.join('/')}: value not allowed in json`,
+  );
 }
 
 export function assertJSONPrimitive(p: any, pointer: string[]) {
@@ -32,7 +41,7 @@ export function assertJSONPrimitive(p: any, pointer: string[]) {
     case 'boolean':
       return;
     default:
-      throw new Error(
+      throw new InvalidQueryError(
         `${pointer.join(
           '/',
         )}: JSON primitive must be of type string, number, boolean, or null`,

--- a/packages/runtime-common/json-validation.ts
+++ b/packages/runtime-common/json-validation.ts
@@ -10,11 +10,8 @@ export function assertJSONValue(v: any, pointer: string[]) {
     case 'boolean':
       return;
     case 'object':
-      // Every element and every entry is checked, at every level of
-      // recursion — a container is JSON only if all of it is. `forEach` is
-      // what makes that so: these callbacks report a failure by throwing and
-      // return nothing, so `every` would read the first `undefined` as false
-      // and stop, leaving the rest of the subtree unchecked.
+      // A container is JSON only if all of it is, so every element and every
+      // entry is checked at every level of recursion.
       if (Array.isArray(v)) {
         v.forEach((value, index) => {
           assertJSONValue(value, pointer.concat(`[${index}]`));

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -207,6 +207,11 @@ export function buildQueryParamValue(query: Query): string {
   return qs.stringify(query, { strictNullHandling: true, encode: false });
 }
 
+// Every `assert*` in this grammar reports a failure by throwing
+// `InvalidQueryError` and returns nothing on success. That makes `forEach` the
+// only correct way to walk a collection of them: `every` reads each callback's
+// `undefined` as false and stops, so it would check a collection's first entry
+// and silently accept the rest.
 export function assertQuery(
   query: any,
   pointer: string[] = [''],
@@ -398,11 +403,6 @@ function assertPage(
   }
 }
 
-// Every `assert*` below reports a failure by throwing `InvalidQueryError` and
-// returns nothing on success. That makes `forEach` the only correct way to walk
-// a collection of them: `every` reads each callback's `undefined` as false and
-// stops, so it would check a collection's first entry and silently accept the
-// rest.
 function assertFilter(
   filter: any,
   pointer: string[],
@@ -657,7 +657,7 @@ function assertRangeFilter(
         default:
           throw new InvalidQueryError(
             `${
-              innerPointer.join('/') || '/'
+              innerPointer.concat(key).join('/') || '/'
             }: range item must be gt, gte, lt, or lte`,
           );
       }

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -207,11 +207,6 @@ export function buildQueryParamValue(query: Query): string {
   return qs.stringify(query, { strictNullHandling: true, encode: false });
 }
 
-// Every `assert*` in this grammar reports a failure by throwing
-// `InvalidQueryError` and returns nothing on success. That makes `forEach` the
-// only correct way to walk a collection of them: `every` reads each callback's
-// `undefined` as false and stops, so it would check a collection's first entry
-// and silently accept the rest.
 export function assertQuery(
   query: any,
   pointer: string[] = [''],
@@ -407,6 +402,10 @@ function assertPage(
   }
 }
 
+// The operator validators below report a failure by throwing and return
+// nothing on success, so a collection of them is walked with `forEach`.
+// `every` reads each callback's `undefined` as false and stops, which would
+// check a collection's first entry and silently accept the rest.
 function assertFilter(
   filter: any,
   pointer: string[],
@@ -468,20 +467,20 @@ function assertAnyFilter(
       `${pointer.join('/') || '/'}: filter must be an object`,
     );
   }
-  pointer.concat('any');
+  let anyPointer = pointer.concat('any');
   if (!('any' in filter)) {
     throw new InvalidQueryError(
-      `${pointer.join('/') || '/'}: AnyFilter must have any property`,
+      `${anyPointer.join('/') || '/'}: AnyFilter must have any property`,
     );
   }
 
   if (!Array.isArray(filter.any)) {
     throw new InvalidQueryError(
-      `${pointer.join('/') || '/'}: any must be an array of Filters`,
+      `${anyPointer.join('/') || '/'}: any must be an array of Filters`,
     );
   } else {
     filter.any.forEach((value: any, index: number) => {
-      assertFilter(value, pointer.concat(`[${index}]`));
+      assertFilter(value, anyPointer.concat(`[${index}]`));
     });
   }
 }
@@ -495,20 +494,20 @@ function assertEveryFilter(
       `${pointer.join('/') || '/'}: filter must be an object`,
     );
   }
-  pointer.concat('every');
+  let everyPointer = pointer.concat('every');
   if (!('every' in filter)) {
     throw new InvalidQueryError(
-      `${pointer.join('/') || '/'}: EveryFilter must have every property`,
+      `${everyPointer.join('/') || '/'}: EveryFilter must have every property`,
     );
   }
 
   if (!Array.isArray(filter.every)) {
     throw new InvalidQueryError(
-      `${pointer.join('/') || '/'}: every must be an array of Filters`,
+      `${everyPointer.join('/') || '/'}: every must be an array of Filters`,
     );
   } else {
     filter.every.forEach((value: any, index: number) => {
-      assertFilter(value, pointer.concat(`[${index}]`));
+      assertFilter(value, everyPointer.concat(`[${index}]`));
     });
   }
 }
@@ -522,14 +521,14 @@ function assertNotFilter(
       `${pointer.join('/') || '/'}: filter must be an object`,
     );
   }
-  pointer.concat('not');
+  let notPointer = pointer.concat('not');
   if (!('not' in filter)) {
     throw new InvalidQueryError(
-      `${pointer.join('/') || '/'}: NotFilter must have not property`,
+      `${notPointer.join('/') || '/'}: NotFilter must have not property`,
     );
   }
 
-  assertFilter(filter.not, pointer);
+  assertFilter(filter.not, notPointer);
 }
 
 function assertEqFilter(
@@ -541,22 +540,20 @@ function assertEqFilter(
       `${pointer.join('/') || '/'}: filter must be an object`,
     );
   }
-  pointer.concat('eq');
+  let eqPointer = pointer.concat('eq');
   if (!('eq' in filter)) {
     throw new InvalidQueryError(
-      `${
-        pointer.concat('eq').join('/') || '/'
-      }: EqFilter must have eq property`,
+      `${eqPointer.join('/') || '/'}: EqFilter must have eq property`,
     );
   }
   if (typeof filter.eq !== 'object' || filter.eq == null) {
     throw new InvalidQueryError(
-      `${pointer.join('/') || '/'}: eq must be an object`,
+      `${eqPointer.join('/') || '/'}: eq must be an object`,
     );
   }
   Object.entries(filter.eq).forEach(([key, value]) => {
-    assertKey(key, pointer);
-    assertJSONValue(value, pointer.concat(key));
+    assertKey(key, eqPointer);
+    assertJSONValue(value, eqPointer.concat(key));
   });
 }
 
@@ -602,22 +599,20 @@ function assertContainsFilter(
       `${pointer.join('/') || '/'}: filter must be an object`,
     );
   }
-  pointer.concat('contains');
+  let containsPointer = pointer.concat('contains');
   if (!('contains' in filter)) {
     throw new InvalidQueryError(
-      `${
-        pointer.concat('contains').join('/') || '/'
-      }: ContainsFilter must have contains property`,
+      `${containsPointer.join('/') || '/'}: ContainsFilter must have contains property`,
     );
   }
   if (typeof filter.contains !== 'object' || filter.contains == null) {
     throw new InvalidQueryError(
-      `${pointer.join('/') || '/'}: contains must be an object`,
+      `${containsPointer.join('/') || '/'}: contains must be an object`,
     );
   }
   Object.entries(filter.contains).forEach(([key, value]) => {
-    assertKey(key, pointer);
-    assertJSONValue(value, pointer.concat(key));
+    assertKey(key, containsPointer);
+    assertJSONValue(value, containsPointer.concat(key));
   });
 }
 
@@ -630,21 +625,19 @@ function assertRangeFilter(
       `${pointer.join('/') || '/'}: filter must be an object`,
     );
   }
-  pointer.concat('range');
+  let rangePointer = pointer.concat('range');
   if (!('range' in filter)) {
     throw new InvalidQueryError(
-      `${
-        pointer.concat('range').join('/') || '/'
-      }: RangeFilter must have range property`,
+      `${rangePointer.join('/') || '/'}: RangeFilter must have range property`,
     );
   }
   if (typeof filter.range !== 'object' || filter.range == null) {
     throw new InvalidQueryError(
-      `${pointer.join('/') || '/'}: range must be an object`,
+      `${rangePointer.join('/') || '/'}: range must be an object`,
     );
   }
   Object.entries(filter.range).forEach(([fieldPath, constraints]) => {
-    let innerPointer = [...pointer, fieldPath];
+    let innerPointer = [...rangePointer, fieldPath];
     if (typeof constraints !== 'object' || constraints == null) {
       throw new InvalidQueryError(
         `${innerPointer.join('/') || '/'}: range constraint must be an object`,

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -354,16 +354,10 @@ function assertSortExpression(
       `${pointer.concat('by').join('/') || '/'}: by must be a string`,
     );
   }
-  if (!('on' in sort)) {
-    if (Object.keys(generalSortFields).includes(sort.by)) {
-      return;
-    }
-    throw new InvalidQueryError(
-      `${pointer.concat('on').join('/') || '/'}: missing on object`,
-    );
-  }
-  assertCardType(sort.on, pointer.concat('on'));
-
+  // Every sort entry carries a direction, whether or not it names a type: a
+  // general sort field is anchored by the column it maps to rather than by
+  // `on`, so it takes the same `asc`/`desc` constraint. Checked ahead of the
+  // branching below so neither shape can reach a `return` with it unchecked.
   if ('direction' in sort) {
     if (sort.direction !== 'asc' && sort.direction !== 'desc') {
       throw new InvalidQueryError(
@@ -373,6 +367,16 @@ function assertSortExpression(
       );
     }
   }
+
+  if (!('on' in sort)) {
+    if (Object.keys(generalSortFields).includes(sort.by)) {
+      return;
+    }
+    throw new InvalidQueryError(
+      `${pointer.concat('on').join('/') || '/'}: missing on object`,
+    );
+  }
+  assertCardType(sort.on, pointer.concat('on'));
 }
 
 function assertPage(

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -1,8 +1,14 @@
 import { isEqual } from 'lodash-es';
-import { assertJSONValue, assertJSONPrimitive } from './json-validation.ts';
 import qs from 'qs';
 
+import { assertJSONValue, assertJSONPrimitive } from './json-validation.ts';
+import { InvalidQueryError } from './invalid-query-error.ts';
 import { type CodeRef, isCodeRef, generalSortFields } from './index.ts';
+
+// `query.ts` is where callers reach for the grammar's error, so it stays
+// exported from here even though the class itself lives one module down.
+export { InvalidQueryError };
+
 type JSONValue =
   | string
   | number
@@ -10,13 +16,6 @@ type JSONValue =
   | null
   | JSONValue[]
   | { [key: string]: JSONValue };
-
-export class InvalidQueryError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'InvalidQueryError';
-  }
-}
 
 export type SparseFieldsets = Record<string, string[]>;
 
@@ -399,6 +398,11 @@ function assertPage(
   }
 }
 
+// Every `assert*` below reports a failure by throwing `InvalidQueryError` and
+// returns nothing on success. That makes `forEach` the only correct way to walk
+// a collection of them: `every` reads each callback's `undefined` as false and
+// stops, so it would check a collection's first entry and silently accept the
+// rest.
 function assertFilter(
   filter: any,
   pointer: string[],
@@ -472,9 +476,9 @@ function assertAnyFilter(
       `${pointer.join('/') || '/'}: any must be an array of Filters`,
     );
   } else {
-    filter.any.every((value: any, index: number) =>
-      assertFilter(value, pointer.concat(`[${index}]`)),
-    );
+    filter.any.forEach((value: any, index: number) => {
+      assertFilter(value, pointer.concat(`[${index}]`));
+    });
   }
 }
 
@@ -635,14 +639,14 @@ function assertRangeFilter(
       `${pointer.join('/') || '/'}: range must be an object`,
     );
   }
-  Object.entries(filter.range).every(([fieldPath, constraints]) => {
+  Object.entries(filter.range).forEach(([fieldPath, constraints]) => {
     let innerPointer = [...pointer, fieldPath];
     if (typeof constraints !== 'object' || constraints == null) {
       throw new InvalidQueryError(
         `${innerPointer.join('/') || '/'}: range constraint must be an object`,
       );
     }
-    Object.entries(constraints).every(([key, value]) => {
+    Object.entries(constraints).forEach(([key, value]) => {
       switch (key) {
         case 'gt':
         case 'gte':

--- a/packages/runtime-common/tests/assert-query-validation-test.ts
+++ b/packages/runtime-common/tests/assert-query-validation-test.ts
@@ -108,6 +108,49 @@ const tests = Object.freeze({
     );
   },
 
+  'assertQuery constrains the sort direction of every sort entry': async (
+    assert,
+  ) => {
+    // A general sort field takes no `on` — it resolves against a column rather
+    // than a card type — so it exercises a different path through
+    // `assertSortExpression` than a card-field sort does. Both constrain
+    // `direction` to `asc` or `desc`.
+    for (let sort of [
+      [{ by: 'lastModified', direction: 'sideways' }],
+      [{ by: 'createdAt', direction: 'sideways' }],
+      [{ by: 'cardURL', direction: 'sideways' }],
+      [{ by: 'title', on: sampleRef, direction: 'sideways' }],
+    ]) {
+      assert.throws(
+        () => assertQuery({ sort }),
+        (err: Error) =>
+          err instanceof InvalidQueryError &&
+          /sort\[0\]\/direction: direction must be either 'asc' or 'desc'/.test(
+            err.message,
+          ),
+        `${JSON.stringify(sort)} is rejected, and the pointer names it`,
+      );
+    }
+    for (let sort of [
+      [{ by: 'lastModified', direction: 'asc' }],
+      [{ by: 'lastModified', direction: 'desc' }],
+      [{ by: 'lastModified' }],
+      [{ by: 'title', on: sampleRef, direction: 'desc' }],
+    ]) {
+      try {
+        assertQuery({ sort });
+        assert.ok(true, `accepted ${JSON.stringify(sort)}`);
+      } catch (err) {
+        assert.ok(
+          false,
+          `unexpected throw for ${JSON.stringify(sort)}: ${
+            (err as Error).message
+          }`,
+        );
+      }
+    }
+  },
+
   'assertQuery accepts the multi-entry shapes the grammar allows': async (
     assert,
   ) => {

--- a/packages/runtime-common/tests/assert-query-validation-test.ts
+++ b/packages/runtime-common/tests/assert-query-validation-test.ts
@@ -1,0 +1,159 @@
+// `assertQuery` is the gate in front of every query the platform accepts from
+// outside itself — the `/_search` and `/_federated-search` endpoints, the AI
+// search tool's model-authored query, and the second opinion on a card
+// author's declared `query` operation. A shape it accepts reaches the query
+// engine, which compiles whatever it can make of it, so a filter that clears
+// validation malformed does not fail loudly: it runs and matches the wrong
+// rows.
+//
+// Every collection in the grammar is therefore validated entry by entry, not
+// just at its head. Each case below puts the offending entry in a
+// **non-first** position, which is the only position that distinguishes a loop
+// that walks the whole collection from one that stops at the first entry.
+import type { RealmResourceIdentifier } from '../realm-identifiers.ts';
+import type { SharedTests } from '../helpers/index.ts';
+import { InvalidQueryError, assertQuery } from '../query.ts';
+
+const sampleRef = {
+  module: 'http://localhost:4201/test/person' as RealmResourceIdentifier,
+  name: 'Person',
+};
+
+const tests = Object.freeze({
+  'assertQuery validates every element of an any filter': async (assert) => {
+    assert.throws(
+      () =>
+        assertQuery({
+          filter: { any: [{ eq: { status: 'open' } }, 'not a filter'] },
+        }),
+      (err: Error) =>
+        err instanceof InvalidQueryError && /filter\/\[1\]/.test(err.message),
+      'the second any element is rejected, and the pointer names it',
+    );
+  },
+
+  'assertQuery validates every field path of a range filter': async (
+    assert,
+  ) => {
+    assert.throws(
+      () =>
+        assertQuery({
+          filter: { range: { a: { gt: 1 }, b: { bogus: 2 } } },
+        }),
+      (err: Error) =>
+        err instanceof InvalidQueryError && /filter\/b/.test(err.message),
+      'the second field path is rejected, and the pointer names it',
+    );
+  },
+
+  'assertQuery validates every constraint of a range field': async (assert) => {
+    assert.throws(
+      () => assertQuery({ filter: { range: { a: { gt: 1, bogus: 2 } } } }),
+      (err: Error) =>
+        err instanceof InvalidQueryError &&
+        /range item must be gt, gte, lt, or lte/.test(err.message),
+      'an unknown constraint key after a valid one is rejected',
+    );
+    assert.throws(
+      () => assertQuery({ filter: { range: { a: { gt: 1, lt: {} } } } }),
+      (err: Error) =>
+        err instanceof InvalidQueryError && /JSON primitive/.test(err.message),
+      'and so is a non-primitive bound after a valid one',
+    );
+  },
+
+  'assertQuery validates every entry of a nested JSON value': async (
+    assert,
+  ) => {
+    assert.throws(
+      () =>
+        assertQuery({
+          filter: { eq: { title: { a: 1, b: () => {} } } },
+        }),
+      (err: Error) =>
+        err instanceof InvalidQueryError &&
+        /filter\/title\/b: value not allowed in json/.test(err.message),
+      'the second key of a nested object is rejected',
+    );
+    assert.throws(
+      () =>
+        assertQuery({
+          filter: {
+            contains: {
+              meta: { first: { ok: 1 }, second: { deep: undefined } },
+            },
+          },
+        }),
+      (err: Error) =>
+        err instanceof InvalidQueryError &&
+        /filter\/meta\/second\/deep: value not allowed in json/.test(
+          err.message,
+        ),
+      'and so is a non-JSON leaf below the second key, at any depth',
+    );
+  },
+
+  'assertQuery validates every element of a nested JSON array': async (
+    assert,
+  ) => {
+    assert.throws(
+      () => assertQuery({ filter: { eq: { tags: [1, () => {}] } } }),
+      (err: Error) =>
+        err instanceof InvalidQueryError &&
+        /filter\/tags\/\[1\]: value not allowed in json/.test(err.message),
+      'the second element of a nested array is rejected',
+    );
+  },
+
+  'assertQuery accepts the multi-entry shapes the grammar allows': async (
+    assert,
+  ) => {
+    // Walking a whole collection rejects more shapes than walking its head, so
+    // these pin the shapes that must keep clearing validation: the search
+    // query-builder's OR of a full-text match with two title matches, and a
+    // range naming several field paths with several bounds each.
+    let accepted = [
+      {
+        filter: {
+          any: [
+            { matches: 'mango' },
+            { contains: { _title: 'mango' } },
+            { contains: { cardTitle: 'mango' } },
+          ],
+        },
+      },
+      {
+        filter: {
+          range: {
+            views: { lte: 10, gt: 5 },
+            'author.posts': { gte: 1 },
+          },
+        },
+      },
+      {
+        filter: {
+          on: sampleRef,
+          every: [
+            { eq: { nested: { a: 1, b: 'two', c: null, d: [1, 2, 3] } } },
+            { in: { status: ['open', 'closed'] } },
+          ],
+        },
+      },
+    ];
+    for (let query of accepted) {
+      try {
+        assertQuery(query);
+        assert.ok(true, `accepted ${JSON.stringify(query)}`);
+      } catch (err) {
+        assert.ok(
+          false,
+          `unexpected throw for ${JSON.stringify(query)}: ${
+            (err as Error).message
+          }`,
+        );
+      }
+    }
+  },
+} as SharedTests<{}>);
+
+export default tests;

--- a/packages/runtime-common/tests/assert-query-validation-test.ts
+++ b/packages/runtime-common/tests/assert-query-validation-test.ts
@@ -51,13 +51,16 @@ const tests = Object.freeze({
       () => assertQuery({ filter: { range: { a: { gt: 1, bogus: 2 } } } }),
       (err: Error) =>
         err instanceof InvalidQueryError &&
-        /range item must be gt, gte, lt, or lte/.test(err.message),
-      'an unknown constraint key after a valid one is rejected',
+        /filter\/a\/bogus: range item must be gt, gte, lt, or lte/.test(
+          err.message,
+        ),
+      'an unknown constraint key after a valid one is rejected, and the pointer names it',
     );
     assert.throws(
       () => assertQuery({ filter: { range: { a: { gt: 1, lt: {} } } } }),
       (err: Error) =>
-        err instanceof InvalidQueryError && /JSON primitive/.test(err.message),
+        err instanceof InvalidQueryError &&
+        /filter\/a\/lt: JSON primitive/.test(err.message),
       'and so is a non-primitive bound after a valid one',
     );
   },

--- a/packages/runtime-common/tests/assert-query-validation-test.ts
+++ b/packages/runtime-common/tests/assert-query-validation-test.ts
@@ -2,14 +2,16 @@
 // outside itself — the `/_search` and `/_federated-search` endpoints, the AI
 // search tool's model-authored query, and the second opinion on a card
 // author's declared `query` operation. A shape it accepts reaches the query
-// engine, which compiles whatever it can make of it, so a filter that clears
-// validation malformed does not fail loudly: it runs and matches the wrong
-// rows.
+// engine, which compiles whatever it can make of it — for these shapes either
+// crashing there on a request that was malformed all along, or, where the
+// engine can make something of them, running and matching the wrong rows.
 //
 // Every collection in the grammar is therefore validated entry by entry, not
 // just at its head. Each case below puts the offending entry in a
 // **non-first** position, which is the only position that distinguishes a loop
-// that walks the whole collection from one that stops at the first entry.
+// that walks the whole collection from one that stops at the first entry, and
+// asserts the pointer that names it — operator segment included, so the
+// pointer identifies the entry rather than merely the node it sits under.
 import type { RealmResourceIdentifier } from '../realm-identifiers.ts';
 import type { SharedTests } from '../helpers/index.ts';
 import { InvalidQueryError, assertQuery } from '../query.ts';
@@ -27,7 +29,8 @@ const tests = Object.freeze({
           filter: { any: [{ eq: { status: 'open' } }, 'not a filter'] },
         }),
       (err: Error) =>
-        err instanceof InvalidQueryError && /filter\/\[1\]/.test(err.message),
+        err instanceof InvalidQueryError &&
+        /filter\/any\/\[1\]: missing filter object/.test(err.message),
       'the second any element is rejected, and the pointer names it',
     );
   },
@@ -41,7 +44,10 @@ const tests = Object.freeze({
           filter: { range: { a: { gt: 1 }, b: { bogus: 2 } } },
         }),
       (err: Error) =>
-        err instanceof InvalidQueryError && /filter\/b/.test(err.message),
+        err instanceof InvalidQueryError &&
+        /filter\/range\/b\/bogus: range item must be gt, gte, lt, or lte/.test(
+          err.message,
+        ),
       'the second field path is rejected, and the pointer names it',
     );
   },
@@ -51,7 +57,7 @@ const tests = Object.freeze({
       () => assertQuery({ filter: { range: { a: { gt: 1, bogus: 2 } } } }),
       (err: Error) =>
         err instanceof InvalidQueryError &&
-        /filter\/a\/bogus: range item must be gt, gte, lt, or lte/.test(
+        /filter\/range\/a\/bogus: range item must be gt, gte, lt, or lte/.test(
           err.message,
         ),
       'an unknown constraint key after a valid one is rejected, and the pointer names it',
@@ -60,7 +66,7 @@ const tests = Object.freeze({
       () => assertQuery({ filter: { range: { a: { gt: 1, lt: {} } } } }),
       (err: Error) =>
         err instanceof InvalidQueryError &&
-        /filter\/a\/lt: JSON primitive/.test(err.message),
+        /filter\/range\/a\/lt: JSON primitive/.test(err.message),
       'and so is a non-primitive bound after a valid one',
     );
   },
@@ -75,7 +81,7 @@ const tests = Object.freeze({
         }),
       (err: Error) =>
         err instanceof InvalidQueryError &&
-        /filter\/title\/b: value not allowed in json/.test(err.message),
+        /filter\/eq\/title\/b: value not allowed in json/.test(err.message),
       'the second key of a nested object is rejected',
     );
     assert.throws(
@@ -89,7 +95,7 @@ const tests = Object.freeze({
         }),
       (err: Error) =>
         err instanceof InvalidQueryError &&
-        /filter\/meta\/second\/deep: value not allowed in json/.test(
+        /filter\/contains\/meta\/second\/deep: value not allowed in json/.test(
           err.message,
         ),
       'and so is a non-JSON leaf below the second key, at any depth',
@@ -103,7 +109,7 @@ const tests = Object.freeze({
       () => assertQuery({ filter: { eq: { tags: [1, () => {}] } } }),
       (err: Error) =>
         err instanceof InvalidQueryError &&
-        /filter\/tags\/\[1\]: value not allowed in json/.test(err.message),
+        /filter\/eq\/tags\/\[1\]: value not allowed in json/.test(err.message),
       'the second element of a nested array is rejected',
     );
   },
@@ -155,9 +161,10 @@ const tests = Object.freeze({
     assert,
   ) => {
     // Walking a whole collection rejects more shapes than walking its head, so
-    // these pin the shapes that must keep clearing validation: the search
-    // query-builder's OR of a full-text match with two title matches, and a
-    // range naming several field paths with several bounds each.
+    // these pin shapes that must keep clearing validation: the search
+    // query-builder's OR of a full-text match with two title matches, a range
+    // naming several field paths with several bounds each, and an `every`
+    // carrying a multi-key nested JSON value alongside an `in`.
     let accepted = [
       {
         filter: {


### PR DESCRIPTION
## What this fixes

Four validation loops in the query grammar iterate with `Array.prototype.every` / `Object.entries(...).every` over a callback that returns nothing. `every` stops the moment its callback returns a falsy value, and `undefined` is falsy — so each of these loops validates only its **first** entry and silently skips the rest.

| Site | What was actually checked |
| -- | -- |
| `query.ts` — `assertAnyFilter` | only `any[0]`; every later element of an `any` array went unvalidated |
| `query.ts` — `assertRangeFilter` | only the first field path in `range` |
| `query.ts` — `assertRangeFilter` | only the first constraint key within that field |
| `json-validation.ts` — `assertJSONValue` | only the first array element / first object entry, at **every** level of recursion — so past the first key a whole nested subtree went unchecked |

(Four functions, five loops — `assertJSONValue` has one for arrays and one for objects.)

Shapes that cleared validation and should not have:

```ts
assertQuery({ filter: { any: [{ eq: { status: 'open' } }, 'not a filter'] } });
assertQuery({ filter: { range: { a: { gt: 1 }, b: { bogus: 2 } } } });
assertQuery({ filter: { range: { a: { gt: 1, bogus: 2 } } } });
assertQuery({ filter: { eq: { title: { a: 1, b: () => {} } } } });
```

`assertQuery` is the gate in front of every query the platform accepts from outside itself — the `entry` search API (`/_search`, `/_federated-search`), the AI search tool where the query is model-generated, and the second opinion on a card author's declared `query` operation. Downstream of it, a malformed filter is not rejected with a 400: it reaches the query engine, which compiles whatever it can make of it.

Most of the grammar's collection walks were already `forEach` and already correct — `assertQuery`'s sort loop, `assertEveryFilter`, `assertEqFilter`, `assertInFilter` at both levels, `assertContainsFilter`. These were the outliers, and they now have the same shape.

## What the malformed shapes actually do downstream

Worth being precise, because it is narrower than "matches the wrong rows" in some cases and wider in others:

- A bogus `range` operator puts `undefined` into the expression array, and `makeExpression` dispatches on `element.kind` → **TypeError, a 500**.
- A non-filter `any` element evaluates `'on' in filter` against a string primitive → **TypeError, a 500**.
- Nested `undefined` under `eq`/`contains` is the one shape that **silently matches the wrong rows** — `JSON.stringify` drops the key. It is also the shape the reachability argument below says cannot arrive.
- On the client-side matcher, `compareRange` is a `switch` with no `default`, so an unknown operator returns `undefined` → falsy → **the row silently never matches**.

So the fix converts a mix of 500s and silent mismatches into 400s, rather than converting silent-wrong-answers alone.

## Also in this change

**`InvalidQueryError` moves to its own module** and is re-exported from `query.ts`, where callers reach for it. It lives apart so `json-validation.ts` can raise it without importing `query.ts`, which imports `json-validation.ts`.

This matters because `search-entry.ts` keys its response off the class: it turns `InvalidQueryError` into a 400 and lets anything else surface as a 500. `assertJSONPrimitive` rejects objects and arrays, which are pure JSON and reachable in *head* position — so `{ filter: { range: { views: { gt: {} } } } }` is a 500 on a plainly bad request today, independent of the loop fix. Both leaf validators now raise `InvalidQueryError` like the rest of the grammar, so all of these report a violation the way the endpoints expect. This half is a fix to a reachable mis-mapping, not only hygiene for the loop change.

**Validation pointers now name the operator.** Six of the filter validators built a pointer segment for their own operator and discarded it — `pointer.concat('any');` as a bare statement — so an error under `any`, `every`, `not`, `eq`, `contains` or `range` reported the enclosing node's pointer as if the operator were not there. Each now binds the segment to a local and uses it, which is what `assertInFilter` and `assertMatchesFilter` already did:

| before | after |
| -- | -- |
| `/filter/[1]` | `/filter/any/[1]` |
| `/filter/a/bogus` | `/filter/range/a/bogus` |
| `/filter/title/b` | `/filter/eq/title/b` |

`assertRangeFilter`'s unknown-key arm also reported the field path without naming the key it rejected, while the `gt/gte/lt/lte` arm beside it already concatenated the key. Between the two, every pointer assertion in the new tests identifies the entry that was rejected rather than the node it sits under.

**`assertSortExpression` now constrains `direction` on every sort entry.** It reached that check only on the branch where an entry names a type; a general sort field (`lastModified`, `createdAt`, `cardURL`) is anchored by the column it maps to rather than by `on`, so it returned before the check and carried any `direction` value through. The check moves above the branching, where it covers both shapes.

**The comment on `withTypeSentinels`** in `packages/base/operations.ts` is updated to match the tightened check: the sentinel's `notJson` entry is refused anywhere the JSON check walks a value, no longer only when it happens to be the object's first key. (No behavioural delta there — `notJson` is the literal's first key, so head-stopping already refused it.)

## Scope review

Tightening a validator changes which requests are accepted, so the question is whether anything depended on the gap.

Two of the four shapes in the table above are pure JSON and **do** reach `assertQuery` from the wire — `translateFieldKeys` copies range constraint objects through verbatim, and the AI tool's JSON arrives directly. Those newly return 400 where they previously 500'd, which is the intent. (`{ any: [good, 'not a filter'] }` is unreachable from `/_search` for a different reason: `translateFilterNode` rejects it first with its own message.)

The shapes that could change a *result* rather than an error are the `assertJSONValue` half — a function, `undefined`, a symbol, a bigint — and those cannot arrive at any of the three `assertQuery` call sites. Two receive JSON-derived data, where none of them survive the trip. The third (`operations.ts`) runs behind `assertReferencesResolve`, a position-aware DFS over the whole declaration that rejects `undefined` everywhere before `assertQueryIsWellFormed` is reached. (It permits functions in type slots — that is what `withTypeSentinels` exists for — so `undefined` is the part of that check this argument rests on.)

The sharp cases confirm the boundary: `{ range: { views: { gte: 1, lte: undefined } } }` and `{ eq: { a: 1, b: undefined } }` are both newly rejected, and both are unreachable for that reason.

Supporting checks:

- **Every query shape the product actually builds still validates** — the search query-builder's OR of a full-text match with two title matches, `workspace`'s process/remix type union, the openrouter model filter's nested `any`, the CRM task ranges (including `gte` + `lte` on one field path), the multi-field/multi-bound range in the text-suggestion tests, `range` with a `null` bound, a field genuinely named `on` under a predicate, `in`, nested JSON values, and a full `filter` + `sort` + `page` + `fields` + `realms` query.
- **No serialized query fixtures depend on it.** No realm content or saved-search fixture carries a stored filter; the only JSON files matching `"any"` / `"range"` are Grafana dashboards.
- **The declared-`query` operation path is unaffected.** Verified the code-ref sentinel across type slots (`filter.type`, `filter.on`, `sort[].on`) and value slots, in both key orders and at depth: type slots still accept it (`isCodeRef` tolerates extra keys), value slots still refuse it.
- **The AI tool path surfaces a clear error, not a crash.** `search-cards.ts` calls `assertQuery` unguarded, but `tool-service.ts` catches a throw from tool execution and posts a `failed` tool result carrying `error.message` — which names the offending pointer, so the model can correct and retry.
- **These were the only sites with this shape**, across every `Array.prototype.every` call site in `packages/`. The others that sit near a `throw` (`search-entry.ts`, `search-utils.ts`) pass a real boolean predicate and check its result.
- **No caller regresses on the error-class change.** `json-validation.ts` has exactly one importer, `InvalidQueryError extends Error` so every `catch` and `instanceof Error` still matches, and no caller narrows on `constructor`, `err.name`, or either validator's message text.

## Tests

`packages/runtime-common/tests/assert-query-validation-test.ts`, mirrored into `packages/realm-server/tests/`. Each collection case places the offending entry in a **non-first** position — the only position that distinguishes a loop that walks the whole collection from one that stops at its head — and asserts both the error class and the full pointer:

- a second `any` element that is not a filter → `/filter/any/[1]`
- a second `range` field path with a bogus constraint → `/filter/range/b/bogus`
- a second constraint key within one field → `/filter/range/a/bogus`, and a non-primitive bound → `/filter/range/a/lt`
- a nested object whose second key is not JSON → `/filter/eq/title/b`, and a non-JSON leaf below the second key at depth → `/filter/contains/meta/second/deep`
- a nested array whose second element is not JSON → `/filter/eq/tags/[1]`
- every general sort field and a card-field sort, each rejected for a `direction` that is not `asc`/`desc`, plus the valid directions and an absent one accepted
- a positive case pinning the multi-entry shapes that must keep clearing validation

**Every part of the diff is independently load-bearing**, checked by reverting each in isolation against the tests:

| reverted | failures |
| -- | -- |
| `query.ts` + `json-validation.ts` to `main` | 7, all "expected a throw" |
| the two leaf error classes only | 4, all "throw did not match" |
| `assertSortExpression` only | 3 — one per general sort field, the card-field entry passing before and after |
| the pointer segments only | 7 — each naming the truncated pointer it produced |

Branch: 18 assertions, 0 failures. Also run: the existing `query-matches-filter-test.ts` shared suite (25 assertions, clean); `eslint` on all changed files (clean); `ember-tsc --noEmit` for `runtime-common` — identical error count to a clean tree, all in `boxel-ui` / generated `boxel-icons` / `ember-draggable-modifiers`, none in the changed files. Shared-test keys verified 7/7 byte-identical to the mirror's test names, which `runSharedTest` requires. The new realm-server test file is picked up by the suite's directory walk and lands in one shard at the default weight, so it needs no registration.

## Known gaps this does not close

Each is tracked, with reproductions:

- **Empty collections still clear validation.** `forEach` over zero entries throws nothing, so `{ eq: {} }`, `{ contains: {} }`, `{ in: {} }`, `{ range: {} }`, `{ range: { views: {} } }` and `{ every: [] }` all compile to `every([])` → SQL `true`, matching every row; `{ any: [] }` compiles to `false`. `assertHtmlQuery` in `search-entry.ts` already rejects its empty `eq` explicitly, and a comment in that same file asserts `assertQuery` does too — it does not.
- **`assertFilter` validates only one predicate per filter node.** It dispatches on the first predicate key in an `if / else if` chain, so `{ filter: { eq: { a: 1 }, range: 'garbage' } }` passes. Three implementations walk that chain in three different orders — `assertFilter`, `IndexQueryEngine.filterCondition`, and `matchInstanceAgainstFilter` — so a two-predicate node can be validated against one operator, compiled from another, and matched client-side on a third. Closing it also requires changing a shipped call site that builds such a node, so it is more than a validator fix.
- **`asserts query is Query` is unsound in both directions.** Arrays pass the field-keyed operator guards (`{ filter: { eq: [1, 2] } }`, and `assertQuery([])` itself), `assertPage` validates neither `page.number` nor `page.generation`, and `page.cursor` and `queryString` are validated but absent from the `Query` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiQbabCe4wRszxUjCAG1pr