### PR TITLE
Let a fill-height isolated template fill the host-mode top card instead of collapsing to its padding

### DIFF
--- a/packages/host/app/components/host-mode/stack-item.gts
+++ b/packages/host/app/components/host-mode/stack-item.gts
@@ -216,6 +216,16 @@ export default class HostModeStackItem extends Component<Signature> {
         padding-top: var(--boxel-sp-2xl);
         z-index: 0;
         pointer-events: none;
+        /* The top card is content-sized (height: auto, see
+           styleForStackedCard) with an 80cqh floor so the page scrolls as a
+           page. But a percentage height never resolves against min-height, so
+           an isolated template that fills its container (height: 100%,
+           container-type: size, cqh units) had nothing to fill and collapsed
+           to its padding. A grid area IS definite for its item even when the
+           grid's own height is auto: the single 1fr row hands the card the
+           floor when content is short and still grows when it is tall. */
+        display: grid;
+        grid-template-rows: minmax(0, 1fr);
       }
 
       .host-mode-stack-item:not(.buried) {

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -686,6 +686,42 @@ module('Acceptance | host mode tests', function (hooks) {
     assert.dom('[data-test-pet-isolated="Mango"]').exists();
   });
 
+  test('a fill-height isolated template fills the top stack card instead of collapsing to its content', async function (assert) {
+    // Pet's isolated root is `height: 100%`. The top card is content-sized
+    // (height: auto) with a min-height floor, and a percentage height never
+    // resolves against min-height — so without a definite box handed down by
+    // the stack item, the root collapsed to the height of its <h2>.
+    await visit('/test');
+    await click('[data-test-boxel-filter-list-button="All Cards"]');
+    await waitFor('[data-test-cards-grid-item]');
+    await click(
+      `[data-test-cards-grid-item="${testHostModeRealmURL}Pet/mango"]`,
+    );
+    await waitFor('[data-test-pet-isolated="Mango"]');
+
+    let item = document.querySelector<HTMLElement>(
+      `[data-test-host-mode-stack-item="${testHostModeRealmURL}Pet/mango"]`,
+    )!;
+    let root = document.querySelector<HTMLElement>(
+      '[data-test-pet-isolated="Mango"]',
+    )!.parentElement!;
+    let itemStyle = getComputedStyle(item);
+    let offered =
+      item.getBoundingClientRect().height -
+      parseFloat(itemStyle.paddingTop) -
+      parseFloat(itemStyle.paddingBottom);
+    let filled = root.getBoundingClientRect().height;
+
+    assert.ok(
+      filled >= offered - 1,
+      `isolated root fills the stack item (root ${filled}px, item offers ${offered}px)`,
+    );
+    assert.ok(
+      filled > root.querySelector('h2')!.getBoundingClientRect().height,
+      'root is taller than its own content',
+    );
+  });
+
   test('viewCard tabs persist after stacking and closing cards in host mode', async function (assert) {
     let primaryCardId = `${testHostModeRealmURL}ViewCardDemo/index`;
     let firstStackCardId = `${testHostModeRealmURL}ViewCardDemo/secondary`;


### PR DESCRIPTION
## The bug, as a user sees it

Publish a realm whose card looks fine in operator mode, open it on the `*.boxel.space` site with `?hostModeStack=[…]`, and the top stack card renders as a **~150px strip** across the top of the page: the card's ground colour, its top padding, one link chip that overflowed a zero-height layout, and the close button. The headline never appears. Underneath, the pinned tile on the workspace Home shows the *same card rendering perfectly* — so it isn't the card's data, it's the container it was handed.

Reproduced with a poster card whose isolated root is `height: 100%; container-type: size` (type sized in `cqh`). Any isolated template that fills its container hits it; the realm's test `Pet` card (`.pet-isolated { height: 100% }`) is enough.

## Why the top card is `height: auto`

#3934 (`65e8163504`, *host mode stack layering and scroll update*) made the host-mode top card **content-sized** with an `80cqh` floor, and moved scrolling to `.inner` so a published page scrolls like a page instead of showing a scrollbar inside the card. That's the right call for a published site — a long document should grow.

The symmetry it broke: operator mode's stack item hands every card a **definite** height (`height: calc(100% - Npx)`) and its `.stack-item-card` is a grid that propagates that height down the chain (see the comment block at `operator-mode/stack-item.gts` ~L1242: "Propagate height through the chain…"). Host mode's `@media print` rules restore exactly that definite contract for printing. So the same `isolated` format meets two contracts, and nothing in the chain below can tell which one it's in.

The specific CSS fact: **a percentage height never resolves against `min-height`.** `height: 100%` on a child of an `auto`-height box computes to `auto` even when that box has a floor. Under `container-type: size` content contributes nothing, so the root has literally no height.

## The fix

Make the stack item a single-row grid:

```css
.host-mode-stack-item {
  display: grid;
  grid-template-rows: minmax(0, 1fr);
}
```

A grid area is definite for its item even when the grid's own height is `auto`, so the row hands `.stack-item-card` the floor when content is short — and still grows when content is tall. `height: auto`, the `80cqh` floor and the page-scroll behaviour from #3934 are untouched. Every layer below already passes `height: 100%` down (`.boxel-card-container`, `.field-component-card.isolated-format`), so this is the one missing link.

Measured through the real element chain (stack item → `.stack-item-card` → `CardContainer.host-mode-card` → `field-component-card.isolated-format` → root) at a 490px floor:

| case | before | after |
|---|---|---|
| root `height: 100%` + `container-type: size` | **48px** (padding only) | **490px** (the floor) |
| `Pet` root `height: 100%` | collapsed to its `<h2>` | **490px** |
| long document, 25 paragraphs | 823px | **823px** — still grows |

## Test

Adds an acceptance test in `host-mode-test.gts` that stacks `Pet/mango` and asserts its `height: 100%` root fills the stack item's content box (item height minus its paddings) and is taller than its own `<h2>`. The assertion is relative, so it holds under `#ember-testing` scaling and any floor value.

I was not able to run the host acceptance suite locally from this checkout — relying on CI for the end-to-end confirmation; the chain measurements above are from a standalone reproduction of the exact DOM/CSS chain in Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
