### PR TITLE
Reset the virtual network in place instead of replacing it

### DIFF
--- a/packages/host/app/services/network.ts
+++ b/packages/host/app/services/network.ts
@@ -63,15 +63,7 @@ export default class NetworkService extends Service {
     return this.virtualNetwork.mount.bind(this.virtualNetwork);
   }
 
-  private makeVirtualNetwork() {
-    let virtualNetwork = new VirtualNetwork(globalThis.fetch, {
-      // Native (un-stubbed) timer so the fetch retry path's header-timeout
-      // abort and retry backoff still fire during prerender, where
-      // render-timer-stub disables the global setTimeout — otherwise a stalled
-      // fetch there can neither abort nor retry and hangs the render. Outside
-      // prerender this is the global setTimeout, so behavior is unchanged.
-      scheduleFetchTimer: (callback, ms) => scheduleNativeTimeout(callback, ms),
-    });
+  private configureVirtualNetwork(virtualNetwork: VirtualNetwork) {
     // Registered from the shared declaration rather than one block per realm,
     // so this set cannot drift from the one the realm-server registers.
     //
@@ -127,11 +119,31 @@ export default class NetworkService extends Service {
         );
       }
     }
+  }
+
+  private makeVirtualNetwork() {
+    let virtualNetwork = new VirtualNetwork(globalThis.fetch, {
+      // Native (un-stubbed) timer so the fetch retry path's header-timeout
+      // abort and retry backoff still fire during prerender, where
+      // render-timer-stub disables the global setTimeout — otherwise a stalled
+      // fetch there can neither abort nor retry and hangs the render. Outside
+      // prerender this is the global setTimeout, so behavior is unchanged.
+      scheduleFetchTimer: (callback, ms) => scheduleNativeTimeout(callback, ms),
+    });
+    this.configureVirtualNetwork(virtualNetwork);
     return virtualNetwork;
   }
 
+  // Returns this service's network to its just-booted configuration without
+  // replacing it. The instance is handed to consumers that keep it — the
+  // Loader folds cache keys through it, `fetcher` closes over it — so
+  // swapping in a replacement would leave them naming through a network
+  // nothing else consults, and their mapping-change subscriptions attached to
+  // the discarded one. `reset()` clears the mappings and tells the
+  // subscribers; re-registering restores the set every boot installs.
   resetState = () => {
-    this.virtualNetwork = this.makeVirtualNetwork();
+    this.virtualNetwork.reset();
+    this.configureVirtualNetwork(this.virtualNetwork);
   };
 }
 

--- a/packages/host/tests/unit/virtual-network-reset-test.ts
+++ b/packages/host/tests/unit/virtual-network-reset-test.ts
@@ -75,7 +75,7 @@ module('Unit | VirtualNetwork reset', function () {
 
   // A reset leaves the handler chain alone, so both the constructor's package
   // shim handler and anything a caller mounted go on serving. Clearing it
-  // stranded every shimmed package, and then every in-process realm.
+  // would strand every shimmed package, and with them every in-process realm.
   test('keeps serving modules shimmed before a reset', async function (assert) {
     let vn = networkWithRealm();
     vn.shimModule('a-package', { thing: 1 });
@@ -120,19 +120,53 @@ module('Unit | VirtualNetwork reset', function () {
     );
   });
 
-  test('a Loader holding the network sees mappings registered after a reset', function (assert) {
+  // Runs through the holder this change is about rather than through the
+  // network directly. The first assertion is the one a reset has to deliver: a
+  // key folded under a mapping the network has forgotten must not survive it.
+  test('a Loader holding the network stops folding through a forgotten mapping', function (assert) {
     let vn = networkWithRealm();
     let loader = new Loader(vn.fetch, vn.resolveImport, {
       virtualNetwork: vn,
     });
+    let resolved = `${realmURL}thing`;
+    assert.strictEqual(
+      loader.moduleKey(resolved),
+      '@scope/realm/thing',
+      'folds through the mapping while it is registered',
+    );
 
     vn.reset();
-    vn.addRealmMapping('@scope/fresh/', 'https://example.com/fresh/');
 
+    assert.strictEqual(
+      loader.moduleKey(resolved),
+      resolved,
+      'the key derived before the reset did not outlive it',
+    );
+
+    vn.addRealmMapping('@scope/fresh/', 'https://example.com/fresh/');
     assert.strictEqual(
       loader.moduleKey('https://example.com/fresh/mod'),
       '@scope/fresh/mod',
-      'the loader folds through the post-reset mapping without being rebuilt',
+      'and a mapping registered afterwards folds without rebuilding the loader',
+    );
+  });
+
+  // The shims a package namespace addresses survive on the shim handler, so
+  // the namespace has to survive with them — otherwise the network serves a
+  // shimmed module while refusing to recognise the specifier naming it.
+  test('keeps package namespaces while forgetting realms', function (assert) {
+    let vn = networkWithRealm();
+    vn.addPackageMapping('@cardstack/boxel-ui/', 'https://packages/boxel-ui/');
+
+    vn.reset();
+
+    assert.true(
+      vn.isRegisteredPrefix('@cardstack/boxel-ui/components'),
+      'the package namespace is still registered',
+    );
+    assert.false(
+      vn.isRegisteredPrefix('@scope/realm/thing'),
+      'the realm mapping is not',
     );
   });
 });

--- a/packages/host/tests/unit/virtual-network-reset-test.ts
+++ b/packages/host/tests/unit/virtual-network-reset-test.ts
@@ -73,6 +73,37 @@ module('Unit | VirtualNetwork reset', function () {
     );
   });
 
+  // The constructor mounts the package shim handler. Emptying the handler chain
+  // on reset left `shimModule` filing shims onto a handler nothing consulted,
+  // so every shimmed package 404'd with nothing to point at the cause.
+  test('keeps serving modules shimmed before a reset', async function (assert) {
+    let vn = networkWithRealm();
+    vn.shimModule('a-package', { thing: 1 });
+
+    vn.reset();
+
+    let response = await vn.fetch(new Request('https://packages/a-package'));
+    assert.strictEqual(
+      (response as any)[Symbol.for('shimmed-module')]?.thing,
+      1,
+      'the shim handler is still mounted',
+    );
+  });
+
+  test('serves modules shimmed after a reset', async function (assert) {
+    let vn = networkWithRealm();
+
+    vn.reset();
+    vn.shimModule('b-package', { thing: 2 });
+
+    let response = await vn.fetch(new Request('https://packages/b-package'));
+    assert.strictEqual(
+      (response as any)[Symbol.for('shimmed-module')]?.thing,
+      2,
+      'shims registered after a reset are served',
+    );
+  });
+
   test('a Loader holding the network sees mappings registered after a reset', function (assert) {
     let vn = networkWithRealm();
     let loader = new Loader(vn.fetch, vn.resolveImport, {

--- a/packages/host/tests/unit/virtual-network-reset-test.ts
+++ b/packages/host/tests/unit/virtual-network-reset-test.ts
@@ -1,0 +1,119 @@
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import { Loader, VirtualNetwork } from '@cardstack/runtime-common';
+
+import { setupRenderingTest } from '../helpers/setup';
+
+const realmURL = 'https://example.com/realm/';
+
+function networkWithRealm() {
+  let vn = new VirtualNetwork(
+    async () => new Response('', { status: 404 }),
+    {},
+  );
+  vn.addRealmMapping('@scope/realm/', realmURL);
+  return vn;
+}
+
+module('Unit | VirtualNetwork reset', function () {
+  test('clears every registered mapping', function (assert) {
+    let vn = networkWithRealm();
+    assert.true(vn.isRegisteredPrefix('@scope/realm/thing'), 'registered');
+
+    vn.reset();
+
+    assert.false(
+      vn.isRegisteredPrefix('@scope/realm/thing'),
+      'the prefix is gone after a reset',
+    );
+  });
+
+  test('notifies mapping-change listeners, because clearing every mapping is a mapping change', function (assert) {
+    let vn = networkWithRealm();
+    let fired = 0;
+    vn.onMappingChange(() => fired++);
+
+    vn.reset();
+
+    assert.strictEqual(fired, 1, 'the listener was told');
+  });
+
+  test('keeps listeners subscribed across a reset', function (assert) {
+    let vn = networkWithRealm();
+    let fired = 0;
+    vn.onMappingChange(() => fired++);
+
+    vn.reset();
+    vn.addRealmMapping('@scope/other/', 'https://example.com/other/');
+
+    assert.strictEqual(
+      fired,
+      2,
+      'a subscriber registered before the reset still hears later changes',
+    );
+  });
+
+  test('stops folding identifiers through mappings it no longer has', function (assert) {
+    let vn = networkWithRealm();
+    let resolved = `${realmURL}thing`;
+    assert.strictEqual(
+      vn.unresolveURL(resolved),
+      '@scope/realm/thing',
+      'folds to the prefix while the mapping is registered',
+    );
+
+    vn.reset();
+
+    assert.strictEqual(
+      vn.unresolveURL(resolved),
+      resolved,
+      'the derived cache did not outlive the mapping it was keyed under',
+    );
+  });
+
+  test('a Loader holding the network sees mappings registered after a reset', function (assert) {
+    let vn = networkWithRealm();
+    let loader = new Loader(vn.fetch, vn.resolveImport, {
+      virtualNetwork: vn,
+    });
+
+    vn.reset();
+    vn.addRealmMapping('@scope/fresh/', 'https://example.com/fresh/');
+
+    assert.strictEqual(
+      loader.moduleKey('https://example.com/fresh/mod'),
+      '@scope/fresh/mod',
+      'the loader folds through the post-reset mapping without being rebuilt',
+    );
+  });
+});
+
+module('Unit | network service reset', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('resets its network in place rather than replacing it', function (assert) {
+    let network = getService('network');
+    let before = network.virtualNetwork;
+
+    network.resetState();
+
+    assert.strictEqual(
+      network.virtualNetwork,
+      before,
+      'consumers holding the network — the loader, the fetcher chain — still hold the live one',
+    );
+  });
+
+  test('re-registers the mappings every boot installs', function (assert) {
+    let network = getService('network');
+
+    network.resetState();
+
+    assert.true(
+      network.virtualNetwork.isRegisteredPrefix('@cardstack/base/card-api'),
+      'the base realm prefix is registered again after a reset',
+    );
+  });
+});

--- a/packages/host/tests/unit/virtual-network-reset-test.ts
+++ b/packages/host/tests/unit/virtual-network-reset-test.ts
@@ -73,9 +73,9 @@ module('Unit | VirtualNetwork reset', function () {
     );
   });
 
-  // The constructor mounts the package shim handler. Emptying the handler chain
-  // on reset left `shimModule` filing shims onto a handler nothing consulted,
-  // so every shimmed package 404'd with nothing to point at the cause.
+  // A reset leaves the handler chain alone, so both the constructor's package
+  // shim handler and anything a caller mounted go on serving. Clearing it
+  // stranded every shimmed package, and then every in-process realm.
   test('keeps serving modules shimmed before a reset', async function (assert) {
     let vn = networkWithRealm();
     vn.shimModule('a-package', { thing: 1 });
@@ -101,6 +101,22 @@ module('Unit | VirtualNetwork reset', function () {
       (response as any)[Symbol.for('shimmed-module')]?.thing,
       2,
       'shims registered after a reset are served',
+    );
+  });
+
+  test('leaves a caller-mounted handler serving across a reset', async function (assert) {
+    let vn = networkWithRealm();
+    vn.mount(async (request: Request) =>
+      request.url === 'http://mounted/thing' ? new Response('served') : null,
+    );
+
+    vn.reset();
+
+    let response = await vn.fetch(new Request('http://mounted/thing'));
+    assert.strictEqual(
+      await response.text(),
+      'served',
+      "a mount is the owner's lifecycle, not the session's",
     );
   });
 

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -110,8 +110,7 @@ export class VirtualNetwork {
 
   // Subscribe to realm-mapping changes; returns an unsubscribe function.
   /**
-   * Drops every registered mapping, caller-mounted handler and derived cache,
-   * returning this instance to the state a fresh one would have.
+   * Drops the registered mappings and the caches derived from them.
    *
    * Resetting in place rather than constructing a replacement is deliberate.
    * Consumers hold this object — the Loader keeps it for cache-key folding,
@@ -127,13 +126,12 @@ export class VirtualNetwork {
    * under the old mappings cannot be allowed to outlive them.
    */
   reset(): void {
-    // The constructor mounts the package shim handler, and a fresh instance
-    // therefore has it. Emptying the chain outright would leave `shimModule`
-    // still filing shims onto a handler nothing consults, so every shimmed
-    // package — `@glimmer/component` and the rest of `shimExternals` — would
-    // 404 with no indication why. Re-mount it, keeping its registry: shims are
-    // module code keyed by package name, not session state.
-    this.handlers = [this.packageShimHandler.handle];
+    // Mounted handlers are deliberately left alone. They are the owner's
+    // lifecycle, not the session's — an in-process realm does not stop
+    // existing because someone logged in — and nothing re-mounts them, so
+    // clearing them here would strand every fetch to one. A fresh instance has
+    // no caller mounts because it belongs to a fresh owner; that isolation
+    // comes from constructing the network, not from resetting it.
     this.urlMappings = [];
     this.importMap.clear();
     this.realmMappings.clear();

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -110,8 +110,8 @@ export class VirtualNetwork {
 
   // Subscribe to realm-mapping changes; returns an unsubscribe function.
   /**
-   * Drops every registered mapping, handler and derived cache, returning this
-   * instance to the state a fresh one would have.
+   * Drops every registered mapping, caller-mounted handler and derived cache,
+   * returning this instance to the state a fresh one would have.
    *
    * Resetting in place rather than constructing a replacement is deliberate.
    * Consumers hold this object — the Loader keeps it for cache-key folding,
@@ -127,7 +127,13 @@ export class VirtualNetwork {
    * under the old mappings cannot be allowed to outlive them.
    */
   reset(): void {
-    this.handlers = [];
+    // The constructor mounts the package shim handler, and a fresh instance
+    // therefore has it. Emptying the chain outright would leave `shimModule`
+    // still filing shims onto a handler nothing consults, so every shimmed
+    // package — `@glimmer/component` and the rest of `shimExternals` — would
+    // 404 with no indication why. Re-mount it, keeping its registry: shims are
+    // module code keyed by package name, not session state.
+    this.handlers = [this.packageShimHandler.handle];
     this.urlMappings = [];
     this.importMap.clear();
     this.realmMappings.clear();

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -109,8 +109,13 @@ export class VirtualNetwork {
   private scheduleFetchTimer: (callback: () => void, ms: number) => unknown;
 
   // Subscribe to realm-mapping changes; returns an unsubscribe function.
+  onMappingChange(listener: () => void): () => void {
+    this.mappingChangeListeners.add(listener);
+    return () => this.mappingChangeListeners.delete(listener);
+  }
+
   /**
-   * Drops the registered mappings and the caches derived from them.
+   * Forgets the realms this network knows, and nothing else.
    *
    * Resetting in place rather than constructing a replacement is deliberate.
    * Consumers hold this object — the Loader keeps it for cache-key folding,
@@ -119,32 +124,48 @@ export class VirtualNetwork {
    * nothing else consults, with no signal that it happened. Identity is what
    * makes those holders correct, so it is preserved and the listeners are told.
    *
-   * Listeners survive the reset for the same reason: a subscriber registered
-   * against this instance is still a live subscriber afterwards. They are
-   * notified last, once the state is already empty, because clearing every
-   * mapping at once is the largest mapping change there is — a cache keyed
-   * under the old mappings cannot be allowed to outlive them.
+   * What survives is what belongs to the host build rather than to a session:
+   * mounted handlers, the shim registry, and the package namespaces that
+   * address it. What goes is realm knowledge — realm mappings, realm URL
+   * aliases, and the memos derived from them.
+   *
+   * Listeners survive too: a subscriber registered against this instance is
+   * still a live subscriber afterwards. They are notified last, once the state
+   * is already gone, because dropping every realm at once is the largest
+   * mapping change there is — a memo keyed under the old mappings cannot be
+   * allowed to outlive them.
    */
   reset(): void {
-    // Mounted handlers are deliberately left alone. They are the owner's
-    // lifecycle, not the session's — an in-process realm does not stop
-    // existing because someone logged in — and nothing re-mounts them, so
-    // clearing them here would strand every fetch to one. A fresh instance has
-    // no caller mounts because it belongs to a fresh owner; that isolation
-    // comes from constructing the network, not from resetting it.
+    // Mounted handlers are the owner's lifecycle, not the session's — an
+    // in-process realm does not stop existing because someone logged in — and
+    // nothing re-mounts them, so clearing them here would strand every fetch
+    // to one. A fresh instance has no caller mounts because it belongs to a
+    // fresh owner; that isolation comes from constructing the network, not
+    // from resetting it.
+    //
+    // Package namespaces are kept for the same reason, one level up: the shims
+    // they address survive on `packageShimHandler`, so dropping the prefix
+    // would leave the network serving a shimmed module while refusing to
+    // recognise the specifier that names it.
+    for (let prefix of [...this.realmMappings.keys()]) {
+      if (this.packageNamespacePrefixes.has(prefix)) {
+        continue;
+      }
+      this.realmMappings.delete(prefix);
+      this.importMap.delete(prefix);
+    }
     this.urlMappings = [];
-    this.importMap.clear();
-    this.realmMappings.clear();
-    this.packageNamespacePrefixes.clear();
-    this.toURLHrefCache.clear();
-    this.unresolveURLCache.clear();
-    this.realURLHrefCache.clear();
+    this.clearURLCaches();
     this.notifyMappingChange();
   }
 
-  onMappingChange(listener: () => void): () => void {
-    this.mappingChangeListeners.add(listener);
-    return () => this.mappingChangeListeners.delete(listener);
+  // The three URL memos are keyed by the mapping set, so every mutation has to
+  // drop all three together. Collected here so a fourth memo cannot be added
+  // to some of the call sites and not the rest.
+  private clearURLCaches() {
+    this.toURLHrefCache.clear();
+    this.unresolveURLCache.clear();
+    this.realURLHrefCache.clear();
   }
 
   private notifyMappingChange() {
@@ -181,9 +202,7 @@ export class VirtualNetwork {
     // its virtual→real mapURL step), so a new URL mapping invalidates their
     // memos. toURLHref resolves only through realmMappings, so clearing its
     // cache here is purely defensive.
-    this.toURLHrefCache.clear();
-    this.unresolveURLCache.clear();
-    this.realURLHrefCache.clear();
+    this.clearURLCaches();
     // Consumers keying caches by a mapping-derived identifier need to hear about
     // this too, not just about realm mappings: a URL mapping changes which alias
     // an identifier folds onto, so a key derived before this call can name a
@@ -277,9 +296,7 @@ export class VirtualNetwork {
     let normalizedId = ensureTrailingSlash(prefix);
     let normalizedTarget = ensureTrailingSlash(targetURL);
     this.realmMappings.set(normalizedId, normalizedTarget);
-    this.toURLHrefCache.clear();
-    this.unresolveURLCache.clear();
-    this.realURLHrefCache.clear();
+    this.clearURLCaches();
     this.addImportMap(
       normalizedId,
       (rest) => new URL(rest, normalizedTarget).href,
@@ -303,9 +320,7 @@ export class VirtualNetwork {
     // growing for the life of the process.
     this.packageNamespacePrefixes.delete(normalizedId);
     this.importMap.delete(normalizedId);
-    this.toURLHrefCache.clear();
-    this.unresolveURLCache.clear();
-    this.realURLHrefCache.clear();
+    this.clearURLCaches();
     this.notifyMappingChange();
   }
 

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -109,6 +109,35 @@ export class VirtualNetwork {
   private scheduleFetchTimer: (callback: () => void, ms: number) => unknown;
 
   // Subscribe to realm-mapping changes; returns an unsubscribe function.
+  /**
+   * Drops every registered mapping, handler and derived cache, returning this
+   * instance to the state a fresh one would have.
+   *
+   * Resetting in place rather than constructing a replacement is deliberate.
+   * Consumers hold this object — the Loader keeps it for cache-key folding,
+   * `fetcher` closes over it, `Loader.cloneLoader` copies it onto the clone —
+   * and a replacement leaves every one of them naming through a network
+   * nothing else consults, with no signal that it happened. Identity is what
+   * makes those holders correct, so it is preserved and the listeners are told.
+   *
+   * Listeners survive the reset for the same reason: a subscriber registered
+   * against this instance is still a live subscriber afterwards. They are
+   * notified last, once the state is already empty, because clearing every
+   * mapping at once is the largest mapping change there is — a cache keyed
+   * under the old mappings cannot be allowed to outlive them.
+   */
+  reset(): void {
+    this.handlers = [];
+    this.urlMappings = [];
+    this.importMap.clear();
+    this.realmMappings.clear();
+    this.packageNamespacePrefixes.clear();
+    this.toURLHrefCache.clear();
+    this.unresolveURLCache.clear();
+    this.realURLHrefCache.clear();
+    this.notifyMappingChange();
+  }
+
   onMappingChange(listener: () => void): () => void {
     this.mappingChangeListeners.add(listener);
     return () => this.mappingChangeListeners.delete(listener);


### PR DESCRIPTION
`NetworkService.resetState` built a fresh `VirtualNetwork` and assigned it over the old one:

```ts
resetState = () => {
  this.virtualNetwork = this.makeVirtualNetwork();
};
```

Consumers hold that object rather than reading it per call. The Loader keeps it to fold cache keys, canonicalize identifiers and compute tracking keys; `fetcher` closes over it; and `Loader.cloneLoader` copies it onto the clone. After a reset each of them named through a network nothing else consulted.

Their `onMappingChange` subscriptions stayed on the discarded instance too, so the memos those subscriptions exist to clear were never cleared — they went on answering under mappings that had been thrown away. The clone path is the sharpest edge: `cloneLoader` carries both `loader.virtualNetwork` and the captured `fetchImplementation` forward, so a session-boundary rebuild — the one operation meant to refresh things — perpetuated the superseded network.

## The fix

Reset the instance rather than replace it, and re-register the mappings onto the same object. Identity is what makes those holders correct, so preserving it fixes all of them at once, the clone path included.

The mapping registration moved out of `makeVirtualNetwork` into `configureVirtualNetwork`, so boot and reset install an identical set.

## What a reset forgets

`reset()` drops **realm knowledge** — realm mappings, realm URL aliases, and the three URL memos derived from them — and notifies its listeners, because dropping every realm at once is the largest mapping change there is.

It keeps what belongs to the **host build** rather than to a session:

| kept | why |
| -- | -- |
| mounted handlers | An in-process realm does not stop existing because someone logged in, and nothing re-mounts them. `SessionParticipant` states the rule: anything torn down in `resetState()` must be re-established, or it does not belong there. |
| the shim registry | Module code keyed by package name. Dropping it obliges every registrant to notice the reset and re-register. |
| package namespaces | The prefixes that address those shims. Dropping them serves a shimmed module while denying the specifier that names it. |
| listeners | A subscriber registered against this instance is still a live subscriber afterwards. |

The isolation the old replacement provided is not lost with it: `virtualNetwork` is an instance field, so a fresh owner builds a fresh network with no caller mounts. That never depended on resetting an existing one.

## Tests

Eight, in `virtual-network-reset-test.ts`. On the mechanism: realm mappings cleared, listeners notified, listeners still subscribed to later changes, a memo not outliving the mapping it was keyed under, modules shimmed before *and* after a reset still served, a caller-mounted handler still serving, and package namespaces surviving while realms do not. Through the holder: a Loader stops folding through a forgotten mapping and picks up one registered afterwards without being rebuilt. On the service: the network is reset in place rather than reassigned, and the standard mappings are registered again.

## Why it matters beyond hygiene

CS-12686's most concrete candidate for its class-identity crossing is a Loader bound to a superseded network whose module cache mapping changes never clear. That is what this closes, so the canonical-seed branch is worth re-running on top of this before anyone resumes the loader-selection investigation.

## Known adjacent asymmetry, not addressed here

`addImportMap` does not call `notifyMappingChange`, yet `resolveImport` feeds `moduleKey`, so an import-map-only registration changes a Loader's cache keys without telling subscribers. Unreachable today — the only bare caller is the boxel-icons registration at boot, and everything else arrives through `addPrefixMapping`, which notifies.