### PR TITLE
Add MediaCache bucket storage panels to the screenshot dashboard

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/screenshot-captures.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/screenshot-captures.json
@@ -789,7 +789,8 @@
         },
         "type": "stat",
         "title": "Bucket size (CloudWatch)",
-        "description": "BucketSizeBytes for boxel-media-cache-${env}. The bucket deliberately has no S3 lifecycle expiry \u2014 the media_cache_ledger-driven GC sweep is the only deletion path \u2014 so this panel is the growth watch. CloudWatch S3 storage metrics are reported once per day, so the value can lag up to ~48h. Shows 'No data' locally \u2014 CloudWatch is staging/production only.",
+        "description": "BucketSizeBytes for boxel-media-cache-${env}. The bucket deliberately has no S3 lifecycle expiry \u2014 the media_cache_ledger-driven deletes (the GC sweep and putMedia's repoint reclaim) are the only deletion path \u2014 so this panel is the growth watch. CloudWatch S3 storage metrics are reported once per day, so the value can lag up to ~48h; this panel spans 2d regardless of the dashboard range so lastNotNull always finds the newest daily sample. Shows 'No data' locally \u2014 CloudWatch is staging/production only.",
+        "timeFrom": "2d",
         "gridPos": {
           "h": 4,
           "w": 6,
@@ -847,7 +848,8 @@
         },
         "type": "stat",
         "title": "Bucket objects (CloudWatch)",
-        "description": "NumberOfObjects for boxel-media-cache-${env}, reported daily. Compare with 'Ledger object keys': the bucket stores one object per distinct object_key (dedupe-on-write), so the two counts should track each other; a persistent excess of bucket objects means orphans no ledger row references \u2014 invisible to GC, which scans ledger rows and never enumerates the bucket.",
+        "description": "NumberOfObjects for boxel-media-cache-${env}, reported daily. Compare with 'Ledger object keys': the bucket stores one object per distinct object_key (dedupe-on-write), so the two counts should track each other; a persistent excess of bucket objects means orphans no ledger row references \u2014 invisible to GC, which scans ledger rows and never enumerates the bucket. Spans 2d regardless of the dashboard range so lastNotNull always finds the newest daily sample.",
+        "timeFrom": "2d",
         "gridPos": {
           "h": 4,
           "w": 6,
@@ -1005,7 +1007,8 @@
         },
         "type": "timeseries",
         "title": "Bucket growth (daily)",
-        "description": "BucketSizeBytes (left axis) and NumberOfObjects (right axis) for boxel-media-cache-${env}, one CloudWatch sample per day. With no lifecycle expiry on the bucket, unbounded growth here means the ledger-driven GC chain (cron enqueue on the realm-server \u2192 queue \u2192 media-cache-gc on a worker) is broken or leaking; check the stats to the left to tell leaked bytes from legitimate growth.",
+        "description": "BucketSizeBytes (left axis) and NumberOfObjects (right axis) for boxel-media-cache-${env}, one CloudWatch sample per day. With no lifecycle expiry on the bucket, unbounded growth here means the ledger-driven GC chain (cron enqueue in the worker-manager \u2192 queue \u2192 media-cache-gc on a worker) is broken or leaking; check the stats to the left to tell leaked bytes from legitimate growth. Spans 30d regardless of the dashboard range so the daily samples form a trend.",
+        "timeFrom": "30d",
         "gridPos": {
           "h": 8,
           "w": 12,

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/screenshot-captures.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/screenshot-captures.json
@@ -769,6 +769,335 @@
             }
           }
         ]
+      },
+      {
+        "type": "row",
+        "title": "MediaCache storage",
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 51
+        },
+        "panels": []
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "type": "stat",
+        "title": "Bucket size (CloudWatch)",
+        "description": "BucketSizeBytes for boxel-media-cache-${env}. The bucket deliberately has no S3 lifecycle expiry \u2014 the media_cache_ledger-driven GC sweep is the only deletion path \u2014 so this panel is the growth watch. CloudWatch S3 storage metrics are reported once per day, so the value can lag up to ~48h. Shows 'No data' locally \u2014 CloudWatch is staging/production only.",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 0,
+          "y": 52
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "unit": "bytes"
+          },
+          "overrides": []
+        },
+        "options": {
+          "colorMode": "none",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "value"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "namespace": "AWS/S3",
+            "metricName": "BucketSizeBytes",
+            "metricEditorMode": 0,
+            "metricQueryType": 0,
+            "dimensions": {
+              "BucketName": "boxel-media-cache-${env}",
+              "StorageType": "StandardStorage"
+            },
+            "statistic": "Maximum",
+            "period": "86400",
+            "region": "default",
+            "refId": "A",
+            "id": "a"
+          }
+        ]
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "type": "stat",
+        "title": "Bucket objects (CloudWatch)",
+        "description": "NumberOfObjects for boxel-media-cache-${env}, reported daily. Compare with 'Ledger object keys': the bucket stores one object per distinct object_key (dedupe-on-write), so the two counts should track each other; a persistent excess of bucket objects means orphans no ledger row references \u2014 invisible to GC, which scans ledger rows and never enumerates the bucket.",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 0,
+          "y": 56
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "options": {
+          "colorMode": "none",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "value"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "namespace": "AWS/S3",
+            "metricName": "NumberOfObjects",
+            "metricEditorMode": 0,
+            "metricQueryType": 0,
+            "dimensions": {
+              "BucketName": "boxel-media-cache-${env}",
+              "StorageType": "AllStorageTypes"
+            },
+            "statistic": "Maximum",
+            "period": "86400",
+            "region": "default",
+            "refId": "A",
+            "id": "a"
+          }
+        ]
+      },
+      {
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "cef5v5sl9k7i8f"
+        },
+        "type": "stat",
+        "title": "Ledger-referenced bytes",
+        "description": "Sum of size_bytes over distinct object_key in media_cache_ledger \u2014 the bytes the ledger believes are in the bucket. A 'Bucket size' reading that grows persistently past this is leaked storage: reclaim deletes that failed (logged and swallowed) or objects written without a ledger row. Expect skew up to ~48h from CloudWatch's daily reporting before reading a gap as a leak.",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 6,
+          "y": 52
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "unit": "bytes"
+          },
+          "overrides": []
+        },
+        "options": {
+          "colorMode": "none",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "value"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-postgresql-datasource",
+              "uid": "cef5v5sl9k7i8f"
+            },
+            "editorMode": "code",
+            "format": "table",
+            "rawQuery": true,
+            "rawSql": "SELECT COALESCE(SUM(size_bytes), 0) AS ledger_bytes\n  FROM (SELECT DISTINCT ON (object_key) size_bytes\n          FROM media_cache_ledger) per_object;",
+            "refId": "A"
+          }
+        ]
+      },
+      {
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "cef5v5sl9k7i8f"
+        },
+        "type": "stat",
+        "title": "Ledger object keys",
+        "description": "COUNT(DISTINCT object_key) in media_cache_ledger \u2014 how many objects the ledger references. The bucket-object counterpart to 'Ledger-referenced bytes'.",
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 6,
+          "y": 56
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "options": {
+          "colorMode": "none",
+          "graphMode": "none",
+          "justifyMode": "center",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "value"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "grafana-postgresql-datasource",
+              "uid": "cef5v5sl9k7i8f"
+            },
+            "editorMode": "code",
+            "format": "table",
+            "rawQuery": true,
+            "rawSql": "SELECT COUNT(DISTINCT object_key) AS ledger_keys\n  FROM media_cache_ledger;",
+            "refId": "A"
+          }
+        ]
+      },
+      {
+        "datasource": {
+          "type": "cloudwatch",
+          "uid": "cef5x9o3yzawwf"
+        },
+        "type": "timeseries",
+        "title": "Bucket growth (daily)",
+        "description": "BucketSizeBytes (left axis) and NumberOfObjects (right axis) for boxel-media-cache-${env}, one CloudWatch sample per day. With no lifecycle expiry on the bucket, unbounded growth here means the ledger-driven GC chain (cron enqueue on the realm-server \u2192 queue \u2192 media-cache-gc on a worker) is broken or leaking; check the stats to the left to tell leaked bytes from legitimate growth.",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 52
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "lineWidth": 1,
+              "pointSize": 5,
+              "showPoints": "auto",
+              "spanNulls": true
+            },
+            "unit": "bytes"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "NumberOfObjects"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "short"
+                },
+                {
+                  "id": "custom.axisPlacement",
+                  "value": "right"
+                }
+              ]
+            }
+          ]
+        },
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "namespace": "AWS/S3",
+            "metricName": "BucketSizeBytes",
+            "metricEditorMode": 0,
+            "metricQueryType": 0,
+            "dimensions": {
+              "BucketName": "boxel-media-cache-${env}",
+              "StorageType": "StandardStorage"
+            },
+            "statistic": "Maximum",
+            "period": "86400",
+            "region": "default",
+            "refId": "A",
+            "id": "a"
+          },
+          {
+            "datasource": {
+              "type": "cloudwatch",
+              "uid": "cef5x9o3yzawwf"
+            },
+            "namespace": "AWS/S3",
+            "metricName": "NumberOfObjects",
+            "metricEditorMode": 0,
+            "metricQueryType": 0,
+            "dimensions": {
+              "BucketName": "boxel-media-cache-${env}",
+              "StorageType": "AllStorageTypes"
+            },
+            "statistic": "Maximum",
+            "period": "86400",
+            "region": "default",
+            "refId": "B",
+            "id": "b"
+          }
+        ]
       }
     ],
     "preload": false,


### PR DESCRIPTION
The `boxel-media-cache-{env}` S3 bucket deliberately carries no lifecycle expiry — a time-based rule would delete objects the `media_cache_ledger` still references — which leaves the ledger-driven deletes (the GC sweep and putMedia's repoint reclaim) as the only deletion path. That path has two permanent-leak modes: a reclaim delete that fails is logged and swallowed, and an object with no ledger row is invisible to GC (which scans ledger rows and never enumerates the bucket). The sweep is cron-enqueued in the worker-manager and executed on a worker, so a break anywhere in that chain is otherwise visible only as spend.

## What this adds

A **MediaCache storage** row on the Screenshot Capture Performance dashboard:

- **Bucket size / Bucket objects** — CloudWatch's daily `AWS/S3` storage metrics (`BucketSizeBytes`, `NumberOfObjects`) for `boxel-media-cache-${env}`.
- **Ledger-referenced bytes / Ledger object keys** — Postgres: `SUM(size_bytes)` over distinct `object_key`, and `COUNT(DISTINCT object_key)`. The bucket stores one object per distinct key (dedupe-on-write), so bucket-vs-ledger drift that persists beyond CloudWatch's ~48h reporting lag reads directly as leaked storage or a broken GC chain.
- **Bucket growth (daily)** — timeseries of both CloudWatch metrics.

Panel descriptions carry the reading instructions (daily-metric lag, orphan semantics, 'No data' locally since CloudWatch is staging/production only).

## Test plan

- `packages/observability/scripts/lint.sh`: JSON syntax, manifest shape, and secret-shape checks pass (the prettier step needs installed node_modules and touches YAML only; this change is JSON-only).
- `grafanactl resources validate` requires a live Grafana token and was not run locally; CI pushes dashboards on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
