### PR TITLE
feat: resolve card() markers nested inside a mutation value

### DIFF
--- a/packages/bxl/docs/mutation-profile.md
+++ b/packages/bxl/docs/mutation-profile.md
@@ -994,6 +994,25 @@ move_item_before(
 );
 ```
 
+A relationship reached through a contained value is written the same way.
+A `card(id)` standing inside the object or array a statement writes is resolved
+where it stands, at any depth:
+
+```bxl
+append(.comments; {body: "Looks right to me", author: card(params("who"))});
+```
+
+A link is an edge of the Card rather than a member of the value, so the stored
+contained value holds `body` alone and the plan carries a separate relationship
+intent at `["comments", 0, "author"]`. A `linksToMany` written this way takes
+one marker per edge, and every member of it must be one, because the whole
+collection leaves the stored value together.
+
+The marker's argument reads the input the value expression was handed, so
+resolution follows the object, array and comma nodes that assemble a value.
+A `card(id)` somewhere that re-roots that input — the body of `map`, the right
+of a pipe — is refused rather than answered against the wrong value.
+
 The schema determines whether a selected location is contained data,
 `linksTo`, or `linksToMany`. It therefore lowers assignment, append, delete,
 insert, and move to relationship intents when the target field is a

--- a/packages/bxl/docs/mutation-profile.md
+++ b/packages/bxl/docs/mutation-profile.md
@@ -1009,9 +1009,12 @@ one marker per edge, and every member of it must be one, because the whole
 collection leaves the stored value together.
 
 The marker's argument reads the input the value expression was handed, so
-resolution follows the object, array and comma nodes that assemble a value.
-A `card(id)` somewhere that re-roots that input — the body of `map`, the right
-of a pipe — is refused rather than answered against the wrong value.
+resolution follows the nodes that pass that input straight down and can
+themselves be the value: object entries, array and comma streams, `//`
+operands, and the branches of an `if`. A `card(id)` somewhere that re-roots the
+input — the body of `map`, the right of a pipe — is refused rather than
+answered against the wrong value, and so is one in a condition, which chooses a
+branch rather than being the value.
 
 The schema determines whether a selected location is contained data,
 `linksTo`, or `linksToMany`. It therefore lowers assignment, append, delete,

--- a/packages/bxl/docs/mutation-profile.md
+++ b/packages/bxl/docs/mutation-profile.md
@@ -1008,13 +1008,22 @@ intent at `["comments", 0, "author"]`. A `linksToMany` written this way takes
 one marker per edge, and every member of it must be one, because the whole
 collection leaves the stored value together.
 
-The marker's argument reads the input the value expression was handed, so
-resolution follows the nodes that pass that input straight down and can
-themselves be the value: object entries, array and comma streams, `//`
-operands, and the branches of an `if`. A `card(id)` somewhere that re-roots the
-input — the body of `map`, the right of a pipe — is refused rather than
-answered against the wrong value, and so is one in a condition, which chooses a
-branch rather than being the value.
+A marker reads its argument against the input the value expression itself was
+handed, so resolution follows the nodes that pass that input straight down and
+whose operands flow into the result: object entries, array and comma streams,
+the operands of `//`, `+` and `*`, and the branches of an `if`. A `card(id)`
+somewhere that re-roots the input — the body of `map`, either side of a pipe —
+is refused rather than answered against the wrong value, and so is one in a
+condition, which chooses a branch rather than being the value, and one in an
+argument read as a plain value, such as an `assert` message or a `reorder_by`
+order, which names no Field to relate a Card to.
+
+The argument is read when the program reaches the marker, so a marker in a
+branch that is not taken costs nothing:
+
+```bxl
+.owner = (card(params("preferred")) // card(params("fallback")));
+```
 
 The schema determines whether a selected location is contained data,
 `linksTo`, or `linksToMany`. It therefore lowers assignment, append, delete,

--- a/packages/bxl/src/mutation/planner.ts
+++ b/packages/bxl/src/mutation/planner.ts
@@ -16,6 +16,7 @@ import {
   withRuntimeDiagnostics,
 } from '../jqtools/evaluate/runtimeState.ts';
 import type {
+  DestructuringAst,
   ExpressionAst,
   NormalBinaryOperator,
   RuntimeAnnotatedExpressionAst,
@@ -509,6 +510,25 @@ function evaluateItems(
   return withEvaluationBudget(context, (evaluate) => evaluate(ast, input));
 }
 
+/** Every expression a destructuring pattern holds, keys included. */
+function destructuringExpressions(
+  destructuring: DestructuringAst,
+): ExpressionAst[] {
+  switch (destructuring.type) {
+    case 'arrayDestructuring':
+      return destructuring.destructuring.flatMap(destructuringExpressions);
+    case 'objectDestructuring':
+      return destructuring.entries.flatMap((entry) => [
+        ...(typeof entry.key === 'string' ? [] : [entry.key]),
+        ...(entry.destructuring
+          ? destructuringExpressions(entry.destructuring)
+          : []),
+      ]);
+    default:
+      return [];
+  }
+}
+
 /** Every child expression of a node, so a whole tree can be searched. */
 function childExpressions(ast: ExpressionAst): ExpressionAst[] {
   switch (ast.type) {
@@ -563,7 +583,11 @@ function childExpressions(ast: ExpressionAst): ExpressionAst[] {
         ...(entry.value === undefined ? [] : [entry.value]),
       ]);
     case 'varDeclaration':
-      return [ast.expr, ast.next];
+      return [
+        ast.expr,
+        ...ast.destructuring.flatMap(destructuringExpressions),
+        ast.next,
+      ];
     default:
       return [];
   }
@@ -612,12 +636,15 @@ function cardMarkerNode(id: string): ExpressionAst {
  * Resolve the `card(…)` markers a value expression builds into its result, so
  * the rest of the expression can evaluate as jq wrote it.
  *
- * The walk follows only the object, array and comma nodes that assemble a
- * value, because a marker's argument is evaluated here, against the input the
- * whole expression was handed. Those nodes pass that input through unchanged;
- * a node that re-roots it — the body of `map`, the right of a pipe — does not,
- * and a marker under one is left alone rather than answered from the wrong
- * place. `evaluateSingleJson` reports what is left as unresolvable.
+ * The walk follows the nodes that both pass the expression's own input through
+ * unchanged and can be the value that results: object entries, array and comma
+ * streams, `//` operands, and the branches of an `if`. A marker's argument is
+ * evaluated here, against the input the whole expression was handed, so a node
+ * that re-roots it — the body of `map`, the right of a pipe — is left alone
+ * rather than answered from the wrong place, and so is a condition, which
+ * chooses a branch rather than being the value. `evaluateSingleJson` reports
+ * whatever is left as unresolvable. `try` needs no thought here: the mutation
+ * profile refuses it.
  *
  * A subtree carrying no marker comes back as it went in, so a program without
  * one is never rebuilt and never evaluates anything ahead of time.
@@ -651,12 +678,32 @@ function resolveValueTreeCards(
       return expr === ast.expr ? ast : { ...ast, expr };
     }
     case 'binary': {
-      if (ast.operator !== ',') return ast;
+      if (ast.operator !== ',' && ast.operator !== '//') return ast;
       const left = resolve(ast.left);
       const right = resolve(ast.right);
       return left === ast.left && right === ast.right
         ? ast
         : { ...ast, left, right };
+    }
+    case 'if': {
+      const branches = ast.elifs?.map((elif) => {
+        const then = resolve(elif.then);
+        return then === elif.then ? elif : { ...elif, then };
+      });
+      const then = resolve(ast.then);
+      const otherwise = ast.else === undefined ? undefined : resolve(ast.else);
+      const changed =
+        then !== ast.then ||
+        otherwise !== ast.else ||
+        Boolean(branches?.some((elif, index) => elif !== ast.elifs![index]));
+      return changed
+        ? {
+            ...ast,
+            then,
+            ...(branches === undefined ? {} : { elifs: branches }),
+            ...(otherwise === undefined ? {} : { else: otherwise }),
+          }
+        : ast;
     }
     default:
       return ast;

--- a/packages/bxl/src/mutation/planner.ts
+++ b/packages/bxl/src/mutation/planner.ts
@@ -18,6 +18,7 @@ import {
 import type {
   ExpressionAst,
   NormalBinaryOperator,
+  RuntimeAnnotatedExpressionAst,
 } from '../jqtools/parser/AST.ts';
 import {
   parseBxlMutationProgram,
@@ -77,6 +78,47 @@ function isCardReference(value: unknown): value is CardReference {
     (value as Partial<CardReference>).kind === 'card-reference' &&
     typeof (value as Partial<CardReference>).id === 'string',
   );
+}
+
+/**
+ * The value a `card(…)` marker leaves behind while an expression it sits
+ * inside is evaluated.
+ *
+ * Identity is what makes a marker a marker. A program builds arbitrary JSON,
+ * so one recognised by its shape could be forged into a relationship write; a
+ * symbol key has no JSON spelling, and the evaluated tree is searched for
+ * markers before anything copies it, so this test can be neither fooled nor
+ * lost.
+ */
+const CARD_MARKER = Symbol('bxl.mutation.card-marker');
+
+function isCardMarker(value: unknown): value is { [CARD_MARKER]: string } {
+  return Boolean(
+    value &&
+    typeof value === 'object' &&
+    typeof (value as Record<symbol, unknown>)[CARD_MARKER] === 'string',
+  );
+}
+
+/** `card(id)` as it is written: a marker the planner reads by shape. */
+function isCardCall(
+  ast: ExpressionAst,
+): ast is Extract<ExpressionAst, { type: 'filter' }> {
+  return (
+    ast.type === 'filter' && ast.name === 'card/1' && ast.args.length === 1
+  );
+}
+
+/** One `card(…)` marker, at its path inside the value that carried it. */
+interface NestedCardReference {
+  path: BxlMutationPath;
+  id: string;
+}
+
+/** A value expression's result, and the markers found inside it. */
+interface EvaluatedValue {
+  value: BxlMutationJson | CardReference;
+  references: NestedCardReference[];
 }
 
 interface ResolvedLocation {
@@ -449,35 +491,226 @@ function evaluateItems(
   return runtime.result ?? [];
 }
 
+/** Every child expression of a node, so a whole tree can be searched. */
+function childExpressions(ast: ExpressionAst): ExpressionAst[] {
+  switch (ast.type) {
+    case 'binary':
+      return [ast.left, ast.right];
+    case 'def':
+      return ast.next ? [ast.body, ast.next] : [ast.body];
+    case 'str':
+      return ast.interpolated
+        ? ast.parts.filter(
+            (part): part is ExpressionAst => typeof part !== 'string',
+          )
+        : [];
+    case 'filter':
+      return ast.args;
+    case 'if':
+      return [
+        ast.cond,
+        ast.then,
+        ...(ast.elifs ?? []).flatMap((elif) => [elif.cond, elif.then]),
+        ...(ast.else ? [ast.else] : []),
+      ];
+    case 'try':
+      return ast.catch ? [ast.body, ast.catch] : [ast.body];
+    case 'reduce':
+      return [ast.expr, ast.init, ast.update];
+    case 'foreach':
+      return [
+        ast.expr,
+        ast.init,
+        ast.update,
+        ...(ast.extract ? [ast.extract] : []),
+      ];
+    case 'label':
+      return [ast.next];
+    case 'unary':
+    case 'iterator':
+      return [ast.expr];
+    case 'index':
+      return typeof ast.index === 'string' ? [ast.expr] : [ast.expr, ast.index];
+    case 'slice':
+      return [
+        ast.expr,
+        ...(ast.from ? [ast.from] : []),
+        ...(ast.to ? [ast.to] : []),
+      ];
+    case 'array':
+      return ast.expr ? [ast.expr] : [];
+    case 'object':
+      return ast.entries.flatMap((entry) => [
+        ...(typeof entry.key === 'string' ? [] : [entry.key]),
+        ...(entry.value === undefined ? [] : [entry.value]),
+      ]);
+    case 'varDeclaration':
+      return [ast.expr, ast.next];
+    default:
+      return [];
+  }
+}
+
+function containsCardCall(ast: ExpressionAst): boolean {
+  return isCardCall(ast) || childExpressions(ast).some(containsCardCall);
+}
+
+/** The Card a `card(…)` marker names, read from its one argument. */
+function readCardId(
+  ast: Extract<ExpressionAst, { type: 'filter' }>,
+  input: BxlMutationJson,
+  context: PlannerContext,
+  statement: number,
+): string {
+  const items = evaluateItems(ast.args[0]!, [createItem(input)], context);
+  if (items.length !== 1 || typeof items[0]!.value !== 'string') {
+    throw new BxlMutationError(
+      'plan',
+      'card-id-invalid',
+      statement,
+      'card(id) requires exactly one string Card ID.',
+    );
+  }
+  return items[0]!.value;
+}
+
+/** A node standing in for one resolved marker, yielding it and nothing else. */
+function cardMarkerNode(id: string): ExpressionAst {
+  const marker = { [CARD_MARKER]: id };
+  const node: RuntimeAnnotatedExpressionAst = {
+    type: 'filter',
+    name: '_card_marker/0',
+    arity: 0,
+    args: [],
+    singleOutput: true,
+    resolvedNative: function* () {
+      yield createItem(marker);
+    },
+  };
+  return node;
+}
+
+/**
+ * Resolve the `card(…)` markers a value expression builds into its result, so
+ * the rest of the expression can evaluate as jq wrote it.
+ *
+ * The walk follows only the object, array and comma nodes that assemble a
+ * value, because a marker's argument is evaluated here, against the input the
+ * whole expression was handed. Those nodes pass that input through unchanged;
+ * a node that re-roots it — the body of `map`, the right of a pipe — does not,
+ * and a marker under one is left alone rather than answered from the wrong
+ * place. `evaluateSingleJson` reports what is left as unresolvable.
+ *
+ * A subtree carrying no marker comes back as it went in, so a program without
+ * one is never rebuilt and never evaluates anything ahead of time.
+ */
+function resolveValueTreeCards(
+  ast: ExpressionAst,
+  input: BxlMutationJson,
+  context: PlannerContext,
+  statement: number,
+): ExpressionAst {
+  if (isCardCall(ast)) {
+    return cardMarkerNode(readCardId(ast, input, context, statement));
+  }
+  const resolve = (child: ExpressionAst) =>
+    resolveValueTreeCards(child, input, context, statement);
+  switch (ast.type) {
+    case 'object': {
+      let changed = false;
+      const entries = ast.entries.map((entry) => {
+        if (entry.value === undefined) return entry;
+        const value = resolve(entry.value);
+        if (value === entry.value) return entry;
+        changed = true;
+        return { ...entry, value };
+      });
+      return changed ? { ...ast, entries } : ast;
+    }
+    case 'array': {
+      if (!ast.expr) return ast;
+      const expr = resolve(ast.expr);
+      return expr === ast.expr ? ast : { ...ast, expr };
+    }
+    case 'binary': {
+      if (ast.operator !== ',') return ast;
+      const left = resolve(ast.left);
+      const right = resolve(ast.right);
+      return left === ast.left && right === ast.right
+        ? ast
+        : { ...ast, left, right };
+    }
+    default:
+      return ast;
+  }
+}
+
+/**
+ * Copy an evaluated value into JSON, lifting every marker out of it.
+ *
+ * A marker's slot is left holding `null` and is filled in by the caller, the
+ * only place that knows the Field the value lands in: what the Card stores
+ * drops the relationship entirely, and the planner's own view puts the loaded
+ * Card there instead.
+ */
+function liftCardMarkers(raw: unknown): {
+  value: BxlMutationJson;
+  references: NestedCardReference[];
+} {
+  const references: NestedCardReference[] = [];
+  const copy = (value: unknown, path: BxlMutationPath): BxlMutationJson => {
+    if (isCardMarker(value)) {
+      references.push({ path, id: value[CARD_MARKER] });
+      return null;
+    }
+    if (Array.isArray(value)) {
+      return value.map((entry, index) => copy(entry, [...path, index]));
+    }
+    if (value !== null && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, entry]) => [
+          key,
+          copy(entry, [...path, key]),
+        ]),
+      );
+    }
+    return value as BxlMutationJson;
+  };
+  return { value: copy(raw, []), references };
+}
+
 function evaluateSingleJson(
   argument: ParsedMutationArgument,
   input: BxlMutationJson,
   context: PlannerContext,
   statement: number,
   reads: ReadContext = {},
-): BxlMutationJson | CardReference {
+): EvaluatedValue {
   recordReads(argument, input, context, statement, reads);
-  if (
-    argument.ast.type === 'filter' &&
-    argument.ast.name === 'card/1' &&
-    argument.ast.args.length === 1
-  ) {
-    const cardIdItems = evaluateItems(
-      argument.ast.args[0]!,
-      [createItem(input)],
-      context,
-    );
-    if (cardIdItems.length !== 1 || typeof cardIdItems[0]!.value !== 'string') {
-      throw new BxlMutationError(
-        'plan',
-        'card-id-invalid',
-        statement,
-        'card(id) requires exactly one string Card ID.',
-      );
-    }
-    return { kind: 'card-reference', id: cardIdItems[0]!.value };
+  if (isCardCall(argument.ast)) {
+    return {
+      value: {
+        kind: 'card-reference',
+        id: readCardId(argument.ast, input, context, statement),
+      },
+      references: [],
+    };
   }
-  const values = evaluateItems(argument.ast, [createItem(input)], context);
+  const resolved = resolveValueTreeCards(
+    argument.ast,
+    input,
+    context,
+    statement,
+  );
+  if (containsCardCall(resolved)) {
+    throw new BxlMutationError(
+      'validate',
+      'card-marker-position',
+      statement,
+      'card(id) names the Card a relationship points at, so it stands where a value is written: on its own, or inside an object or array the value expression builds.',
+    );
+  }
+  const values = evaluateItems(resolved, [createItem(input)], context);
   if (values.length !== 1) {
     throw new BxlMutationError(
       'plan',
@@ -486,7 +719,21 @@ function evaluateSingleJson(
       `Mutation value expressions must produce exactly one value; received ${values.length}.`,
     );
   }
-  return clone(values[0]!.value) as BxlMutationJson;
+  if (resolved === argument.ast) {
+    return {
+      value: clone(values[0]!.value) as BxlMutationJson,
+      references: [],
+    };
+  }
+  const lifted = liftCardMarkers(values[0]!.value);
+  // A marker the whole value resolved to is the whole-value form arrived at by
+  // another route — a conditional, say — and answers the same way.
+  const whole = lifted.references.find(
+    (reference) => reference.path.length === 0,
+  );
+  return whole
+    ? { value: { kind: 'card-reference', id: whole.id }, references: [] }
+    : { value: lifted.value, references: lifted.references };
 }
 
 function resolveLocations(
@@ -809,6 +1056,168 @@ function loadedCard(
   return clone(card);
 }
 
+/**
+ * One marker resolved against the Field it lands on.
+ *
+ * `strip` is the relationship's own subtree inside the value rather than the
+ * marker's slot, because a `linksToMany` holds its edges as a collection and
+ * the whole collection is the relationship — none of it is stored as a value.
+ */
+interface NestedRelationship {
+  /** Where the marker sat inside the value. */
+  path: BxlMutationPath;
+  /** What the stored value must not carry, inside the value. */
+  strip: BxlMutationPath;
+  /** Absent where the Field takes the write as an intentional no-op. */
+  intent?: BxlMutationIntent;
+  /** The loaded Card the marker named, for the planner's own view. */
+  card?: BxlMutationJson;
+}
+
+/**
+ * Resolve the markers lifted out of a value against the Fields they fill.
+ *
+ * `base` is where the value lands, so joining it to a marker's path inside the
+ * value names a Field. That Field has to be a relationship: a link is an edge
+ * in the Card's relationship map with no value of its own to hold it, which is
+ * also why the stored value sheds the relationship's subtree —
+ * `.examples[0].friend` is written as an edge at `examples.0.friend`, never as
+ * a member of the contained value. The planner's own view keeps the loaded
+ * Card there, so a later statement reads a link this program just wrote the
+ * same way it reads one the document already held.
+ */
+function nestedRelationships(
+  references: NestedCardReference[],
+  base: BxlMutationPath,
+  context: PlannerContext,
+  statement: number,
+): NestedRelationship[] {
+  return references.map((reference) => {
+    const path = [...base, ...reference.path];
+    const field = resolveField(path, context, statement);
+    if (!field.relationship) {
+      throw new BxlMutationError(
+        'validate',
+        'card-reference-destination',
+        statement,
+        'card(id) may only be assigned to a relationship Field.',
+      );
+    }
+    const edge = field.relationship.path;
+    const strip = edge.slice(base.length);
+    // An edge of a link collection is addressed by its position; the marker
+    // standing where the collection itself goes names no edge to change.
+    const last = path.at(-1);
+    const index =
+      path.length === edge.length + 1 && typeof last === 'number'
+        ? last
+        : undefined;
+    if (field.relationship.type === 'linksToMany' && index === undefined) {
+      throw new BxlMutationError(
+        'validate',
+        'collection-replacement-forbidden',
+        statement,
+        'Use relationship collection operations instead of replacing linksToMany wholesale.',
+      );
+    }
+    if (field.writeBehavior === 'skip') {
+      return { path: reference.path, strip };
+    }
+    assertWritableOverlayPath(path, context, statement);
+    return {
+      path: reference.path,
+      strip,
+      intent: {
+        op: 'relate',
+        field: [...edge],
+        cardId: reference.id,
+        ...(index === undefined ? {} : { index }),
+      },
+      card: loadedCard(reference.id, context, statement),
+    };
+  });
+}
+
+/**
+ * Refuse a link collection carrying anything but markers.
+ *
+ * The whole collection leaves the stored value, so a member written beside the
+ * edges would be dropped without a word rather than stored as it reads.
+ */
+function assertLinkCollectionsAreEdges(
+  value: BxlMutationJson,
+  nested: NestedRelationship[],
+  statement: number,
+): void {
+  const edges = new Map<string, { path: BxlMutationPath; at: Set<number> }>();
+  for (const entry of nested) {
+    const index = entry.path.at(-1);
+    // A `linksTo` marker fills the relationship's own slot, so its path and
+    // the subtree the value sheds are the same; only a collection's edge sits
+    // one position deeper.
+    if (entry.strip.length === entry.path.length || typeof index !== 'number') {
+      continue;
+    }
+    const key = pathKey(entry.strip);
+    const collection = edges.get(key) ?? { path: entry.strip, at: new Set() };
+    collection.at.add(index);
+    edges.set(key, collection);
+  }
+  for (const { path, at } of edges.values()) {
+    const collection = valueAt(value, path);
+    if (
+      Array.isArray(collection) &&
+      collection.length === at.size &&
+      collection.every((_, index) => at.has(index))
+    ) {
+      continue;
+    }
+    throw new BxlMutationError(
+      'validate',
+      'relationship-value-required',
+      statement,
+      'Every member of a linksToMany written inside a value must be card("id").',
+    );
+  }
+}
+
+/**
+ * The value as the planner reads it back: markers replaced by the Cards they
+ * named, and a Field that takes the write as a no-op left holding nothing.
+ */
+function modelValue(
+  value: BxlMutationJson,
+  nested: NestedRelationship[],
+): BxlMutationJson {
+  if (nested.length === 0) return value;
+  let model = clone(value);
+  for (const entry of nested) {
+    if (entry.card !== undefined) {
+      model = setAt(model, entry.path, entry.card);
+    } else if (hasAt(model, entry.strip)) {
+      model = deleteAt(model, entry.strip);
+    }
+  }
+  return model;
+}
+
+/** The value as the Card stores it, with every relationship shed. */
+function storedValue(
+  model: BxlMutationJson,
+  nested: NestedRelationship[],
+): BxlMutationJson {
+  if (nested.length === 0) return model;
+  let stored = clone(model);
+  for (const entry of nested) {
+    if (hasAt(stored, entry.strip)) stored = deleteAt(stored, entry.strip);
+  }
+  return stored;
+}
+
+function relateIntents(nested: NestedRelationship[]): BxlMutationIntent[] {
+  return nested.flatMap((entry) => (entry.intent ? [entry.intent] : []));
+}
+
 function applyCompound(
   operator: MutationAssignmentOperator,
   current: BxlMutationJson | undefined,
@@ -896,30 +1305,57 @@ function planAssignment(
     const location = locations[index]!;
     const field = fields[index]!;
     if (field.writeBehavior === 'skip') continue;
+    // A marker in the relationship's own slot is the whole-value form, which
+    // the branch below answers; resolving one against the Field it fills is
+    // for a value the Card stores.
+    const resolveNested = (evaluated: EvaluatedValue) => {
+      if (field.relationship || isCardReference(evaluated.value)) return [];
+      const nested = nestedRelationships(
+        evaluated.references,
+        location.path,
+        context,
+        statement.statement,
+      );
+      assertLinkCollectionsAreEdges(
+        evaluated.value,
+        nested,
+        statement.statement,
+      );
+      return nested;
+    };
     let next: BxlMutationJson | CardReference;
+    let nested: NestedRelationship[] = [];
     if (statement.operator === '=') {
-      next = evaluateSingleJson(
+      const evaluated = evaluateSingleJson(
         statement.value,
         readView(output, context),
         context,
         statement.statement,
       );
+      nested = resolveNested(evaluated);
+      next = isCardReference(evaluated.value)
+        ? evaluated.value
+        : modelValue(evaluated.value, nested);
     } else if (statement.operator === '|=') {
       // An update sees the layered value, so a Field an overlay filled into
       // a stored container is in scope; what it returns is settled back
       // against the Card's.
       const layered = (valueAt(readView(output, context), location.path) ??
         null) as BxlMutationJson;
-      next = evaluateSingleJson(
+      const evaluated = evaluateSingleJson(
         statement.value,
         layered,
         context,
         statement.statement,
         { prefix: location.path },
       );
+      nested = resolveNested(evaluated);
+      next = evaluated.value;
       if (!isCardReference(next)) {
+        // Settled as the planner reads it, links included: a marker's slot
+        // still standing empty would read as a member the Card dropped.
         next = settleUpdate(
-          next,
+          modelValue(next, nested),
           layered,
           location,
           context,
@@ -933,7 +1369,7 @@ function planAssignment(
         context,
         statement.statement,
       );
-      if (isCardReference(right)) {
+      if (isCardReference(right.value) || right.references.length > 0) {
         throw new BxlMutationError(
           'validate',
           'relationship-arithmetic',
@@ -944,7 +1380,7 @@ function planAssignment(
       next = applyCompound(
         statement.operator,
         location.value,
-        right as BxlMutationJson,
+        right.value as BxlMutationJson,
       );
     }
 
@@ -990,10 +1426,10 @@ function planAssignment(
       op: 'set',
       path: [...location.path],
       ...(location.exists ? { before: clone(location.value!) } : {}),
-      after: clone(next as BxlMutationJson),
+      after: clone(storedValue(next, nested)),
     };
-    intents.push(intent);
-    output = setAt(output, location.path, next as BxlMutationJson);
+    intents.push(intent, ...relateIntents(nested));
+    output = setAt(output, location.path, next);
     documentChanged(context);
   }
   return { root: output, plan: statementPlan(statement, intents) };
@@ -1021,7 +1457,7 @@ function jsonValue(
   context: PlannerContext,
   statement: number,
   reads: ReadContext = {},
-): BxlMutationJson | CardReference {
+): EvaluatedValue {
   return evaluateSingleJson(
     argument,
     readView(root, context),
@@ -1029,6 +1465,36 @@ function jsonValue(
     statement,
     reads,
   );
+}
+
+/**
+ * Resolve the markers in a value the Card stores at `base`, giving back what
+ * the planner reads, what the document stores, and the edges in between.
+ */
+function containedValue(
+  evaluated: EvaluatedValue,
+  base: BxlMutationPath,
+  context: PlannerContext,
+  statement: number,
+): {
+  model: BxlMutationJson;
+  stored: BxlMutationJson;
+  intents: BxlMutationIntent[];
+} {
+  const value = evaluated.value as BxlMutationJson;
+  const nested = nestedRelationships(
+    evaluated.references,
+    base,
+    context,
+    statement,
+  );
+  assertLinkCollectionsAreEdges(value, nested, statement);
+  const model = modelValue(value, nested);
+  return {
+    model,
+    stored: storedValue(model, nested),
+    intents: relateIntents(nested),
+  };
 }
 
 function planCall(
@@ -1081,7 +1547,7 @@ function planCall(
         // even when the message itself reads an unavailable path.
         const message = jsonValue(statement.args[1]!, root, context, number, {
           policy: bestEffort ? 'best-effort' : 'strict',
-        });
+        }).value;
         throw new BxlMutationError(
           'plan',
           'assertion-failed',
@@ -1125,7 +1591,7 @@ function planCall(
         );
       }
       const value = jsonValue(statement.args[1]!, root, context, number);
-      if (isCardReference(value)) {
+      if (isCardReference(value.value)) {
         throw new BxlMutationError(
           'validate',
           'card-reference-destination',
@@ -1133,13 +1599,17 @@ function planCall(
           'card(id) may only target relationships.',
         );
       }
-      intents.push({
-        op: 'set',
-        path: location.path,
-        before: clone(location.value!),
-        after: clone(value as BxlMutationJson),
-      });
-      output = setAt(output, location.path, value as BxlMutationJson);
+      const contained = containedValue(value, location.path, context, number);
+      intents.push(
+        {
+          op: 'set',
+          path: location.path,
+          before: clone(location.value!),
+          after: clone(contained.stored),
+        },
+        ...contained.intents,
+      );
+      output = setAt(output, location.path, contained.model);
       documentChanged(context);
       break;
     }
@@ -1256,7 +1726,12 @@ function planCall(
             'insert_at requires a pinned base revision.',
           );
         }
-        const requested = jsonValue(statement.args[1]!, root, context, number);
+        const requested = jsonValue(
+          statement.args[1]!,
+          root,
+          context,
+          number,
+        ).value;
         if (
           typeof requested !== 'number' ||
           !Number.isInteger(requested) ||
@@ -1275,7 +1750,7 @@ function planCall(
       }
       const value = jsonValue(valueArg, root, context, number);
       if (target.field.relationship) {
-        if (!isCardReference(value)) {
+        if (!isCardReference(value.value)) {
           throw new BxlMutationError(
             'validate',
             'relationship-value-required',
@@ -1286,13 +1761,17 @@ function planCall(
         intents.push({
           op: 'relate',
           field: target.field.relationship.path,
-          cardId: value.id,
+          cardId: value.value.id,
           index,
         });
-        collection.splice(index, 0, loadedCard(value.id, context, number));
+        collection.splice(
+          index,
+          0,
+          loadedCard(value.value.id, context, number),
+        );
         documentChanged(context);
       } else {
-        if (isCardReference(value)) {
+        if (isCardReference(value.value)) {
           throw new BxlMutationError(
             'validate',
             'card-reference-destination',
@@ -1300,13 +1779,22 @@ function planCall(
             'card(id) may only target relationships.',
           );
         }
-        intents.push({
-          op: 'insert',
-          collection: target.location.path,
-          index,
-          value: clone(value as BxlMutationJson),
-        });
-        collection.splice(index, 0, clone(value as BxlMutationJson));
+        const contained = containedValue(
+          value,
+          [...target.location.path, index],
+          context,
+          number,
+        );
+        intents.push(
+          {
+            op: 'insert',
+            collection: target.location.path,
+            index,
+            value: clone(contained.stored),
+          },
+          ...contained.intents,
+        );
+        collection.splice(index, 0, clone(contained.model));
         documentChanged(context);
       }
       break;
@@ -1329,7 +1817,7 @@ function planCall(
         anchorIndex + (statement.name === 'insert_item_after' ? 1 : 0);
       const value = jsonValue(statement.args[0]!, root, context, number);
       if (anchor.field.relationship) {
-        if (!isCardReference(value)) {
+        if (!isCardReference(value.value)) {
           throw new BxlMutationError(
             'validate',
             'relationship-value-required',
@@ -1340,13 +1828,17 @@ function planCall(
         intents.push({
           op: 'relate',
           field: anchor.field.relationship.path,
-          cardId: value.id,
+          cardId: value.value.id,
           index,
         });
-        collection.splice(index, 0, loadedCard(value.id, context, number));
+        collection.splice(
+          index,
+          0,
+          loadedCard(value.value.id, context, number),
+        );
         documentChanged(context);
       } else {
-        if (isCardReference(value)) {
+        if (isCardReference(value.value)) {
           throw new BxlMutationError(
             'validate',
             'card-reference-destination',
@@ -1354,13 +1846,22 @@ function planCall(
             'card(id) may only target relationships.',
           );
         }
-        intents.push({
-          op: 'insert',
-          collection: collectionPath,
-          index,
-          value: clone(value as BxlMutationJson),
-        });
-        collection.splice(index, 0, clone(value as BxlMutationJson));
+        const contained = containedValue(
+          value,
+          [...collectionPath, index],
+          context,
+          number,
+        );
+        intents.push(
+          {
+            op: 'insert',
+            collection: collectionPath,
+            index,
+            value: clone(contained.stored),
+          },
+          ...contained.intents,
+        );
+        collection.splice(index, 0, clone(contained.model));
         documentChanged(context);
       }
       break;
@@ -1505,7 +2006,7 @@ function planCall(
         );
       }
       const keyPath = keyPathItems[0]!.path as BxlMutationPath;
-      const order = jsonValue(statement.args[2]!, root, context, number);
+      const order = jsonValue(statement.args[2]!, root, context, number).value;
       if (
         !Array.isArray(order) ||
         order.some(

--- a/packages/bxl/src/mutation/planner.ts
+++ b/packages/bxl/src/mutation/planner.ts
@@ -85,11 +85,13 @@ function isCardReference(value: unknown): value is CardReference {
  * The value a `card(…)` marker leaves behind while an expression it sits
  * inside is evaluated.
  *
- * Identity is what makes a marker a marker. A program builds arbitrary JSON,
- * so one recognised by its shape could be forged into a relationship write; a
- * symbol key has no JSON spelling, and the evaluated tree is searched for
- * markers before anything copies it, so this test can be neither fooled nor
- * lost.
+ * Identity is what makes a marker a marker. A program builds arbitrary JSON, so
+ * one recognised by its shape could be forged; a symbol key has no JSON
+ * spelling, and the evaluated tree is searched for markers before anything
+ * copies it, so this test can be neither fooled nor lost. `isCardReference`
+ * above is the older shape-recognised form, and a whole value matching it is
+ * still taken for a reference — bounded by `loadedCard`, which refuses an id
+ * the caller did not supply.
  */
 const CARD_MARKER = Symbol('bxl.mutation.card-marker');
 
@@ -593,18 +595,29 @@ function childExpressions(ast: ExpressionAst): ExpressionAst[] {
   }
 }
 
+/**
+ * Binary operators whose operands are values the result is built from, rather
+ * than a stream re-rooted or a decision made from them.
+ */
+const VALUE_COMBINING_OPERATORS: ReadonlySet<string> = new Set([
+  ',',
+  '//',
+  '+',
+  '*',
+]);
+
 function containsCardCall(ast: ExpressionAst): boolean {
   return isCardCall(ast) || childExpressions(ast).some(containsCardCall);
 }
 
 /** The Card a `card(…)` marker names, read from its one argument. */
 function readCardId(
-  ast: Extract<ExpressionAst, { type: 'filter' }>,
+  argument: ExpressionAst,
   input: BxlMutationJson,
   evaluate: EvaluateItems,
   statement: number,
 ): string {
-  const items = evaluate(ast.args[0]!, [createItem(input)]);
+  const items = evaluate(argument, [createItem(input)]);
   if (items.length !== 1 || typeof items[0]!.value !== 'string') {
     throw new BxlMutationError(
       'plan',
@@ -616,16 +629,38 @@ function readCardId(
   return items[0]!.value;
 }
 
-/** A node standing in for one resolved marker, yielding it and nothing else. */
-function cardMarkerNode(id: string): ExpressionAst {
-  const marker = { [CARD_MARKER]: id };
+/**
+ * A node standing in for one marker, yielding it and nothing else.
+ *
+ * The Card it names is read when the node is reached, not while the tree is
+ * being rewritten, so a marker in a branch the program does not take costs
+ * nothing: no argument evaluated for a branch that never runs, no error from
+ * one that only makes sense there, and no share of the statement's steps. The
+ * budget frame is already open around the whole evaluation, so reading it here
+ * is still metered with everything else.
+ *
+ * `singleOutput` stays false, as it is for every filter node the annotator
+ * marks: the single-output evaluator has no case for a filter and throws on
+ * one. Nothing in the walk puts a marker where that evaluator runs, and saying
+ * `true` here would arm that throw for whoever widens the walk next.
+ */
+function cardMarkerNode(
+  argument: ExpressionAst,
+  input: BxlMutationJson,
+  evaluate: EvaluateItems,
+  statement: number,
+): ExpressionAst {
+  let marker: { [CARD_MARKER]: string } | undefined;
   const node: RuntimeAnnotatedExpressionAst = {
     type: 'filter',
     name: '_card_marker/0',
     arity: 0,
     args: [],
-    singleOutput: true,
+    singleOutput: false,
     resolvedNative: function* () {
+      marker ??= {
+        [CARD_MARKER]: readCardId(argument, input, evaluate, statement),
+      };
       yield createItem(marker);
     },
   };
@@ -636,18 +671,18 @@ function cardMarkerNode(id: string): ExpressionAst {
  * Resolve the `card(…)` markers a value expression builds into its result, so
  * the rest of the expression can evaluate as jq wrote it.
  *
- * The walk follows the nodes that both pass the expression's own input through
- * unchanged and can be the value that results: object entries, array and comma
- * streams, `//` operands, and the branches of an `if`. A marker's argument is
- * evaluated here, against the input the whole expression was handed, so a node
- * that re-roots it — the body of `map`, the right of a pipe — is left alone
- * rather than answered from the wrong place, and so is a condition, which
- * chooses a branch rather than being the value. `evaluateSingleJson` reports
- * whatever is left as unresolvable. `try` needs no thought here: the mutation
+ * A marker reads its argument against the input the value expression itself was
+ * handed, so the walk follows the nodes that pass that input down unchanged and
+ * whose operands flow into the result: object entries, array and comma streams,
+ * the operands of `//`, `+` and `*`, and the branches of an `if`. Everywhere
+ * else the marker is left as written and `evaluateSingleJson` reports it as
+ * unresolvable — a node that re-roots the input (the body of `map`, either side
+ * of a pipe) would answer it from the wrong place, and a condition chooses a
+ * branch rather than being the value. `try` needs no thought here: the mutation
  * profile refuses it.
  *
  * A subtree carrying no marker comes back as it went in, so a program without
- * one is never rebuilt and never evaluates anything ahead of time.
+ * one is never rebuilt.
  */
 function resolveValueTreeCards(
   ast: ExpressionAst,
@@ -656,7 +691,7 @@ function resolveValueTreeCards(
   statement: number,
 ): ExpressionAst {
   if (isCardCall(ast)) {
-    return cardMarkerNode(readCardId(ast, input, evaluate, statement));
+    return cardMarkerNode(ast.args[0]!, input, evaluate, statement);
   }
   const resolve = (child: ExpressionAst) =>
     resolveValueTreeCards(child, input, evaluate, statement);
@@ -678,7 +713,10 @@ function resolveValueTreeCards(
       return expr === ast.expr ? ast : { ...ast, expr };
     }
     case 'binary': {
-      if (ast.operator !== ',' && ast.operator !== '//') return ast;
+      // `.` merged with an object literal is how a program writes part of a
+      // contained value, so the operators that combine two values into the one
+      // that results carry markers as much as the structural nodes do.
+      if (!VALUE_COMBINING_OPERATORS.has(ast.operator)) return ast;
       const left = resolve(ast.left);
       const right = resolve(ast.right);
       return left === ast.left && right === ast.right
@@ -757,7 +795,7 @@ function evaluateSingleJson(
       return {
         value: {
           kind: 'card-reference',
-          id: readCardId(argument.ast, input, evaluate, statement),
+          id: readCardId(argument.ast.args[0]!, input, evaluate, statement),
         },
         references: [],
       };
@@ -1214,10 +1252,12 @@ function nestedRelationships(
 }
 
 /**
- * Refuse a link collection carrying anything but markers.
+ * Refuse a link collection whose members are not all markers.
  *
  * The whole collection leaves the stored value, so a member written beside the
- * edges would be dropped without a word rather than stored as it reads.
+ * edges would be dropped without a word rather than stored as it reads. This
+ * sees the collections a marker writes to; one written wholly as data carries
+ * no marker to resolve and reaches the Card the way any other value does.
  */
 function assertLinkCollectionsAreEdges(
   value: BxlMutationJson,
@@ -1276,7 +1316,14 @@ function modelValue(
   return model;
 }
 
-/** The value as the Card stores it, with every relationship shed. */
+/**
+ * The value as the Card stores it, with the relationships a marker named shed.
+ *
+ * A link written as plain data rather than through a marker is not a
+ * relationship as far as this is concerned and stays in the value, which is
+ * what `assertLinkCollectionsAreEdges` refuses for a collection a marker also
+ * writes to.
+ */
 function storedValue(
   model: BxlMutationJson,
   nested: NestedRelationship[],
@@ -1543,6 +1590,30 @@ function jsonValue(
 }
 
 /**
+ * The value of an argument that names no Field to relate a Card to.
+ *
+ * An `assert` message, an insertion index and a reorder key are read as plain
+ * values, so a marker in one has nothing to resolve against. Reporting it is
+ * what keeps it from being quietly dropped — the lifted marker leaves `null`
+ * behind, which an index or a key would go on to refuse for the wrong reason
+ * and a message would print.
+ */
+function plainValue(
+  evaluated: EvaluatedValue,
+  statement: number,
+): BxlMutationJson | CardReference {
+  if (evaluated.references.length > 0) {
+    throw new BxlMutationError(
+      'validate',
+      'card-marker-position',
+      statement,
+      'card(id) names the Card a relationship points at, so it stands where a value is written, not in an argument read as a plain value.',
+    );
+  }
+  return evaluated.value;
+}
+
+/**
  * Resolve the markers in a value the Card stores at `base`, giving back what
  * the planner reads, what the document stores, and the edges in between.
  */
@@ -1620,9 +1691,12 @@ function planCall(
         // The whole statement is best-effort, message included: an author who
         // marked the assert tolerant of stale values gets their wording back
         // even when the message itself reads an unavailable path.
-        const message = jsonValue(statement.args[1]!, root, context, number, {
-          policy: bestEffort ? 'best-effort' : 'strict',
-        }).value;
+        const message = plainValue(
+          jsonValue(statement.args[1]!, root, context, number, {
+            policy: bestEffort ? 'best-effort' : 'strict',
+          }),
+          number,
+        );
         throw new BxlMutationError(
           'plan',
           'assertion-failed',
@@ -1801,12 +1875,10 @@ function planCall(
             'insert_at requires a pinned base revision.',
           );
         }
-        const requested = jsonValue(
-          statement.args[1]!,
-          root,
-          context,
+        const requested = plainValue(
+          jsonValue(statement.args[1]!, root, context, number),
           number,
-        ).value;
+        );
         if (
           typeof requested !== 'number' ||
           !Number.isInteger(requested) ||
@@ -2081,7 +2153,10 @@ function planCall(
         );
       }
       const keyPath = keyPathItems[0]!.path as BxlMutationPath;
-      const order = jsonValue(statement.args[2]!, root, context, number).value;
+      const order = plainValue(
+        jsonValue(statement.args[2]!, root, context, number),
+        number,
+      );
       if (
         !Array.isArray(order) ||
         order.some(

--- a/packages/bxl/src/mutation/planner.ts
+++ b/packages/bxl/src/mutation/planner.ts
@@ -471,24 +471,42 @@ function assertJsonContext(context: BxlMutationContext) {
   }
 }
 
+/** Evaluate one expression against the budget the caller already opened. */
+type EvaluateItems = (ast: ExpressionAst, input: Item[]) => Item[];
+
+/**
+ * Run `body` under one runtime budget, handing it the evaluator to use.
+ *
+ * Every limit lives on the frame `withRuntimeDiagnostics` opens — steps,
+ * milliseconds and output bytes all start again with each one — so what shares
+ * a frame shares a ceiling. A value expression and the `card(…)` arguments
+ * standing inside it are one evaluation, and spend the host's allowance
+ * between them rather than each taking the whole of it.
+ */
+function withEvaluationBudget<T>(
+  context: PlannerContext,
+  body: (evaluate: EvaluateItems) => T,
+): T {
+  const evaluate: EvaluateItems = (ast, input) =>
+    Array.from(evaluateItemsWithRegistry(ast, input, context.registry));
+  const run = () =>
+    withRuntimeDiagnostics(() => body(evaluate), context.prepare.runtimeLimits);
+  // Scoped outside the diagnostics frame, and around every statement's
+  // evaluation, so `params`/`actor`/`instance` read this plan's context
+  // wherever in the program they appear.
+  const runtime = context.requestContext
+    ? withRequestContext(context.requestContext, run)
+    : run();
+  if (runtime.error) throw runtime.error;
+  return runtime.result as T;
+}
+
 function evaluateItems(
   ast: ExpressionAst,
   input: Item[],
   context: PlannerContext,
 ): Item[] {
-  const evaluate = () =>
-    withRuntimeDiagnostics(
-      () => Array.from(evaluateItemsWithRegistry(ast, input, context.registry)),
-      context.prepare.runtimeLimits,
-    );
-  // Scoped outside the diagnostics frame, and around every statement's
-  // evaluation, so `params`/`actor`/`instance` read this plan's context
-  // wherever in the program they appear.
-  const runtime = context.requestContext
-    ? withRequestContext(context.requestContext, evaluate)
-    : evaluate();
-  if (runtime.error) throw runtime.error;
-  return runtime.result ?? [];
+  return withEvaluationBudget(context, (evaluate) => evaluate(ast, input));
 }
 
 /** Every child expression of a node, so a whole tree can be searched. */
@@ -559,10 +577,10 @@ function containsCardCall(ast: ExpressionAst): boolean {
 function readCardId(
   ast: Extract<ExpressionAst, { type: 'filter' }>,
   input: BxlMutationJson,
-  context: PlannerContext,
+  evaluate: EvaluateItems,
   statement: number,
 ): string {
-  const items = evaluateItems(ast.args[0]!, [createItem(input)], context);
+  const items = evaluate(ast.args[0]!, [createItem(input)]);
   if (items.length !== 1 || typeof items[0]!.value !== 'string') {
     throw new BxlMutationError(
       'plan',
@@ -607,14 +625,14 @@ function cardMarkerNode(id: string): ExpressionAst {
 function resolveValueTreeCards(
   ast: ExpressionAst,
   input: BxlMutationJson,
-  context: PlannerContext,
+  evaluate: EvaluateItems,
   statement: number,
 ): ExpressionAst {
   if (isCardCall(ast)) {
-    return cardMarkerNode(readCardId(ast, input, context, statement));
+    return cardMarkerNode(readCardId(ast, input, evaluate, statement));
   }
   const resolve = (child: ExpressionAst) =>
-    resolveValueTreeCards(child, input, context, statement);
+    resolveValueTreeCards(child, input, evaluate, statement);
   switch (ast.type) {
     case 'object': {
       let changed = false;
@@ -687,53 +705,55 @@ function evaluateSingleJson(
   reads: ReadContext = {},
 ): EvaluatedValue {
   recordReads(argument, input, context, statement, reads);
-  if (isCardCall(argument.ast)) {
-    return {
-      value: {
-        kind: 'card-reference',
-        id: readCardId(argument.ast, input, context, statement),
-      },
-      references: [],
-    };
-  }
-  const resolved = resolveValueTreeCards(
-    argument.ast,
-    input,
-    context,
-    statement,
-  );
-  if (containsCardCall(resolved)) {
-    throw new BxlMutationError(
-      'validate',
-      'card-marker-position',
+  return withEvaluationBudget(context, (evaluate): EvaluatedValue => {
+    if (isCardCall(argument.ast)) {
+      return {
+        value: {
+          kind: 'card-reference',
+          id: readCardId(argument.ast, input, evaluate, statement),
+        },
+        references: [],
+      };
+    }
+    const resolved = resolveValueTreeCards(
+      argument.ast,
+      input,
+      evaluate,
       statement,
-      'card(id) names the Card a relationship points at, so it stands where a value is written: on its own, or inside an object or array the value expression builds.',
     );
-  }
-  const values = evaluateItems(resolved, [createItem(input)], context);
-  if (values.length !== 1) {
-    throw new BxlMutationError(
-      'plan',
-      'value-cardinality',
-      statement,
-      `Mutation value expressions must produce exactly one value; received ${values.length}.`,
+    if (containsCardCall(resolved)) {
+      throw new BxlMutationError(
+        'validate',
+        'card-marker-position',
+        statement,
+        'card(id) names the Card a relationship points at, so it stands where a value is written: on its own, or inside an object or array the value expression builds.',
+      );
+    }
+    const values = evaluate(resolved, [createItem(input)]);
+    if (values.length !== 1) {
+      throw new BxlMutationError(
+        'plan',
+        'value-cardinality',
+        statement,
+        `Mutation value expressions must produce exactly one value; received ${values.length}.`,
+      );
+    }
+    if (resolved === argument.ast) {
+      return {
+        value: clone(values[0]!.value) as BxlMutationJson,
+        references: [],
+      };
+    }
+    const lifted = liftCardMarkers(values[0]!.value);
+    // A marker the whole value resolved to is the whole-value form arrived at
+    // by another route — a conditional, say — and answers the same way.
+    const whole = lifted.references.find(
+      (reference) => reference.path.length === 0,
     );
-  }
-  if (resolved === argument.ast) {
-    return {
-      value: clone(values[0]!.value) as BxlMutationJson,
-      references: [],
-    };
-  }
-  const lifted = liftCardMarkers(values[0]!.value);
-  // A marker the whole value resolved to is the whole-value form arrived at by
-  // another route — a conditional, say — and answers the same way.
-  const whole = lifted.references.find(
-    (reference) => reference.path.length === 0,
-  );
-  return whole
-    ? { value: { kind: 'card-reference', id: whole.id }, references: [] }
-    : { value: lifted.value, references: lifted.references };
+    return whole
+      ? { value: { kind: 'card-reference', id: whole.id }, references: [] }
+      : { value: lifted.value, references: lifted.references };
+  });
 }
 
 function resolveLocations(
@@ -830,6 +850,16 @@ function nestedSchema(field: BxlMutationField): BxlMutationSchema | undefined {
   if (field.fields) return { fields: field.fields };
   return undefined;
 }
+
+/**
+ * What a Field with no Fields of its own descends into: nothing.
+ *
+ * A path that keeps going past such a Field addresses something the schema
+ * does not describe, and reading the next key against the *parent* schema
+ * would answer it with a sibling — `.label.friend` on a scalar `label`
+ * resolving the `friend` beside it, and naming a Field the path never reaches.
+ */
+const NO_FIELDS: BxlMutationSchema = { fields: [] };
 
 function resolveField(
   path: BxlMutationPath,
@@ -937,8 +967,7 @@ function resolveField(
           `Unexpected collection index at ${pathKey(path.slice(0, index + 1))}.`,
         );
       }
-      const item = nestedSchema(field);
-      if (item) schema = item;
+      schema = nestedSchema(field) ?? NO_FIELDS;
       field = undefined;
       continue;
     }
@@ -976,8 +1005,7 @@ function resolveField(
         );
       }
     }
-    const next = nestedSchema(field);
-    if (next) schema = next;
+    schema = nestedSchema(field) ?? NO_FIELDS;
   }
   return {
     field,

--- a/packages/bxl/tests/boxel/card-source-mutation.ts
+++ b/packages/bxl/tests/boxel/card-source-mutation.ts
@@ -3263,7 +3263,7 @@ strictEqual(
 );
 
 // A whole-value marker plans as it always has, and so does a value with no
-// marker in it: the resolution runs only over a value tree that has one.
+// marker in it.
 deepStrictEqual(
   nestedLinkMutation(
     'whole-value-marker',
@@ -3359,14 +3359,6 @@ function voyageMutation(
   );
 }
 
-function voyageMutationWithLimits(
-  programId: string,
-  program: string,
-  runtimeLimits: { maxSteps?: number },
-) {
-  return voyageMutation(programId, program, runtimeLimits);
-}
-
 const crewed = voyageMutation(
   'append-nested-link-collection',
   `append(.crews;{"name":"alpha","members":[card(params("who")),card(${JSON.stringify(ana)})]});`,
@@ -3442,19 +3434,26 @@ function markerBudgetOutcome(
   markers: number,
   maxSteps: number,
 ): 'completed' | 'refused' {
+  // Only a refusal that names the step limit counts: any other
+  // BxlMutationError would let this keep passing while the budget stopped
+  // being shared.
+  const spentTheBudget = (error: BxlMutationError) =>
+    error.message.includes(`${maxSteps} step`);
   const costly =
     'card(([range(0;40)]|map(tostring)|join("-")|length|tostring) | ' +
     `${JSON.stringify(zoe)})`;
   const members = Array.from({ length: markers }, () => costly).join(',');
   try {
-    voyageMutationWithLimits(
+    voyageMutation(
       `marker-budget-${markers}-${maxSteps}`,
       `append(.crews;{"name":"alpha","members":[${members}]});`,
       { maxSteps },
     );
     return 'completed';
   } catch (error) {
-    if (error instanceof BxlMutationError) return 'refused';
+    if (error instanceof BxlMutationError && spentTheBudget(error)) {
+      return 'refused';
+    }
     throw error;
   }
 }
@@ -3533,6 +3532,145 @@ strictEqual(
       '"friend":(if card(params("who")) then null else null end)});',
   ).code,
   'card-marker-position',
+);
+
+// A marker reads its argument when the program reaches it, so a branch that is
+// not taken costs nothing — no argument evaluated for it, and no error from one
+// that only makes sense on the branch that runs. Falling back is the whole
+// reason `if` and `//` carry markers, and an argument read ahead of time would
+// refuse the fallback on the strength of the branch it exists to avoid.
+deepStrictEqual(
+  nestedLinkMutation(
+    'marker-in-an-untaken-branch',
+    '.examples[0].friend = ' +
+      '(if false then card(params("missing")) else card(params("who")) end);',
+  ).plan.intents,
+  [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'marker-in-a-short-circuited-operand',
+    '.examples[0].friend = (card(params("who")) // card(params("missing")));',
+  ).plan.intents,
+  [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+
+// An argument the program does reach still answers for itself.
+strictEqual(
+  nestedLinkError(
+    'nested-marker-argument-not-a-string',
+    `append(.examples;{${zeta},"parts":[],"friend":card(123)});`,
+  ).code,
+  'card-id-invalid',
+);
+
+// `.` merged with an object literal is how a program writes part of a
+// contained value, so a marker rides through the merge.
+deepStrictEqual(
+  nestedLinkMutation(
+    'nested-marker-through-a-merge',
+    '.examples[1] |= (. + {"friend":card(params("who"))});',
+  ).plan.intents,
+  [
+    {
+      op: 'set',
+      path: ['examples', 1],
+      before: {
+        key: 'b',
+        label: 'Beta',
+        friend: { id: 'https://example.test/Friend/b' },
+        aliases: [],
+        parts: [],
+      },
+      after: { key: 'b', label: 'Beta', aliases: [], parts: [] },
+    },
+    { op: 'relate', field: ['examples', 1, 'friend'], cardId: zoe },
+  ],
+);
+
+// An `elif` branch is a branch like any other, and either operand of `//` can
+// be the one that answers.
+deepStrictEqual(
+  nestedLinkMutation(
+    'marker-in-an-elif-branch',
+    '.examples[0].friend = (if false then null elif true then ' +
+      'card(params("who")) else null end);',
+  ).plan.intents,
+  [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+
+// An argument read as a plain value has no Field to relate a Card to, so a
+// marker in one is reported rather than quietly leaving its slot empty. The
+// message of an assertion that holds is never built at all, so there is
+// nothing there to report.
+for (const [programId, program] of [
+  ['marker-in-an-assert-message', 'assert(false;{"a":card(params("who"))});'],
+  [
+    'marker-in-a-reorder-order',
+    'reorder_by(.examples; .key; {"a":card(params("who"))});',
+  ],
+] as const) {
+  strictEqual(
+    nestedLinkError(programId, program).code,
+    'card-marker-position',
+    programId,
+  );
+}
+doesNotThrow(() =>
+  nestedLinkMutation(
+    'marker-in-the-message-of-an-assertion-that-holds',
+    'assert(true;{"a":card(params("who"))});',
+  ),
+);
+
+// The other statements that write a contained value resolve markers the same
+// way `append` does, each against the place its own value lands.
+deepStrictEqual(
+  nestedLinkMutation(
+    'replace-a-contained-value-carrying-a-link',
+    `replace(.examples[1];{"key":"b2","label":"B2","aliases":[],"parts":[],` +
+      '"friend":card(params("who"))});',
+  ).plan.intents.filter((intent) => intent.op === 'relate'),
+  [{ op: 'relate', field: ['examples', 1, 'friend'], cardId: zoe }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'prepend-a-contained-value-carrying-a-link',
+    `prepend(.examples;{${zeta},"parts":[],"friend":card(params("who"))});`,
+  ).plan.intents.filter((intent) => intent.op === 'relate'),
+  [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'insert-a-contained-value-carrying-a-link-before-another',
+    `insert_item_before({${zeta},"parts":[],"friend":card(params("who"))};` +
+      '.examples[2]);',
+  ).plan.intents.filter((intent) => intent.op === 'relate'),
+  [{ op: 'relate', field: ['examples', 2, 'friend'], cardId: zoe }],
+);
+
+// A prepared program is planned many times, so resolution must not consume the
+// parsed tree or hold a Card from an earlier run.
+const preparedWithMarker = prepareBxlMutation(
+  `append(.examples;{${zeta},"parts":[],"friend":card(params("who"))});`,
+  { schema: richSchema, syntax: 'solidified', targetKind: 'card' },
+);
+const preparedSnapshot = snapshotBxlCardSource(
+  richSourceFixture(),
+  richSchema,
+  richProjectionOptions,
+);
+const planWith = (who: string) =>
+  preparedWithMarker.plan(preparedSnapshot, {
+    programId: 'prepared-twice',
+    ...richProjectionOptions,
+    context: { params: { who } },
+    resolveCard: (id: string) => nestedLinkCards[id],
+  }).intents;
+deepStrictEqual(planWith(zoe), planWith(zoe));
+deepStrictEqual(
+  planWith(ana).filter((intent) => intent.op === 'relate'),
+  [{ op: 'relate', field: ['examples', 3, 'friend'], cardId: ana }],
 );
 
 console.log(

--- a/packages/bxl/tests/boxel/card-source-mutation.ts
+++ b/packages/bxl/tests/boxel/card-source-mutation.ts
@@ -3473,6 +3473,68 @@ strictEqual(
   'markers share the budget of the value they sit in',
 );
 
+// A marker resolves through any node that hands the value expression's own
+// input straight down and can itself be the value: an `if` branch and a `//`
+// operand, whole-value or nested. `try` needs no case of its own — the
+// mutation profile refuses it outright.
+deepStrictEqual(
+  nestedLinkMutation(
+    'whole-value-marker-through-a-conditional',
+    '.examples[0].friend = (if true then card(params("who")) else null end);',
+  ).plan.intents,
+  [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'whole-value-marker-through-an-alternative',
+    '.examples[0].friend = (null // card(params("who")));',
+  ).plan.intents,
+  [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'nested-marker-through-a-conditional',
+    `append(.examples;{${zeta},"parts":[],` +
+      '"friend":(if true then card(params("who")) else null end)});',
+  ).plan.intents,
+  [
+    {
+      op: 'insert',
+      collection: ['examples'],
+      index: 3,
+      value: { key: 'z', label: 'Zeta', aliases: [], parts: [] },
+    },
+    { op: 'relate', field: ['examples', 3, 'friend'], cardId: zoe },
+  ],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'nested-marker-through-an-alternative',
+    `append(.examples;{${zeta},"parts":[],` +
+      '"friend":(null // card(params("who")))});',
+  ).plan.intents,
+  [
+    {
+      op: 'insert',
+      collection: ['examples'],
+      index: 3,
+      value: { key: 'z', label: 'Zeta', aliases: [], parts: [] },
+    },
+    { op: 'relate', field: ['examples', 3, 'friend'], cardId: zoe },
+  ],
+);
+
+// A condition chooses a branch rather than being the value, so a marker there
+// is refused the same way one in a re-rooting position is.
+strictEqual(
+  nestedLinkError(
+    'nested-marker-in-a-condition',
+    `append(.examples;{${zeta},"parts":[],` +
+      '"friend":(if card(params("who")) then null else null end)});',
+  ).code,
+  'card-marker-position',
+);
+
 console.log(
   'BXL Boxel card-source adapter: Definition schema, computed skips, recursive metadata, structural collections, RRI/relative relationship matrix, preservation, request-context builtins, stale-plan safety, and read-only computed/linked overlays passed',
 );

--- a/packages/bxl/tests/boxel/card-source-mutation.ts
+++ b/packages/bxl/tests/boxel/card-source-mutation.ts
@@ -3329,7 +3329,11 @@ const voyageSchema = await mutationSchemaForCardSource(voyageDefinition, {
   },
 });
 
-function voyageMutation(programId: string, program: string) {
+function voyageMutation(
+  programId: string,
+  program: string,
+  runtimeLimits?: { maxSteps?: number },
+) {
   return mutateBxlCardSource(
     {
       data: {
@@ -3350,8 +3354,17 @@ function voyageMutation(programId: string, program: string) {
         id.replace('https://example.test/', '../'),
       context: { params: { who: zoe } },
       resolveCard: (id: string) => nestedLinkCards[id],
+      ...(runtimeLimits === undefined ? {} : { runtimeLimits }),
     },
   );
+}
+
+function voyageMutationWithLimits(
+  programId: string,
+  program: string,
+  runtimeLimits: { maxSteps?: number },
+) {
+  return voyageMutation(programId, program, runtimeLimits);
 }
 
 const crewed = voyageMutation(
@@ -3403,6 +3416,61 @@ strictEqual(
     'append(.crews;{"name":"alpha","members":card(params("who"))});',
   ).code,
   'collection-replacement-forbidden',
+);
+
+// A path only descends through a Field that has Fields of its own. A marker
+// under a scalar addresses something the schema does not describe, and reading
+// its key against the parent schema instead would answer with the sibling
+// beside it — resolving `label.friend` to the `friend` relationship and naming
+// a Field the path never reaches.
+strictEqual(
+  nestedLinkError(
+    'nested-marker-below-a-scalar',
+    `append(.examples;{${zeta},"parts":[],"label":{"friend":card(params("who"))}});`,
+  ).code,
+  'field-unknown',
+);
+
+// Every runtime limit lives on the frame an evaluation opens — steps,
+// milliseconds and output bytes all start again with each one — so what shares
+// a frame shares a ceiling. A value expression and the `card(…)` arguments
+// standing inside it are one evaluation: raising the marker count must not
+// raise what the statement is allowed to spend. Calibrated against a single
+// marker rather than a fixed count, so the claim survives a change in how
+// steps are counted.
+function markerBudgetOutcome(
+  markers: number,
+  maxSteps: number,
+): 'completed' | 'refused' {
+  const costly =
+    'card(([range(0;40)]|map(tostring)|join("-")|length|tostring) | ' +
+    `${JSON.stringify(zoe)})`;
+  const members = Array.from({ length: markers }, () => costly).join(',');
+  try {
+    voyageMutationWithLimits(
+      `marker-budget-${markers}-${maxSteps}`,
+      `append(.crews;{"name":"alpha","members":[${members}]});`,
+      { maxSteps },
+    );
+    return 'completed';
+  } catch (error) {
+    if (error instanceof BxlMutationError) return 'refused';
+    throw error;
+  }
+}
+
+let oneMarkerBudget = 0;
+for (const candidate of [500, 1000, 2000, 4000, 8000, 16000]) {
+  if (markerBudgetOutcome(1, candidate) === 'completed') {
+    oneMarkerBudget = candidate;
+    break;
+  }
+}
+ok(oneMarkerBudget > 0, 'one marker fits inside some step budget');
+strictEqual(
+  markerBudgetOutcome(8, oneMarkerBudget),
+  'refused',
+  'markers share the budget of the value they sit in',
 );
 
 console.log(

--- a/packages/bxl/tests/boxel/card-source-mutation.ts
+++ b/packages/bxl/tests/boxel/card-source-mutation.ts
@@ -16,6 +16,7 @@ import {
   type BxlBoxelSourceDefinition,
   type BxlCardSourceDocument,
   type BxlCardSourceRelationship,
+  type BxlMutationJson,
   type BxlMutationSchema,
   mergeBxlMutationOverlays,
   type BxlMutationOverlays,
@@ -3058,6 +3059,350 @@ strictEqual(
 strictEqual(
   mergeBxlMutationOverlays(collectionSnapshot, { unavailable: [] }).index,
   EMPTY_OVERLAY_INDEX,
+);
+
+// A relationship reached through a contained value. `card(…)` is resolved
+// wherever it stands in the value a statement writes, and what it names
+// becomes an edge in the Card's relationship map: a link has no member of the
+// contained value to live in, so the stored value never carries one.
+const zoe = 'https://example.test/Friend/zoe';
+const ana = 'https://example.test/Friend/ana';
+const ghost = 'https://example.test/Friend/ghost';
+const nestedLinkCards: Record<string, BxlMutationJson> = {
+  [zoe]: { id: zoe },
+  [ana]: { id: ana },
+};
+
+function nestedLinkMutation(programId: string, program: string) {
+  return mutateBxlCardSource(richSourceFixture(), program, {
+    schema: richSchema,
+    syntax: 'solidified',
+    programId,
+    ...richProjectionOptions,
+    context: { params: { who: zoe } },
+    resolveCard: (id: string) => nestedLinkCards[id],
+    serializeContainedValue: () => ({
+      meta: { adoptsFrom: { module: '../fields', name: 'ZetaExample' } },
+    }),
+  });
+}
+
+function nestedLinkError(programId: string, program: string) {
+  try {
+    nestedLinkMutation(programId, program);
+  } catch (error) {
+    if (error instanceof BxlMutationError) return error;
+    throw error;
+  }
+  throw new Error(`${programId} was expected to fail`);
+}
+
+const zeta = '"key":"z","label":"Zeta","aliases":[]';
+
+// An appended contained value: the link is an intent of its own, and the value
+// the collection stores holds everything but the link.
+const appendedLink = nestedLinkMutation(
+  'append-nested-link',
+  `append(.examples;{${zeta},"parts":[],"friend":card(params("who"))});`,
+);
+deepStrictEqual(appendedLink.plan.intents, [
+  {
+    op: 'insert',
+    collection: ['examples'],
+    index: 3,
+    value: { key: 'z', label: 'Zeta', aliases: [], parts: [] },
+  },
+  { op: 'relate', field: ['examples', 3, 'friend'], cardId: zoe },
+]);
+deepStrictEqual(
+  (
+    appendedLink.document.data.attributes?.examples as Array<
+      Record<string, unknown>
+    >
+  )[3],
+  { key: 'z', label: 'Zeta', aliases: [], parts: [] },
+);
+deepStrictEqual(relationship(appendedLink.document, 'examples.3.friend'), {
+  links: { self: '../Friend/zoe' },
+});
+
+// The same marker two levels down, inside a contained value of a contained
+// value. Depth is not a special case: the marker's path inside the value names
+// the Field once the two are joined.
+const deepLink = nestedLinkMutation(
+  'append-deep-nested-link',
+  `append(.examples;{${zeta},"parts":[{"key":"p9","owner":card(params("who"))}]});`,
+);
+deepStrictEqual(deepLink.plan.intents, [
+  {
+    op: 'insert',
+    collection: ['examples'],
+    index: 3,
+    value: { key: 'z', label: 'Zeta', aliases: [], parts: [{ key: 'p9' }] },
+  },
+  { op: 'relate', field: ['examples', 3, 'parts', 0, 'owner'], cardId: zoe },
+]);
+deepStrictEqual(relationship(deepLink.document, 'examples.3.parts.0.owner'), {
+  links: { self: '../Friend/zoe' },
+});
+
+// An assignment rather than an append. Replacing a contained value clears the
+// sidecars the old one had, and the marker writes the new edge after.
+const assignedLink = nestedLinkMutation(
+  'assign-nested-link',
+  '.examples[1] = {"key":"b2","label":"Beta 2","aliases":[],"parts":[],' +
+    '"friend":card(params("who"))};',
+);
+deepStrictEqual(assignedLink.plan.intents, [
+  {
+    op: 'set',
+    path: ['examples', 1],
+    before: {
+      key: 'b',
+      label: 'Beta',
+      friend: { id: 'https://example.test/Friend/b' },
+      aliases: [],
+      parts: [],
+    },
+    after: { key: 'b2', label: 'Beta 2', aliases: [], parts: [] },
+  },
+  { op: 'relate', field: ['examples', 1, 'friend'], cardId: zoe },
+]);
+deepStrictEqual(relationship(assignedLink.document, 'examples.1.friend'), {
+  links: { self: '../Friend/zoe' },
+});
+
+// An array of contained values where only some members carry a link.
+const someLinked = nestedLinkMutation(
+  'assign-collection-partly-linked',
+  '.examples = [{"key":"x","label":"X","aliases":[],"parts":[],' +
+    '"friend":card(params("who"))},' +
+    '{"key":"y","label":"Y","aliases":[],"parts":[]}];',
+);
+deepStrictEqual(someLinked.plan.intents, [
+  {
+    op: 'set',
+    path: ['examples'],
+    before: [
+      {
+        key: 'a',
+        label: 'Alpha',
+        friend: { id: 'https://example.test/Friend/a' },
+        aliases: ['A-one', 'A-two'],
+        parts: [
+          { key: 'p1', owner: { id: 'https://example.test/Friend/part-1' } },
+          { key: 'p2', owner: { id: 'https://example.test/Friend/part-2' } },
+        ],
+      },
+      {
+        key: 'b',
+        label: 'Beta',
+        friend: { id: 'https://example.test/Friend/b' },
+        aliases: [],
+        parts: [],
+      },
+      {
+        key: 'c',
+        label: 'Gamma',
+        friend: { id: 'https://example.test/Friend/c' },
+        aliases: [],
+        parts: [],
+      },
+    ],
+    after: [
+      { key: 'x', label: 'X', aliases: [], parts: [] },
+      { key: 'y', label: 'Y', aliases: [], parts: [] },
+    ],
+  },
+  { op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe },
+]);
+deepStrictEqual(relationship(someLinked.document, 'examples.0.friend'), {
+  links: { self: '../Friend/zoe' },
+});
+strictEqual(
+  someLinked.document.data.relationships?.['examples.1.friend'],
+  undefined,
+);
+
+// A marker naming a Card the Store did not hand over is refused wherever it
+// stands, exactly as the whole-value form is.
+strictEqual(
+  nestedLinkError(
+    'nested-marker-card-missing',
+    `append(.examples;{${zeta},"parts":[],"friend":card(${JSON.stringify(ghost)})});`,
+  ).code,
+  'card-not-loaded',
+);
+strictEqual(
+  nestedLinkError(
+    'whole-value-marker-card-missing',
+    `.examples[0].friend = card(${JSON.stringify(ghost)});`,
+  ).code,
+  'card-not-loaded',
+);
+
+// A marker in a slot the Card stores as a value has no edge to write.
+strictEqual(
+  nestedLinkError(
+    'nested-marker-not-a-relationship',
+    `append(.examples;{${zeta},"parts":[],"label":card(params("who"))});`,
+  ).code,
+  'card-reference-destination',
+);
+
+// The marker's argument is read against the input the value expression was
+// handed, so the walk follows only the object, array and comma nodes that
+// assemble a value. A marker somewhere that re-roots the input is reported
+// rather than answered from the wrong place.
+strictEqual(
+  nestedLinkError(
+    'nested-marker-reroots-input',
+    '.examples |= map({"key":.key,"friend":card(params("who"))});',
+  ).code,
+  'card-marker-position',
+);
+
+// A whole-value marker plans as it always has, and so does a value with no
+// marker in it: the resolution runs only over a value tree that has one.
+deepStrictEqual(
+  nestedLinkMutation(
+    'whole-value-marker',
+    '.examples[0].friend = card(params("who"));',
+  ).plan.intents,
+  [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'append-without-marker',
+    `append(.examples;{${zeta},"parts":[]});`,
+  ).plan.intents,
+  [
+    {
+      op: 'insert',
+      collection: ['examples'],
+      index: 3,
+      value: { key: 'z', label: 'Zeta', aliases: [], parts: [] },
+    },
+  ],
+);
+
+// A link collection is a set of edges rather than a value, so appending an
+// array of markers to one is still refused: `append` adds one edge, and the
+// operation that adds several is not spelled this way.
+strictEqual(
+  nestedLinkError(
+    'append-array-of-markers-to-link-collection',
+    'append(.linked;[card(params("who"))]);',
+  ).code,
+  'relationship-value-required',
+);
+
+// A link collection nested inside a contained value. Each marker is one edge,
+// addressed by its position, and the collection leaves the stored value whole
+// rather than a member at a time.
+const crewDefinition: BxlBoxelSourceDefinition = {
+  type: 'field-def',
+  codeRef: ref('Crew'),
+  displayName: 'Crew',
+  fields: { name: 'f0', members: 'f1' },
+  fieldDefs: {
+    f0: field('contains', 'String', { primitive: true }),
+    f1: field('linksToMany', 'Friend'),
+  },
+};
+const voyageDefinition: BxlBoxelSourceDefinition = {
+  type: 'card-def',
+  codeRef: ref('Voyage'),
+  displayName: 'Voyage',
+  fields: { crews: 'f0' },
+  fieldDefs: { f0: field('containsMany', 'Crew') },
+};
+const voyageDefinitions = new Map(
+  [crewDefinition, voyageDefinition].map((definition) => [
+    JSON.stringify(definition.codeRef),
+    definition,
+  ]),
+);
+const voyageSchema = await mutationSchemaForCardSource(voyageDefinition, {
+  async lookupDefinition(codeRef) {
+    return voyageDefinitions.get(JSON.stringify(codeRef));
+  },
+});
+
+function voyageMutation(programId: string, program: string) {
+  return mutateBxlCardSource(
+    {
+      data: {
+        type: 'card',
+        attributes: { crews: [] },
+        meta: { adoptsFrom: ref('Voyage') },
+      },
+    },
+    program,
+    {
+      schema: voyageSchema,
+      syntax: 'solidified',
+      programId,
+      targetId: 'https://example.test/Voyage/one',
+      resolveReference: (reference: string) =>
+        new URL(reference, 'https://example.test/Voyage/one').href,
+      formatReference: (id: string) =>
+        id.replace('https://example.test/', '../'),
+      context: { params: { who: zoe } },
+      resolveCard: (id: string) => nestedLinkCards[id],
+    },
+  );
+}
+
+const crewed = voyageMutation(
+  'append-nested-link-collection',
+  `append(.crews;{"name":"alpha","members":[card(params("who")),card(${JSON.stringify(ana)})]});`,
+);
+deepStrictEqual(crewed.plan.intents, [
+  {
+    op: 'insert',
+    collection: ['crews'],
+    index: 0,
+    value: { name: 'alpha' },
+  },
+  { op: 'relate', field: ['crews', 0, 'members'], cardId: zoe, index: 0 },
+  { op: 'relate', field: ['crews', 0, 'members'], cardId: ana, index: 1 },
+]);
+deepStrictEqual(crewed.document.data.attributes?.crews, [{ name: 'alpha' }]);
+deepStrictEqual(relationship(crewed.document, 'crews.0.members.0'), {
+  links: { self: '../Friend/zoe' },
+});
+deepStrictEqual(relationship(crewed.document, 'crews.0.members.1'), {
+  links: { self: '../Friend/ana' },
+});
+
+function voyageError(programId: string, program: string) {
+  try {
+    voyageMutation(programId, program);
+  } catch (error) {
+    if (error instanceof BxlMutationError) return error;
+    throw error;
+  }
+  throw new Error(`${programId} was expected to fail`);
+}
+
+// The whole collection leaves the stored value, so a member written beside the
+// edges would go with it rather than be stored as it reads.
+strictEqual(
+  voyageError(
+    'nested-link-collection-mixed-members',
+    'append(.crews;{"name":"alpha","members":[card(params("who")),"ana"]});',
+  ).code,
+  'relationship-value-required',
+);
+
+// A marker standing where the collection itself goes names no edge to change.
+strictEqual(
+  voyageError(
+    'nested-link-collection-replaced',
+    'append(.crews;{"name":"alpha","members":card(params("who"))});',
+  ).code,
+  'collection-replacement-forbidden',
 );
 
 console.log(


### PR DESCRIPTION
## Background and Goal

`card(id)` is how a BXL mutation program names *which* Card a relationship
points at. It is not a callable function — the planner recognises it by shape
and turns it into a relationship intent. Recognising it only as an entire value
expression leaves one shape with no executable spelling: a relationship carried
inside a contained value.

```
append(.comments; {body: params("body"), author: card(actor("id"))});
```

This resolves the marker wherever it stands in the value a statement writes —
on its own, or at any depth inside an object or array the value expression
builds. Additive: a value tree holding no marker is never rebuilt and plans
exactly as it did.

## Where to start

- `packages/bxl/src/mutation/planner.ts` — `resolveValueTreeCards` and
  `liftCardMarkers` (getting the markers out of an expression), then
  `nestedRelationships` (resolving them against the Fields they fill), then
  `modelValue` / `storedValue` (the two halves a written value splits into).
- `packages/bxl/tests/boxel/card-source-mutation.ts` — the planned `intents`
  are asserted verbatim for each shape, plus the committed card source, so a
  case proves the edge landed where the adapter writes it rather than only that
  planning succeeded.
- `packages/bxl/docs/mutation-profile.md` — the profile's statement of the rule.

## Key decisions and non-obvious mechanics

- **A link is an edge of the Card, not a member of the value.** So a marker
  inside a contained value splits the write in two: the stored value sheds the
  relationship's subtree, and the plan carries a separate `relate` intent at the
  Field the marker filled. `append(.examples; {key: "z", friend: card(…)})`
  stores `{key: "z"}` and relates at `["examples", 3, "friend"]`, which the
  card-source adapter already commits as `relationships["examples.3.friend"]`
  through its existing nested-path handling — no adapter change.

- **The planner's own view keeps the loaded Card in the marker's place.** The
  two values differ on purpose: what the document stores drops the link, and
  what the planner reads back holds it, so a later statement reads a link this
  program just wrote the same way it reads one the document already held. That
  is the same split whole-value `card(…)` has always made — it emits a `relate`
  and puts `loadedCard(id)` in the working document — applied one level in.

- **A marker is identified by identity, not by shape.** Resolution rewrites each
  `card(…)` node into a node yielding an object carrying a module-private
  symbol, and the evaluated tree is searched for those before anything copies
  it. A program builds arbitrary JSON, so a marker recognised by a well-known
  key could be forged; a symbol key has no JSON spelling. Rewriting the node
  rather than evaluating the value tree by hand is also what keeps jq's own
  semantics — comma streams, dynamic keys, object merges — answering for
  everything that is not the marker. (`isCardReference`, the older
  shape-recognised form, still applies to a *whole* value; it is bounded by
  `loadedCard`, which refuses an id the caller did not supply.)

- **A marker reads its Card when the program reaches it, not while the tree is
  rewritten.** Reading it up front would make every marker in the tree cost
  something whether or not the program went that way — an `if` branch the
  condition rejects and a `//` operand that short-circuits away would both have
  their arguments evaluated, which refuses the fallback on the strength of the
  branch it exists to avoid. Since the profile bans `try`, those two are the
  only fallback spellings a program has, so this is what makes them usable:

  ```
  .owner = (card(params("preferred")) // card(params("fallback")));
  ```

- **Which positions resolve, and why it is not "anywhere in the AST".** A marker
  reads its argument against the input the value expression itself was handed,
  so the walk follows the nodes that pass that input straight down *and* whose
  operands flow into the result: object entries, array and comma streams, the
  operands of `//`, `+` and `*`, and the branches of an `if`. `+` earns its
  place because `.` merged with an object literal is how a program writes part
  of a contained value, and is this package's own idiom. Three kinds of position
  are left alone and reported as `card-marker-position` — one that re-roots the
  input (the body of `map`, either side of a pipe), a condition, which chooses a
  branch rather than being the value, and an argument read as a plain value (an
  `assert` message, an insertion index, a reorder order), which names no Field
  to relate a Card to. `try` needs no handling: the profile refuses it outright.

- **A path only descends through a Field that has Fields of its own.** Keeping
  the parent's schema past a scalar would let the next key resolve against it
  and answer with the sibling beside it, so a marker written at `.label.friend`
  would name the `friend` relationship the path never reaches and plan an edge
  the card source has nowhere to put. This was latent in `resolveField` and only
  reachable once marker paths came from a value's shape rather than from a path
  resolved against the document.

- **A value expression and the `card(…)` arguments inside it share one runtime
  budget.** Every limit lives on the frame the evaluation opens — steps,
  milliseconds and output bytes all restart with each one — so evaluating each
  marker argument on its own frame would multiply the host's ceiling by the
  marker count. `withEvaluationBudget` opens the frame once and hands the body
  an evaluator that does not open its own.

- **A `linksToMany` written inside a value takes one marker per edge**, indexed
  by position, and every member of a collection a marker writes to must be one
  (`relationship-value-required`). The whole collection leaves the stored value
  together, so a plain member written beside the edges would be dropped without
  a word. A marker standing where the collection itself goes names no edge to
  change and is refused as a wholesale replacement. The adapter builds a
  `linksToMany` item schema as `{fields: [{key: 'id', writable: false}]}`, so
  the edge is the only thing that can be written here — never an `id` attribute.

- **Every existing refusal keeps its code.** A marker in a slot the Card stores
  as a value is `card-reference-destination`; one naming a Card the Store did
  not hand over is `card-not-loaded`, the same as the whole-value form; a
  compound assignment carrying one is `relationship-arithmetic`. Appending an
  array of markers to a link collection is still `relationship-value-required`:
  `append` adds one edge, and adding several is not spelled that way.

- **`|=` settles on the value as the planner reads it.** An update's result is
  compared against the layered value it was produced from, so the markers become
  loaded Cards before the comparison; a slot left standing empty would read as a
  member the Card dropped. The stored value is derived from the settled result.

## Test plan

Ran locally against a full workspace install:

- `pnpm test` in `packages/bxl` — **71 / 71 suites pass**.
- `pnpm lint` in `packages/bxl` — `lint:js` (eslint) and `lint:types`
  (`ember-tsc --noEmit`) both clean.
- `packages/realm-server` `bxl-node-smoke-test.ts` — 5 / 5, so the package still
  resolves and runs from a sibling workspace package.
- Each case below was confirmed to fail without the corresponding source change,
  with the error the change addresses.

Added to `packages/bxl/tests/boxel/card-source-mutation.ts`, each asserting the
planned `intents` verbatim and, where it is the point, the committed card
source:

- an appended contained value carrying a link, and the same marker two levels
  down inside a contained value of a contained value;
- `replace`, `prepend` and `insert_item_before` carrying one, each resolved
  against the place its own value lands;
- an assignment rather than an append, over a value whose old sidecars clear;
- a marker riding through a `.` + object-literal merge under `|=`;
- an array of contained values where only some members carry a link;
- a link collection nested inside a contained value, its mixed-member refusal,
  and the wholesale-replacement refusal;
- a marker in a branch that is not taken and in a short-circuited `//` operand,
  neither of which may evaluate its argument, plus `elif` and an argument that
  *is* reached being held to `card-id-invalid`;
- a marker naming a Card the Store did not hand over, refused the way the
  whole-value form is;
- a marker in a slot the Card stores as a value, one below a scalar Field, one
  in a condition, one in a position that re-roots the input, and one in an
  argument read as a plain value;
- markers sharing one runtime budget — calibrated by finding the smallest budget
  a single marker fits in, then requiring eight to be refused at that same
  budget *naming the step limit*, so the claim survives a change in how steps
  are counted and cannot pass on an unrelated refusal;
- one prepared program planned repeatedly, giving identical intents and picking
  up a new `params` each time, since resolution must not consume the parsed tree;
- an array of markers appended to a root link collection, still refused;
- a whole-value marker and a marker-free append, both pinned to the intents they
  produce.

The four host `bxl-*` integration suites need the dev stack and did not run
locally; CI runs them, and they were green on the previous head, as were the
realm-server suites (2,655) and the host suites (4,663).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2iNWh3HgzSpARz82g48eA