### PR TITLE
fix: recognise a card() reference by identity rather than by shape

### DIFF
--- a/packages/bxl/docs/mutation-profile.md
+++ b/packages/bxl/docs/mutation-profile.md
@@ -1026,9 +1026,9 @@ branch that is not taken costs nothing:
 ```
 
 `card(id)` is the only spelling that names a relationship target. A marker is
-recognised by an identity the planner stamps on the node it rewrote, never by
-the shape of the value that node produced, so a value a program assembles to
-look like a reference is plain JSON: at a relationship Field it is refused as
+recognised by an identity the planner mints from a `card(…)` node the program
+itself wrote, never by the shape of the value that node produced, so a value a
+program assembles to look like a reference is plain JSON: at a relationship Field it is refused as
 `relationship-value-required`, and in a slot the Card stores as a value it is
 stored as it reads. A program therefore cannot point a link at a Card without
 writing `card(…)`, which is what lets declaration lowering, the profile's own

--- a/packages/bxl/docs/mutation-profile.md
+++ b/packages/bxl/docs/mutation-profile.md
@@ -1025,6 +1025,16 @@ branch that is not taken costs nothing:
 .owner = (card(params("preferred")) // card(params("fallback")));
 ```
 
+`card(id)` is the only spelling that names a relationship target. A marker is
+recognised by an identity the planner stamps on the node it rewrote, never by
+the shape of the value that node produced, so a value a program assembles to
+look like a reference is plain JSON: at a relationship Field it is refused as
+`relationship-value-required`, and in a slot the Card stores as a value it is
+stored as it reads. A program therefore cannot point a link at a Card without
+writing `card(…)`, which is what lets declaration lowering, the profile's own
+classification and a reader of the program all reason about links from one
+vocabulary.
+
 The schema determines whether a selected location is contained data,
 `linksTo`, or `linksToMany`. It therefore lowers assignment, append, delete,
 insert, and move to relationship intents when the target field is a

--- a/packages/bxl/docs/mutation-profile.md
+++ b/packages/bxl/docs/mutation-profile.md
@@ -1011,12 +1011,18 @@ collection leaves the stored value together.
 A marker reads its argument against the input the value expression itself was
 handed, so resolution follows the nodes that pass that input straight down and
 whose operands flow into the result: object entries, array and comma streams,
-the operands of `//`, `+` and `*`, and the branches of an `if`. A `card(id)`
+the operands of `//` and `+`, and the branches of an `if`. A `card(id)`
 somewhere that re-roots the input — the body of `map`, either side of a pipe —
 is refused rather than answered against the wrong value, and so is one in a
 condition, which chooses a branch rather than being the value, and one in an
 argument read as a plain value, such as an `assert` message or a `reorder_by`
 order, which names no Field to relate a Card to.
+
+`+` is the merge a marker rides through; `*` is not. A recursive merge descends
+into a key both operands hold, and a marker merged into rather than replaced
+would lose the relationship while the rest of the write landed, so a marker in
+a `*` operand is refused as well. `.` merged with an object literal is how a
+value expression writes part of a contained value, and `+` is that merge.
 
 The argument is read when the program reaches the marker, so a marker in a
 branch that is not taken costs nothing:
@@ -1028,12 +1034,17 @@ branch that is not taken costs nothing:
 `card(id)` is the only spelling that names a relationship target. A marker is
 recognised by an identity the planner mints from a `card(…)` node the program
 itself wrote, never by the shape of the value that node produced, so a value a
-program assembles to look like a reference is plain JSON: at a relationship Field it is refused as
-`relationship-value-required`, and in a slot the Card stores as a value it is
-stored as it reads. A program therefore cannot point a link at a Card without
-writing `card(…)`, which is what lets declaration lowering, the profile's own
-classification and a reader of the program all reason about links from one
-vocabulary.
+program assembles to look like a reference is treated as the plain JSON it is.
+A statement whose whole value is one is refused where the target is a
+relationship (`relationship-value-required`) and stores it where the target is
+a slot the Card holds a value in. Written as a member of a contained value it
+is stored as that member, which is the same thing the Card does with any other
+value written where a link belongs.
+
+No route produces a relationship intent, so a program cannot point a link at a
+Card without writing `card(…)` — which is what lets declaration lowering, the
+profile's own classification and a reader of the program all reason about links
+from one vocabulary.
 
 The schema determines whether a selected location is contained data,
 `linksTo`, or `linksToMany`. It therefore lowers assignment, append, delete,

--- a/packages/bxl/src/mutation/planner.ts
+++ b/packages/bxl/src/mutation/planner.ts
@@ -67,35 +67,34 @@ import {
   type PreparedBxlMutation,
 } from './types.ts';
 
-interface CardReference {
-  readonly kind: 'card-reference';
-  readonly id: string;
-}
-
-function isCardReference(value: unknown): value is CardReference {
-  return Boolean(
-    value &&
-    typeof value === 'object' &&
-    (value as Partial<CardReference>).kind === 'card-reference' &&
-    typeof (value as Partial<CardReference>).id === 'string',
-  );
-}
-
 /**
- * The value a `card(…)` marker leaves behind while an expression it sits
- * inside is evaluated.
+ * The value a `card(…)` marker leaves behind while the value expression it
+ * sits inside is evaluated — whether it stands for the whole value or for one
+ * Field nested inside it.
  *
- * Identity is what makes a marker a marker. A program builds arbitrary JSON, so
- * one recognised by its shape could be forged; a symbol key has no JSON
- * spelling, and the evaluated tree is searched for markers before anything
- * copies it, so this test can be neither fooled nor lost. `isCardReference`
- * above is the older shape-recognised form, and a whole value matching it is
- * still taken for a reference — bounded by `loadedCard`, which refuses an id
- * the caller did not supply.
+ * Identity is what makes a marker a marker, and it is the only thing that
+ * does. A program builds arbitrary JSON, so a marker recognised by its shape
+ * could be forged: a value spelled out as data would name a relationship
+ * target that the program never wrote `card(…)` for, and the vocabulary the
+ * platform reasons about — declaration lowering emits `card(…)`, the profile
+ * classifies it, a reviewer reads it — would have a second, silent spelling. A
+ * symbol key has no JSON spelling, and the planner stamps one only where it
+ * rewrote a `card(…)` node itself, so a marker can be neither forged nor
+ * confused with the data around it. The evaluated tree is searched for markers
+ * before anything copies it, so it cannot be lost either: `clone` drops symbol
+ * keys.
  */
 const CARD_MARKER = Symbol('bxl.mutation.card-marker');
 
-function isCardMarker(value: unknown): value is { [CARD_MARKER]: string } {
+interface CardReference {
+  readonly [CARD_MARKER]: string;
+}
+
+function cardReference(id: string): CardReference {
+  return { [CARD_MARKER]: id };
+}
+
+function isCardReference(value: unknown): value is CardReference {
   return Boolean(
     value &&
     typeof value === 'object' &&
@@ -103,7 +102,7 @@ function isCardMarker(value: unknown): value is { [CARD_MARKER]: string } {
   );
 }
 
-/** `card(id)` as it is written: a marker the planner reads by shape. */
+/** `card(id)` as a program writes it: the node the planner rewrites. */
 function isCardCall(
   ast: ExpressionAst,
 ): ast is Extract<ExpressionAst, { type: 'filter' }> {
@@ -650,7 +649,7 @@ function cardMarkerNode(
   evaluate: EvaluateItems,
   statement: number,
 ): ExpressionAst {
-  let marker: { [CARD_MARKER]: string } | undefined;
+  let marker: CardReference | undefined;
   const node: RuntimeAnnotatedExpressionAst = {
     type: 'filter',
     name: '_card_marker/0',
@@ -658,9 +657,9 @@ function cardMarkerNode(
     args: [],
     singleOutput: false,
     resolvedNative: function* () {
-      marker ??= {
-        [CARD_MARKER]: readCardId(argument, input, evaluate, statement),
-      };
+      marker ??= cardReference(
+        readCardId(argument, input, evaluate, statement),
+      );
       yield createItem(marker);
     },
   };
@@ -762,7 +761,7 @@ function liftCardMarkers(raw: unknown): {
 } {
   const references: NestedCardReference[] = [];
   const copy = (value: unknown, path: BxlMutationPath): BxlMutationJson => {
-    if (isCardMarker(value)) {
+    if (isCardReference(value)) {
       references.push({ path, id: value[CARD_MARKER] });
       return null;
     }
@@ -793,10 +792,9 @@ function evaluateSingleJson(
   return withEvaluationBudget(context, (evaluate): EvaluatedValue => {
     if (isCardCall(argument.ast)) {
       return {
-        value: {
-          kind: 'card-reference',
-          id: readCardId(argument.ast.args[0]!, input, evaluate, statement),
-        },
+        value: cardReference(
+          readCardId(argument.ast.args[0]!, input, evaluate, statement),
+        ),
         references: [],
       };
     }
@@ -836,7 +834,7 @@ function evaluateSingleJson(
       (reference) => reference.path.length === 0,
     );
     return whole
-      ? { value: { kind: 'card-reference', id: whole.id }, references: [] }
+      ? { value: cardReference(whole.id), references: [] }
       : { value: lifted.value, references: lifted.references };
   });
 }
@@ -1523,15 +1521,16 @@ function planAssignment(
           'Use relationship collection operations instead of replacing linksToMany wholesale.',
         );
       }
+      const cardId = next[CARD_MARKER];
       intents.push({
         op: 'relate',
         field: field.relationship.path,
-        cardId: next.id,
+        cardId,
       });
       output = setAt(
         output,
         field.relationship.path,
-        loadedCard(next.id, context, statement.statement),
+        loadedCard(cardId, context, statement.statement),
       );
       documentChanged(context);
       continue;
@@ -1905,17 +1904,14 @@ function planCall(
             'Relationship insertion requires card("id").',
           );
         }
+        const cardId = value.value[CARD_MARKER];
         intents.push({
           op: 'relate',
           field: target.field.relationship.path,
-          cardId: value.value.id,
+          cardId,
           index,
         });
-        collection.splice(
-          index,
-          0,
-          loadedCard(value.value.id, context, number),
-        );
+        collection.splice(index, 0, loadedCard(cardId, context, number));
         documentChanged(context);
       } else {
         if (isCardReference(value.value)) {
@@ -1972,17 +1968,14 @@ function planCall(
             'Relationship insertion requires card("id").',
           );
         }
+        const cardId = value.value[CARD_MARKER];
         intents.push({
           op: 'relate',
           field: anchor.field.relationship.path,
-          cardId: value.value.id,
+          cardId,
           index,
         });
-        collection.splice(
-          index,
-          0,
-          loadedCard(value.value.id, context, number),
-        );
+        collection.splice(index, 0, loadedCard(cardId, context, number));
         documentChanged(context);
       } else {
         if (isCardReference(value.value)) {

--- a/packages/bxl/src/mutation/planner.ts
+++ b/packages/bxl/src/mutation/planner.ts
@@ -81,9 +81,17 @@ import {
  * symbol key has no JSON spelling, and the planner mints one only from a
  * `card(…)` node the program itself wrote — directly where such a node is the
  * whole value, and by rewriting the node where it sits inside one — so a
- * marker can be neither forged nor confused with the data around it. The evaluated tree is searched for markers
- * before anything copies it, so it cannot be lost either: `clone` drops symbol
- * keys.
+ * marker can be neither forged nor confused with the data around it.
+ *
+ * Keeping it also means not losing it, which is a property of the routes a
+ * value travels rather than of the symbol: a rebuilt object keeps its string
+ * keys and drops its symbol ones. So every route the walk resolves through is
+ * one that carries the brand — object and array literals build around it and
+ * `+` spreads it — and `VALUE_COMBINING_OPERATORS` says which those are.
+ * `clone` is not one, since `structuredClone` drops symbol-keyed properties,
+ * which is why the evaluated tree is searched for markers before anything
+ * copies it and a reference becomes a `cardId` at the write path rather than
+ * being stored in the working document.
  */
 const CARD_MARKER = Symbol('bxl.mutation.card-marker');
 
@@ -598,12 +606,20 @@ function childExpressions(ast: ExpressionAst): ExpressionAst[] {
 /**
  * Binary operators whose operands are values the result is built from, rather
  * than a stream re-rooted or a decision made from them.
+ *
+ * `*` is not one of them, though it combines values too. It merges objects
+ * recursively, and the merge rebuilds each object from its string keys, so a
+ * marker at a key the left operand already holds an object at is merged into
+ * and its brand dropped — which would take the relationship with it and leave
+ * the write looking like it succeeded. Refusing the position reports what a
+ * program cannot express here instead of losing an edge to it; `+` is the
+ * merge a value expression writes part of a contained value with, and it
+ * spreads its operands rather than descending into them.
  */
 const VALUE_COMBINING_OPERATORS: ReadonlySet<string> = new Set([
   ',',
   '//',
   '+',
-  '*',
 ]);
 
 function containsCardCall(ast: ExpressionAst): boolean {
@@ -674,7 +690,7 @@ function cardMarkerNode(
  * A marker reads its argument against the input the value expression itself was
  * handed, so the walk follows the nodes that pass that input down unchanged and
  * whose operands flow into the result: object entries, array and comma streams,
- * the operands of `//`, `+` and `*`, and the branches of an `if`. Everywhere
+ * the operands of `//` and `+`, and the branches of an `if`. Everywhere
  * else the marker is left as written and `evaluateSingleJson` reports it as
  * unresolvable — a node that re-roots the input (the body of `map`, either side
  * of a pipe) would answer it from the wrong place, and a condition chooses a

--- a/packages/bxl/src/mutation/planner.ts
+++ b/packages/bxl/src/mutation/planner.ts
@@ -78,9 +78,10 @@ import {
  * target that the program never wrote `card(…)` for, and the vocabulary the
  * platform reasons about — declaration lowering emits `card(…)`, the profile
  * classifies it, a reviewer reads it — would have a second, silent spelling. A
- * symbol key has no JSON spelling, and the planner stamps one only where it
- * rewrote a `card(…)` node itself, so a marker can be neither forged nor
- * confused with the data around it. The evaluated tree is searched for markers
+ * symbol key has no JSON spelling, and the planner mints one only from a
+ * `card(…)` node the program itself wrote — directly where such a node is the
+ * whole value, and by rewriting the node where it sits inside one — so a
+ * marker can be neither forged nor confused with the data around it. The evaluated tree is searched for markers
  * before anything copies it, so it cannot be lost either: `clone` drops symbol
  * keys.
  */

--- a/packages/bxl/tests/boxel/card-source-mutation.ts
+++ b/packages/bxl/tests/boxel/card-source-mutation.ts
@@ -3286,6 +3286,63 @@ deepStrictEqual(
   ],
 );
 
+// `card(id)` is the only spelling that names a relationship target. A marker
+// is recognised by an identity the planner stamps on the node it rewrote, so a
+// value a program builds to look like one is plain JSON wherever it stands: at
+// a relationship Field it is refused the way any other value there is, and in
+// a slot the Card stores as a value it is stored as it reads.
+const forgedReference = `{"kind":"card-reference","id":${JSON.stringify(zoe)}}`;
+strictEqual(
+  nestedLinkError(
+    'forged-reference-at-a-relationship',
+    `.examples[0].friend = ${forgedReference};`,
+  ).code,
+  'relationship-value-required',
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'forged-reference-at-a-value-slot',
+    `.examples[0].key = ${forgedReference};`,
+  ).plan.intents,
+  [
+    {
+      op: 'set',
+      path: ['examples', 0, 'key'],
+      before: 'a',
+      after: { kind: 'card-reference', id: zoe },
+    },
+  ],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'forged-reference-nested-in-a-contained-value',
+    `append(.examples;{${zeta},"parts":[],"label":${forgedReference}});`,
+  ).plan.intents,
+  [
+    {
+      op: 'insert',
+      collection: ['examples'],
+      index: 3,
+      value: {
+        key: 'z',
+        label: { kind: 'card-reference', id: zoe },
+        aliases: [],
+        parts: [],
+      },
+    },
+  ],
+);
+
+// The pair the refusal is measured against: the same location and the same id,
+// differing only in whether the program said `card`.
+deepStrictEqual(
+  nestedLinkMutation(
+    'marker-beside-the-forged-shape',
+    `.examples[0].friend = card(${JSON.stringify(zoe)});`,
+  ).plan.intents,
+  [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+
 // A link collection is a set of edges rather than a value, so appending an
 // array of markers to one is still refused: `append` adds one edge, and the
 // operation that adds several is not spelled this way.

--- a/packages/bxl/tests/boxel/card-source-mutation.ts
+++ b/packages/bxl/tests/boxel/card-source-mutation.ts
@@ -3287,8 +3287,9 @@ deepStrictEqual(
 );
 
 // `card(id)` is the only spelling that names a relationship target. A marker
-// is recognised by an identity the planner stamps on the node it rewrote, so a
-// value a program builds to look like one is plain JSON wherever it stands: at
+// is recognised by an identity the planner mints from a `card(…)` node the
+// program itself wrote — whether that node is the whole value or sits inside
+// one — so a value built to look like one is plain JSON wherever it stands: at
 // a relationship Field it is refused the way any other value there is, and in
 // a slot the Card stores as a value it is stored as it reads.
 const forgedReference = `{"kind":"card-reference","id":${JSON.stringify(zoe)}}`;

--- a/packages/bxl/tests/boxel/card-source-mutation.ts
+++ b/packages/bxl/tests/boxel/card-source-mutation.ts
@@ -3073,12 +3073,17 @@ const nestedLinkCards: Record<string, BxlMutationJson> = {
   [ana]: { id: ana },
 };
 
-function nestedLinkMutation(programId: string, program: string) {
+function nestedLinkMutation(
+  programId: string,
+  program: string,
+  baseRevision?: string,
+) {
   return mutateBxlCardSource(richSourceFixture(), program, {
     schema: richSchema,
     syntax: 'solidified',
     programId,
     ...richProjectionOptions,
+    ...(baseRevision === undefined ? {} : { baseRevision }),
     context: { params: { who: zoe } },
     resolveCard: (id: string) => nestedLinkCards[id],
     serializeContainedValue: () => ({
@@ -3087,9 +3092,18 @@ function nestedLinkMutation(programId: string, program: string) {
   });
 }
 
-function nestedLinkError(programId: string, program: string) {
+/** The same run with a pinned base revision, which `insert_at` requires. */
+function nestedLinkMutationAt(programId: string, program: string) {
+  return nestedLinkMutation(programId, program, 'revision-1');
+}
+
+function nestedLinkError(
+  programId: string,
+  program: string,
+  run: (programId: string, program: string) => unknown = nestedLinkMutation,
+) {
   try {
-    nestedLinkMutation(programId, program);
+    run(programId, program);
   } catch (error) {
     if (error instanceof BxlMutationError) return error;
     throw error;
@@ -3334,14 +3348,107 @@ deepStrictEqual(
   ],
 );
 
-// The pair the refusal is measured against: the same location and the same id,
-// differing only in whether the program said `card`.
+// Every route that reaches a relationship refuses the forged shape, not just a
+// root assignment: a `linksTo` below a contained value, an update, a branch
+// that answers, and each of the three ways an edge joins a link collection.
+for (const [programId, program] of [
+  [
+    'forged-below-a-contained-value',
+    `.examples[0].parts[0].owner = ${forgedReference};`,
+  ],
+  ['forged-through-an-update', `.examples[0].friend |= ${forgedReference};`],
+  [
+    'forged-through-a-branch',
+    `.examples[0].friend = (if true then ${forgedReference} else null end);`,
+  ],
+  [
+    'forged-appended-to-a-link-collection',
+    `append(.linked; ${forgedReference});`,
+  ],
+  [
+    'forged-inserted-before-an-edge',
+    `insert_item_before(${forgedReference}; .linked[0]);`,
+  ],
+] as const) {
+  strictEqual(
+    nestedLinkError(programId, program).code,
+    'relationship-value-required',
+    `${programId} refuses a value shaped like a reference`,
+  );
+}
+// `insert_at` names a position, so it runs against a pinned base revision.
+strictEqual(
+  nestedLinkError(
+    'forged-inserted-into-a-link-collection',
+    `insert_at(.linked; 0; ${forgedReference});`,
+    nestedLinkMutationAt,
+  ).code,
+  'relationship-value-required',
+);
+
+// `card(…)` reaches every one of those routes, so the refusals above are the
+// spelling being enforced rather than the route being closed.
+deepStrictEqual(
+  nestedLinkMutationAt(
+    'marker-inserted-into-a-link-collection',
+    'insert_at(.linked; 0; card(params("who")));',
+  ).plan.intents,
+  [{ op: 'relate', field: ['linked'], cardId: zoe, index: 0 }],
+);
 deepStrictEqual(
   nestedLinkMutation(
-    'marker-beside-the-forged-shape',
-    `.examples[0].friend = card(${JSON.stringify(zoe)});`,
+    'marker-below-a-contained-value',
+    '.examples[0].parts[0].owner = card(params("who"));',
+  ).plan.intents,
+  [{ op: 'relate', field: ['examples', 0, 'parts', 0, 'owner'], cardId: zoe }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'marker-through-an-update',
+    '.examples[0].friend |= card(params("who"));',
   ).plan.intents,
   [{ op: 'relate', field: ['examples', 0, 'friend'], cardId: zoe }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'marker-inserted-before-an-edge',
+    'insert_item_before(card(params("who")); .linked[0]);',
+  ).plan.intents,
+  [{ op: 'relate', field: ['linked'], cardId: zoe, index: 0 }],
+);
+deepStrictEqual(
+  nestedLinkMutation(
+    'marker-inserted-after-an-edge',
+    'insert_item_after(card(params("who")); .linked[0]);',
+  ).plan.intents,
+  [{ op: 'relate', field: ['linked'], cardId: zoe, index: 1 }],
+);
+
+// A real marker in a slot the Card stores as a value still names a Field with
+// no edge to write, which is the refusal the forged shape no longer draws.
+strictEqual(
+  nestedLinkError(
+    'marker-at-a-value-slot',
+    '.examples[0].key = card(params("who"));',
+  ).code,
+  'card-reference-destination',
+);
+
+// Compound assignment against a forged shape reaches the operator, because by
+// then it is plain JSON: the refusal a marker draws is for a marker.
+strictEqual(
+  nestedLinkError(
+    'forged-under-compound-assignment',
+    `.examples[0].key += ${forgedReference};`,
+  ).code,
+  'statement-failed',
+);
+strictEqual(
+  nestedLinkError(
+    'marker-under-compound-assignment',
+    '.examples[0].key += card(params("who"));',
+  ).code,
+  'relationship-arithmetic',
 );
 
 // A link collection is a set of edges rather than a value, so appending an
@@ -3641,6 +3748,52 @@ deepStrictEqual(
         parts: [],
       },
       after: { key: 'b', label: 'Beta', aliases: [], parts: [] },
+    },
+    { op: 'relate', field: ['examples', 1, 'friend'], cardId: zoe },
+  ],
+);
+
+// `*` merges recursively, so a marker at a key both operands hold would be
+// merged into rather than replacing it, and the merge would drop its brand —
+// losing the relationship while the rest of the write landed. The position is
+// refused instead, whether or not the left operand happens to hold that key,
+// so the same program cannot turn silent on a different document.
+for (const [programId, program] of [
+  [
+    'marker-through-a-recursive-merge',
+    '.examples[1] |= (. * {"label":"Beta II","friend":card(params("who"))});',
+  ],
+  [
+    'marker-through-a-recursive-merge-of-a-fresh-object',
+    '.examples[1] |= ({"key":.key} * {"friend":card(params("who"))});',
+  ],
+] as const) {
+  strictEqual(
+    nestedLinkError(programId, program).code,
+    'card-marker-position',
+    `${programId} refuses a marker in a recursive merge`,
+  );
+}
+
+// `+` spreads its operands instead of descending into them, so it is the merge
+// a marker rides through, and the edge lands where the marker stood.
+deepStrictEqual(
+  nestedLinkMutation(
+    'marker-through-a-spreading-merge',
+    '.examples[1] |= (. + {"label":"Beta II","friend":card(params("who"))});',
+  ).plan.intents,
+  [
+    {
+      op: 'set',
+      path: ['examples', 1],
+      before: {
+        key: 'b',
+        label: 'Beta',
+        friend: { id: 'https://example.test/Friend/b' },
+        aliases: [],
+        parts: [],
+      },
+      after: { key: 'b', label: 'Beta II', aliases: [], parts: [] },
     },
     { op: 'relate', field: ['examples', 1, 'friend'], cardId: zoe },
   ],


### PR DESCRIPTION
## Background and Goal

`card(id)` is how a BXL mutation program names which Card a relationship points
at. The planner recognised it in two different ways depending on where it
stood, and only one of them was safe.

A marker nested inside a value is recognised by a module-private symbol. A
marker standing as the *whole* value was recognised by the shape of the
evaluated result — an object carrying `kind: "card-reference"` and a string
`id`. That is a shape a program can build:

```
.examples[0].friend = {"kind":"card-reference","id":"https://example.test/Friend/zoe"};

intents:  [{"op":"relate","field":["examples",0,"friend"],"cardId":"https://example.test/Friend/zoe"}]
document: relationships["examples.0.friend"].links.self = "../Friend/zoe"
```

So a program could point a link at a Card without ever writing `card(…)`,
outside the vocabulary the platform reasons about — declaration lowering emits
`card(…)`, the profile classifies it, a reviewer reading a program sees it —
and against the refusal's own wording, which says loaded Card JSON is not
accepted as a value.

Both paths now test the same identity. `CardReference` *is* the symbol-branded
marker, so the planner takes a value for a reference only where the program
wrote a `card(…)` node, and the shape test is gone.

Making identity the *only* recognition means the brand has to survive every
route a value travels, since there is no shape to fall back on. It does not
survive a recursive merge, so `*` is no longer a position a marker may stand
in — see below.

## Where to start

- `packages/bxl/src/mutation/planner.ts` — `CARD_MARKER`, `CardReference`,
  `cardReference` / `isCardReference`, `VALUE_COMBINING_OPERATORS`, and the
  write paths that branch on a reference.
- `packages/bxl/tests/boxel/card-source-mutation.ts` — the forged-shape cases,
  each paired with the `card(…)` spelling at the same location.
- `packages/bxl/docs/mutation-profile.md` — the profile's statement of both
  rules.

## Key decisions and non-obvious mechanics

- **One representation, not two tests.** Unifying the marker and the
  whole-value reference is what makes the guarantee structural rather than
  duplicated: there is one predicate, and every write path that asks "is this a
  reference" asks the same question the nested path asks.

- **Two routes mint the brand, both from a `card(…)` node the program wrote.**
  `evaluateSingleJson` mints it straight from an `isCardCall` node when such a
  node *is* the whole value; `resolveValueTreeCards` rewrites the node into a
  marker-yielding one when it sits inside a value expression, and the
  marker-lifted route that reaches a whole value through a conditional or a
  `//` operand converges on the same object. What the identity guarantees is
  the source, not the route: nothing but a `card(…)` node produces it.

- **A marker may not stand in a `*` operand.** A rebuilt object keeps its
  string keys and drops its symbol ones, and `*` merges recursively — it
  descends into a key both operands hold. A marker merged into rather than
  replaced loses its brand, and with it the relationship:
  `.examples[0] |= (. * {"friend": card(id)})` over a document already holding
  `examples.0.friend` planned no `relate`, stored the old Card's JSON as an
  attribute, and dropped the existing edge, while the rest of the write landed
  and nothing reported a problem. The same program was correct when the left
  operand happened not to hold that key, which is the worse half — it turns
  silent on a different document. The position is now refused as
  `card-marker-position`. `+` spreads its operands instead of descending into
  them, carries the brand, and is already the merge the profile gives for
  writing part of a contained value.

  The alternative was teaching the vendored merge to carry symbol keys, which
  is worse: the lazy card view's `ownKeys` trap reports its target's symbols,
  so `. * {…}` over a card would copy card-api's `getFields` **function** onto
  a plain merged value and make it answer `getFieldsFor` as if it were a card.
  Verified by probe. The vendored `jqtools/` layer is untouched by this PR.

- **A symbol brand cannot be forged, and the planner never carries it far.**
  A symbol key has no JSON spelling, so no program can produce one. `clone`
  does not carry one either (`structuredClone` drops symbol-keyed properties),
  which is why the evaluated tree is searched for markers *before* anything
  copies it, and why a reference becomes a `cardId` at the write path rather
  than being stored in the working document.

- **What a program relying on the shape now gets.** A statement whose whole
  value is a forged shape is refused as `relationship-value-required` where the
  target is a relationship, and stores it where the target is a slot the Card
  holds a value in. Written as a member of a contained value it is stored as
  that member. No route produces a relationship intent, which is the property
  that matters.

- **Compound assignment.** `.key += forged` now reaches the operator and fails
  as a type error, because by then the value *is* plain JSON;
  `relationship-arithmetic` is the refusal a real marker draws. Both are pinned.

## Test plan

Ran locally against a full workspace install:

- `pnpm test` in `packages/bxl` — **71 / 71 suites pass**.
- `pnpm lint` in `packages/bxl` — `lint:js` (eslint) and `lint:types`
  (`ember-tsc --noEmit`) both clean.
- `packages/realm-server` `bxl-node-smoke-test.ts` — 5 / 5, so the package
  still resolves and runs from a sibling workspace package.

Cases in `packages/bxl/tests/boxel/card-source-mutation.ts`, asserting the
planned `intents` verbatim. The forged shape is refused, and `card(…)` at the
same location is pinned beside it, on every route the identity check governs:

| route | forged shape | `card(…)` |
| --- | --- | --- |
| assignment to a `linksTo` | `relationship-value-required` | `relate` |
| a `linksTo` below a contained value | `relationship-value-required` | `relate` |
| `\|=` update | `relationship-value-required` | `relate` |
| a taken `if` branch | `relationship-value-required` | `relate` |
| `append` to a link collection | `relationship-value-required` | `relate` |
| `insert_at` (pinned revision) | `relationship-value-required` | `relate`, index 0 |
| `insert_item_before` / `_after` | `relationship-value-required` | `relate`, index 0 / 1 |
| a slot the Card stores a value in | stored as it reads | `card-reference-destination` |
| a member of a contained value | stored as that member | `relate` at that Field |
| `+=` | operator type error | `relationship-arithmetic` |

Verified by reverting `planner.ts` to the base branch's version: the
whole-value routes above planned a real `relate` intent and committed the edge
before this change. The contained-value case holds either way — the nested path
already recognised markers by identity — so it is a regression guard rather
than a behaviour change.

For the merge rule: a marker in a `*` operand is refused whether or not the
left operand holds that key, and the `+` case is pinned to the `relate` intent
and stored value it produces.

`insert_item_before` / `_after` on a relationship had no coverage in the
package suite at all, so the `[CARD_MARKER]` read on that branch was previously
unexercised.

The four host `bxl-*` integration suites need the dev stack and did not run
locally; CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ey1EtjV1NLXqkbrjpaGicx