### PR TITLE
Cap concurrent realm-server searches and shed the excess with 429

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -11,7 +11,7 @@ import { isTesting } from '@embroider/macros';
 import { tracked } from '@glimmer/tracking';
 
 import { formatDistanceToNow } from 'date-fns';
-import { keepLatestTask, task, didCancel } from 'ember-concurrency';
+import { keepLatestTask, task, didCancel, timeout } from 'ember-concurrency';
 
 import { cloneDeep } from 'lodash-es';
 import { isEqual } from 'lodash-es';
@@ -227,6 +227,25 @@ type DependencyTrackingOptions = {
 };
 type TrackedCreateOptions = CreateOptions & DependencyTrackingOptions;
 type TrackedAddOptions = AddOptions & DependencyTrackingOptions;
+
+// How many times a search the realm-server shed (a 429 from its search
+// admission gate) is retried before the shed surfaces as an error. Three
+// retries at the server's one-second Retry-After span a burst that clears
+// within a few seconds, and give up on a server that stays saturated.
+const MAX_SHED_SEARCH_RETRIES = 3;
+const MAX_SHED_RETRY_AFTER_SECONDS = 5;
+
+// The wait a shed response asks for, in ms, with jitter so the clients a burst
+// shed together don't all come back together. A missing or unparseable header
+// (the HTTP-date form, say) counts as one second.
+function shedRetryDelayMs(retryAfter: string | null): number {
+  let seconds = Number(retryAfter);
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    seconds = 1;
+  }
+  seconds = Math.min(seconds, MAX_SHED_RETRY_AFTER_SECONDS);
+  return seconds * 1000 + Math.random() * 250;
+}
 
 export default class StoreService extends Service implements StoreInterface {
   @service declare private realm: RealmService;
@@ -1656,23 +1675,36 @@ export default class StoreService extends Service implements StoreInterface {
     this.realmServer.assertOwnRealmServer(realmServerURLs);
     let [realmServerURL] = realmServerURLs;
     let searchURL = new URL('_federated-search', realmServerURL);
-    let response = await this.realmServer.maybeAuthedFetchForRealms(
-      searchURL.href,
-      realms,
-      {
-        method: 'QUERY',
-        headers: {
-          Accept: SupportedMimeType.CardJson,
-          'Content-Type': 'application/json',
-          ...duringPrerenderHeaders(),
-          ...consumingRealmHeader(),
-          ...jobIdHeader(),
-          ...jobPriorityHeader(),
-          ...loggingCorrelationIdHeader(),
+    let response: Response;
+    for (let attempt = 0; ; attempt++) {
+      response = await this.realmServer.maybeAuthedFetchForRealms(
+        searchURL.href,
+        realms,
+        {
+          method: 'QUERY',
+          headers: {
+            Accept: SupportedMimeType.CardJson,
+            'Content-Type': 'application/json',
+            ...duringPrerenderHeaders(),
+            ...consumingRealmHeader(),
+            ...jobIdHeader(),
+            ...jobPriorityHeader(),
+            ...loggingCorrelationIdHeader(),
+          },
+          body: JSON.stringify({ ...query, realms }),
         },
-        body: JSON.stringify({ ...query, realms }),
-      },
-    );
+      );
+      // A 429 is the realm-server shedding load: it is running its maximum
+      // number of concurrent searches and turned this one away before doing
+      // any work on it. The condition is transient by construction (slots free
+      // as searches finish), so wait the interval it names and try again,
+      // rather than surfacing a burst as a broken query field. Bounded so a
+      // server that stays saturated still fails, just later.
+      if (response.status !== 429 || attempt >= MAX_SHED_SEARCH_RETRIES) {
+        break;
+      }
+      await timeout(shedRetryDelayMs(response.headers.get('Retry-After')));
+    }
     if (!response.ok) {
       let responseText = await response.text();
       let err = new Error(

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -400,6 +400,68 @@ module(`Integration | search resource`, function (hooks) {
     }
   });
 
+  test(`a search the realm server sheds with 429 is retried after Retry-After`, async function (assert) {
+    let realmServer = getService('realm-server') as RealmServerService;
+    let fetchCalls = 0;
+    let originalMaybeAuthedFetchForRealms =
+      realmServer.maybeAuthedFetchForRealms.bind(realmServer);
+    realmServer.maybeAuthedFetchForRealms = (async (...args) => {
+      fetchCalls++;
+      if (fetchCalls === 1) {
+        // What the realm-server's search admission gate answers when it is
+        // already running its maximum of concurrent searches.
+        return new Response(
+          JSON.stringify({
+            errors: [
+              { status: '429', title: 'Too Many Requests', message: 'shed' },
+            ],
+          }),
+          {
+            status: 429,
+            headers: {
+              'content-type': 'application/vnd.card+json',
+              'retry-after': '0',
+            },
+          },
+        );
+      }
+      return await originalMaybeAuthedFetchForRealms(...args);
+    }) as RealmServerService['maybeAuthedFetchForRealms'];
+
+    try {
+      let query: Query = {
+        filter: {
+          on: {
+            module: testRRI('book'),
+            name: 'Book',
+          },
+          eq: {
+            'author.lastName': 'Jones',
+          },
+        },
+      };
+      let search = getSearchResourceForTest(loaderService, () => ({
+        named: {
+          query,
+          realms: [testRealmURL],
+          isLive: false,
+          isAutoSaved: false,
+          storeService,
+          owner: this.owner,
+        },
+      }));
+      await search.loaded;
+      assert.strictEqual(fetchCalls, 2, 'the shed search was sent again');
+      assert.strictEqual(
+        search.instances[0].id,
+        `${testRealmURL}card-2`,
+        'and the retry produced the result',
+      );
+    } finally {
+      realmServer.maybeAuthedFetchForRealms = originalMaybeAuthedFetchForRealms;
+    }
+  });
+
   test(`can perform a live search for cards`, async function (assert) {
     let query: Query = {
       filter: {

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -21,18 +21,34 @@ import {
   SupportedMimeType,
 } from '@cardstack/runtime-common/router';
 import {
+  DURING_PRERENDER_HEADER,
   PRERENDER_JOB_ID_HEADER,
   sanitizePrerenderJobId,
 } from '../prerender/prerender-constants.ts';
 import {
-  incrementSearchInFlight,
-  decrementSearchInFlight,
+  admitSearch,
+  admitSearchUnconditionally,
+  getSearchAdmissionLimit,
+  getSearchInFlight,
+  getSearchShedCount,
 } from '../search-inflight.ts';
 
 // Matches the realm-server's search endpoints (`/_search`,
-// `/_federated-search`) so the request middleware can track how
-// many searches are in flight for the health sampler.
+// `/_federated-search`) so the request middleware can put searches through
+// the admission gate and report how many are in flight to the health sampler.
 const SEARCH_PATH_PATTERN = /(^|\/)_(federated-)?search$/;
+
+// Only the methods the search endpoints answer with a search are gated. A
+// CORS preflight or a HEAD to the same path does no search work and must
+// neither count against the ceiling nor be shed by it — a shed preflight would
+// fail the QUERY behind it. The method-override middleware runs later, so a
+// QUERY tunnelled as POST is still a POST here.
+const SEARCH_METHODS = new Set(['POST', 'QUERY']);
+
+// What a shed search tells the client to do. One second is the granularity
+// `Retry-After` allows and is long enough for the burst that filled the gate
+// to drain a slot or two.
+const SEARCH_SHED_RETRY_AFTER_SECONDS = 1;
 
 const REQUEST_BODY_STATE = 'requestBody';
 
@@ -185,48 +201,116 @@ export function httpLogging(ctxt: Koa.Context, next: Koa.Next) {
   }
   let startedAt = Date.now();
 
-  // Track in-flight search load for the health sampler across the request's
-  // full lifecycle (queue → parse → SQL → serialize → send), which is the
-  // window during which a saturated event loop would leave it unserviced.
-  let isSearch = SEARCH_PATH_PATTERN.test(ctxt.path);
-  let releasedInFlight = false;
-  let releaseInFlight = () => {
-    if (releasedInFlight) {
-      return;
-    }
-    releasedInFlight = true;
-    decrementSearchInFlight();
-  };
-  if (isSearch) {
-    incrementSearchInFlight();
-  }
-
   logger.info(
     `<-- ${ctxt.method} ${ctxt.req.headers.accept} ${
       fullRequestURL(ctxt).href
     }${jobTag}${corrTag}`,
   );
 
-  let onSettled = () => {
-    if (isSearch) {
-      releaseInFlight();
-    }
+  ctxt.res.on('finish', () => {
     logger.info(
       `--> ${ctxt.method} ${ctxt.req.headers.accept} ${
         fullRequestURL(ctxt).href
       }: ${ctxt.status}${jobTag}${corrTag} dur=${Date.now() - startedAt}ms`,
     );
     logger.debug(JSON.stringify(ctxt.req.headers));
-  };
-  // `finish` fires on a fully-sent response; `close` covers a connection
-  // torn down before that (so the in-flight count can't leak on aborts).
-  ctxt.res.on('finish', onSettled);
-  ctxt.res.on('close', () => {
-    if (isSearch) {
-      releaseInFlight();
-    }
   });
   return next();
+}
+
+// Puts a search through the admission gate (`search-inflight.ts`) and holds
+// its slot for the request's full lifecycle (parse → SQL → serialize → send),
+// which is the window in which it holds heap and in which a saturated event
+// loop would leave it unserviced. Mounted after CORS so that a shed response
+// carries the headers a cross-origin client needs to read its status and
+// Retry-After; before the body is parsed so that a shed costs nothing.
+export async function searchAdmission(ctxt: Koa.Context, next: Koa.Next) {
+  if (
+    !SEARCH_PATH_PATTERN.test(ctxt.path) ||
+    !SEARCH_METHODS.has(ctxt.method)
+  ) {
+    return next();
+  }
+  // Indexing traffic is admitted regardless of the ceiling — see the gate
+  // for why. Both headers are only stamped by the worker-driven prerender
+  // path; a caller that forges one bypasses the wait, the same trust the
+  // cache-only definition lookup already places in them.
+  let isIndexing =
+    sanitizePrerenderJobId(ctxt.get(PRERENDER_JOB_ID_HEADER)) !== null ||
+    ctxt.get(DURING_PRERENDER_HEADER).length > 0;
+  let arrivedAt = Date.now();
+  let closed = false;
+  let release: (() => void) | undefined;
+  let releaseSlot = () => {
+    release?.();
+    release = undefined;
+  };
+  // `finish` fires on a fully-sent response; `close` covers a connection
+  // torn down before that, so a slot can't leak on an abort.
+  ctxt.res.on('finish', releaseSlot);
+  ctxt.res.on('close', () => {
+    closed = true;
+    releaseSlot();
+  });
+
+  if (isIndexing) {
+    release = admitSearchUnconditionally();
+  } else {
+    let admitted = await admitSearch();
+    if (!admitted) {
+      await shedSearch(ctxt, Date.now() - arrivedAt);
+      return;
+    }
+    if (closed) {
+      // The client went away while this request waited for a slot. The
+      // `close` listener ran before there was anything to release, so hand
+      // the slot back here rather than spend it on a response no one reads.
+      admitted();
+      return;
+    }
+    release = admitted;
+  }
+  return next();
+}
+
+// Answer a search the admission gate turned away. Nothing about the request
+// has been read beyond its path, method and headers, so the response is the
+// whole cost of the shed. The body follows the search handlers' own error
+// shape so a client already parsing search errors can read this one.
+async function shedSearch(ctxt: Koa.Context, waitedMs: number) {
+  let limit = getSearchAdmissionLimit();
+  let loggingCorrelationId = sanitizeLoggingCorrelationId(
+    ctxt.get(X_BOXEL_LOGGING_CORRELATION_ID_HEADER),
+  );
+  let corrTag = loggingCorrelationId ? ` corr=${loggingCorrelationId}` : '';
+  getLogger('realm:search-admission').warn(
+    `shed ${ctxt.method} ${fullRequestURL(ctxt).href} after ${waitedMs}ms: ` +
+      `inFlight=${getSearchInFlight()} limit=${limit} shedTotal=${getSearchShedCount()}${corrTag}`,
+  );
+  await setContextResponse(
+    ctxt,
+    new Response(
+      JSON.stringify({
+        errors: [
+          {
+            status: '429',
+            title: 'Too Many Requests',
+            message:
+              `The realm server is already running its maximum of ${limit} ` +
+              `concurrent searches; retry after ${SEARCH_SHED_RETRY_AFTER_SECONDS}s.`,
+          },
+        ],
+      }),
+      {
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: {
+          'content-type': SupportedMimeType.CardJson,
+          'retry-after': String(SEARCH_SHED_RETRY_AFTER_SECONDS),
+        },
+      },
+    ),
+  );
 }
 
 export function ecsMetadata(ctxt: Koa.Context, next: Koa.Next) {

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -36,7 +36,11 @@ import {
 // Matches the realm-server's search endpoints (`/_search`,
 // `/_federated-search`) so the request middleware can put searches through
 // the admission gate and report how many are in flight to the health sampler.
-const SEARCH_PATH_PATTERN = /(^|\/)_(federated-)?search$/;
+// The router matches these routes case-insensitively and with an optional
+// trailing slash, so the pattern accepts every spelling the router does;
+// otherwise a request written one of those ways would run a search without
+// holding a slot.
+const SEARCH_PATH_PATTERN = /(^|\/)_(federated-)?search\/?$/i;
 
 // Only the methods the search endpoints answer with a search are gated. A
 // CORS preflight or a HEAD to the same path does no search work and must

--- a/packages/realm-server/search-inflight.ts
+++ b/packages/realm-server/search-inflight.ts
@@ -1,21 +1,173 @@
-// Count of `_federated-search` requests the realm-server is currently
-// handling. Incremented at the search handler's entry and decremented when
-// it settles. Read by the health sampler so a spike in concurrent searches
-// can be correlated with event-loop lag — the signature of the realm-server
-// process being saturated while prerenders wait on in-render `_search`
-// round-trips. A plain module-level counter (the realm-server is a single
-// process) kept separate from the sampler so the search handler doesn't pull
-// in `perf_hooks`.
-let inFlight = 0;
+import {
+  SEARCH_ADMISSION_WAIT_MS,
+  SERVER_MAX_IN_FLIGHT_SEARCHES,
+} from '@cardstack/runtime-common';
 
-export function incrementSearchInFlight(): void {
-  inFlight++;
+// Admission gate for the realm-server's search endpoints (`/_search`,
+// `/_federated-search`). Every in-flight search holds tens of MB of heap while
+// its result set is assembled, and the process is a single event loop, so the
+// number of searches running at once is what decides whether the heap survives
+// a burst. The gate bounds it: up to `limit` searches run concurrently,
+// arrivals above that wait up to a bounded time for a slot in FIFO order, and a
+// request still waiting when its time is up is shed — the middleware answers
+// 429 + Retry-After without having parsed a body or touched the index, so a
+// shed costs the process almost nothing.
+//
+// Indexing traffic (a request stamped with a prerender job id or the
+// during-prerender header) is admitted unconditionally: shedding an in-render
+// search would write a render error into the index, and that lane is already
+// bounded upstream by the prerender pool's page count. It still counts toward
+// `inFlight`, so interactive arrivals see the true load and wait behind it.
+//
+// One process, one gate: the counters are module state, read by the health
+// sampler (`realm:health`) as `inFlightSearch`.
+export class SearchAdmissionGate {
+  #limit: number;
+  #inFlight = 0;
+  #shed = 0;
+  #waiters: Array<{
+    resolve: (release: (() => void) | null) => void;
+    timer: NodeJS.Timeout;
+  }> = [];
+
+  constructor(limit: number) {
+    this.#limit = normalizeLimit(limit);
+  }
+
+  get limit(): number {
+    return this.#limit;
+  }
+
+  // Searches currently holding a slot, including any admitted past the limit
+  // by `admitUnconditionally`.
+  get inFlight(): number {
+    return this.#inFlight;
+  }
+
+  // Arrivals waiting for a slot.
+  get waiting(): number {
+    return this.#waiters.length;
+  }
+
+  // Arrivals that ran out of wait and were turned away, since construction.
+  get shedCount(): number {
+    return this.#shed;
+  }
+
+  // Take a slot immediately, even past the limit. For traffic that must never
+  // be shed and is bounded elsewhere.
+  admitUnconditionally(): () => void {
+    this.#inFlight++;
+    return this.#makeRelease();
+  }
+
+  // Resolves with a release function once a slot is free, or with `null` if
+  // none freed within `waitMs`. Waiters are served in arrival order as slots
+  // release, so a burst drains fairly rather than by luck of timing.
+  admit(waitMs: number): Promise<(() => void) | null> {
+    if (this.#inFlight < this.#limit) {
+      this.#inFlight++;
+      return Promise.resolve(this.#makeRelease());
+    }
+    if (waitMs <= 0) {
+      this.#shed++;
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve) => {
+      let waiter = {
+        resolve,
+        timer: setTimeout(() => {
+          let idx = this.#waiters.indexOf(waiter);
+          if (idx !== -1) {
+            this.#waiters.splice(idx, 1);
+          }
+          this.#shed++;
+          resolve(null);
+        }, waitMs),
+      };
+      // A waiting request must not keep the process alive on its own.
+      waiter.timer.unref?.();
+      this.#waiters.push(waiter);
+    });
+  }
+
+  // Raising the limit admits queued waiters up to the new value. Lowering it
+  // never preempts a running search; admissions simply pause until the count
+  // falls under the new limit.
+  setLimit(limit: number): void {
+    this.#limit = normalizeLimit(limit);
+    this.#drain();
+  }
+
+  // Each admission gets its own release so a caller that releases twice (a
+  // response that both finished and closed) hands back exactly one slot.
+  #makeRelease(): () => void {
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      if (this.#inFlight > 0) {
+        this.#inFlight--;
+      }
+      this.#drain();
+    };
+  }
+
+  #drain(): void {
+    while (this.#inFlight < this.#limit && this.#waiters.length > 0) {
+      let next = this.#waiters.shift()!;
+      clearTimeout(next.timer);
+      this.#inFlight++;
+      next.resolve(this.#makeRelease());
+    }
+  }
 }
 
-export function decrementSearchInFlight(): void {
-  inFlight = inFlight > 0 ? inFlight - 1 : 0;
+// A limit is a positive integer; anything else would either admit nothing or
+// let `inFlight < limit` compare against NaN and stall every admission.
+function normalizeLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return 1;
+  }
+  let floored = Math.floor(limit);
+  return floored < 1 ? 1 : floored;
+}
+
+let gate = new SearchAdmissionGate(SERVER_MAX_IN_FLIGHT_SEARCHES);
+let admissionWaitMs = SEARCH_ADMISSION_WAIT_MS;
+
+export function admitSearch(): Promise<(() => void) | null> {
+  return gate.admit(admissionWaitMs);
+}
+
+export function admitSearchUnconditionally(): () => void {
+  return gate.admitUnconditionally();
 }
 
 export function getSearchInFlight(): number {
-  return inFlight;
+  return gate.inFlight;
+}
+
+export function getSearchAdmissionLimit(): number {
+  return gate.limit;
+}
+
+export function getSearchShedCount(): number {
+  return gate.shedCount;
+}
+
+// Tests exercise the ceiling with a small limit and a short wait instead of
+// opening thirty connections or waiting out the real second.
+export function setSearchAdmissionForTests(opts: {
+  limit?: number;
+  waitMs?: number;
+}): void {
+  gate = new SearchAdmissionGate(opts.limit ?? SERVER_MAX_IN_FLIGHT_SEARCHES);
+  admissionWaitMs = opts.waitMs ?? SEARCH_ADMISSION_WAIT_MS;
+}
+
+export function resetSearchAdmissionForTests(): void {
+  setSearchAdmissionForTests({});
 }

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -22,6 +22,7 @@ const { ensureDirSync } = fsExtra;
 import {
   httpLogging,
   ecsMetadata,
+  searchAdmission,
   methodOverrideSupport,
   proxyAsset,
 } from './middleware/index.ts';
@@ -865,6 +866,7 @@ export class RealmServer {
           maxAge: 86400,
         }),
       )
+      .use(searchAdmission)
       .use(async (ctx, next) => {
         // Disable browser cache for all data requests to the realm server. The condition captures our supported mime types but not others,
         // such as assets, which we probably want to cache.

--- a/packages/realm-server/tests/search-admission-test.ts
+++ b/packages/realm-server/tests/search-admission-test.ts
@@ -1,0 +1,394 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import Koa from 'koa';
+import Router from '@koa/router';
+import supertest from 'supertest';
+import cors from '@koa/cors';
+import {
+  SearchAdmissionGate,
+  getSearchInFlight,
+  getSearchShedCount,
+  resetSearchAdmissionForTests,
+  setSearchAdmissionForTests,
+} from '../search-inflight.ts';
+import { httpLogging, searchAdmission } from '../middleware/index.ts';
+
+// The admission gate is what stands between a burst of searches and a heap
+// exhausted by their concurrent result sets. These tests pin the contract the
+// middleware relies on — a hard ceiling, FIFO waiting for a bounded time, a
+// cheap shed after it, unconditional admission for indexing traffic — and then
+// the middleware's own behaviour over HTTP: which requests are gated, what a
+// shed response looks like, and that a slot is handed back however the
+// response ends.
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Settles `promise` if it resolves before `ms` elapses; otherwise reports it
+// still pending. Lets a test assert that a waiter is genuinely blocked without
+// depending on the wait timer firing.
+async function settledWithin<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<{ settled: true; value: T } | { settled: false }> {
+  let pending = Symbol('pending');
+  let result = await Promise.race([
+    promise,
+    wait(ms).then(() => pending as unknown as T),
+  ]);
+  return result === (pending as unknown as T)
+    ? { settled: false }
+    : { settled: true, value: result };
+}
+
+module(basename(import.meta.filename), function () {
+  module('SearchAdmissionGate', function () {
+    test('admits up to the limit and makes the next arrival wait', async function (assert) {
+      let gate = new SearchAdmissionGate(2);
+      let first = await gate.admit(1000);
+      let second = await gate.admit(1000);
+      assert.ok(first, 'the first is admitted');
+      assert.ok(second, 'the second is admitted');
+      assert.strictEqual(gate.inFlight, 2);
+
+      let third = gate.admit(1000);
+      assert.strictEqual(gate.waiting, 1, 'the third is queued');
+      let blocked = await settledWithin(third, 30);
+      assert.false(blocked.settled, 'the third has not been admitted');
+
+      first!();
+      let admitted = await settledWithin(third, 200);
+      assert.true(admitted.settled, 'a release admits the waiter');
+      assert.ok(
+        (admitted as { value: unknown }).value,
+        'with a release of its own',
+      );
+      assert.strictEqual(gate.inFlight, 2, 'the slot changed hands');
+      assert.strictEqual(gate.waiting, 0);
+      assert.strictEqual(gate.shedCount, 0);
+    });
+
+    test('a waiter still queued when its wait runs out is shed', async function (assert) {
+      let gate = new SearchAdmissionGate(1);
+      let held = await gate.admit(1000);
+      let result = await gate.admit(20);
+      assert.strictEqual(result, null, 'shed');
+      assert.strictEqual(gate.shedCount, 1);
+      assert.strictEqual(gate.waiting, 0, 'the shed waiter left the queue');
+      assert.strictEqual(gate.inFlight, 1, 'the running search is untouched');
+      held!();
+      assert.strictEqual(gate.inFlight, 0);
+    });
+
+    test('a zero wait sheds immediately when the gate is full', async function (assert) {
+      let gate = new SearchAdmissionGate(1);
+      let held = await gate.admit(0);
+      assert.ok(held, 'admitted while a slot is free');
+      let result = await gate.admit(0);
+      assert.strictEqual(result, null);
+      assert.strictEqual(gate.shedCount, 1);
+      held!();
+    });
+
+    test('waiters are admitted in arrival order', async function (assert) {
+      let gate = new SearchAdmissionGate(1);
+      let held = await gate.admit(1000);
+      let order: string[] = [];
+      let a = gate.admit(1000).then((r) => (order.push('a'), r));
+      let b = gate.admit(1000).then((r) => (order.push('b'), r));
+      let c = gate.admit(1000).then((r) => (order.push('c'), r));
+      assert.strictEqual(gate.waiting, 3);
+
+      held!();
+      let releaseA = await a;
+      assert.deepEqual(order, ['a'], 'one release, one admission');
+      releaseA!();
+      let releaseB = await b;
+      assert.deepEqual(order, ['a', 'b']);
+      releaseB!();
+      let releaseC = await c;
+      assert.deepEqual(order, ['a', 'b', 'c']);
+      releaseC!();
+      assert.strictEqual(gate.inFlight, 0);
+    });
+
+    test('a release hands back exactly one slot however often it is called', async function (assert) {
+      let gate = new SearchAdmissionGate(2);
+      let release = await gate.admit(0);
+      release!();
+      release!();
+      release!();
+      assert.strictEqual(gate.inFlight, 0, 'not negative');
+      let again = await gate.admit(0);
+      assert.ok(again);
+      assert.strictEqual(gate.inFlight, 1);
+    });
+
+    test('unconditional admission exceeds the limit and is counted', async function (assert) {
+      let gate = new SearchAdmissionGate(1);
+      let held = await gate.admit(1000);
+      let indexing = gate.admitUnconditionally();
+      assert.strictEqual(gate.inFlight, 2, 'past the limit');
+
+      let interactive = gate.admit(1000);
+      let blocked = await settledWithin(interactive, 30);
+      assert.false(blocked.settled, 'an interactive arrival waits behind it');
+
+      indexing();
+      let stillBlocked = await settledWithin(interactive, 30);
+      assert.false(
+        stillBlocked.settled,
+        'one release leaves the gate at its limit',
+      );
+      held!();
+      let admitted = await settledWithin(interactive, 200);
+      assert.true(admitted.settled, 'the second release admits the waiter');
+      (admitted as { value: () => void }).value();
+    });
+
+    test('raising the limit admits queued waiters', async function (assert) {
+      let gate = new SearchAdmissionGate(1);
+      let held = await gate.admit(1000);
+      let queued = gate.admit(1000);
+      assert.strictEqual(gate.waiting, 1);
+      gate.setLimit(2);
+      let admitted = await settledWithin(queued, 200);
+      assert.true(admitted.settled);
+      assert.strictEqual(gate.inFlight, 2);
+      held!();
+      (admitted as { value: () => void }).value();
+    });
+
+    test('a non-finite or sub-1 limit is clamped to 1', function (assert) {
+      assert.strictEqual(new SearchAdmissionGate(0).limit, 1);
+      assert.strictEqual(new SearchAdmissionGate(NaN).limit, 1);
+      assert.strictEqual(new SearchAdmissionGate(2.7).limit, 2);
+    });
+  });
+
+  module('searchAdmission middleware', function (hooks) {
+    // Held searches wait on one of these until the test lets them go.
+    let holds: Array<() => void> = [];
+    let onHeld: (() => void) | undefined;
+
+    function buildApp() {
+      let app = new Koa();
+      let router = new Router();
+      let search = async (ctxt: Koa.Context) => {
+        if (ctxt.query.hold) {
+          await new Promise<void>((resolve) => {
+            holds.push(resolve);
+            onHeld?.();
+          });
+        }
+        ctxt.status = 200;
+        ctxt.body = JSON.stringify({ data: [] });
+      };
+      router.post('/_federated-search', search);
+      router.options('/_federated-search', async (ctxt) => {
+        ctxt.status = 204;
+      });
+      router.post('/some-realm/_search', search);
+      router.post('/some-realm/cards', search);
+      // The production order: logging, CORS, then admission, so a shed
+      // response is a CORS-readable one.
+      app.use(httpLogging);
+      app.use(cors({ origin: '*' }));
+      app.use(searchAdmission);
+      app.use(router.routes());
+      return app.callback();
+    }
+
+    // A supertest request is lazy: nothing is sent until it is awaited.
+    // `.then` starts it now, so a test can hold several requests in flight at
+    // once before awaiting any of them.
+    function send(
+      app: ReturnType<typeof buildApp>,
+      path: string,
+      headers: Record<string, string> = {},
+    ) {
+      let request = supertest(app).post(path);
+      for (let [name, value] of Object.entries(headers)) {
+        request = request.set(name, value);
+      }
+      return request.send({}).then((response) => response);
+    }
+
+    // Starts a search that the handler will hold, and resolves once the
+    // handler is actually holding it — so a following request is guaranteed to
+    // find the slot taken.
+    function holdSearch(
+      app: ReturnType<typeof buildApp>,
+      path = '/_federated-search',
+      headers: Record<string, string> = {},
+    ) {
+      let held = new Promise<void>((resolve) => (onHeld = resolve));
+      let response = send(app, `${path}?hold=1`, headers);
+      return { response, held };
+    }
+
+    hooks.beforeEach(function () {
+      holds = [];
+      onHeld = undefined;
+      setSearchAdmissionForTests({ limit: 2, waitMs: 50 });
+    });
+
+    hooks.afterEach(async function () {
+      for (let release of holds) {
+        release();
+      }
+      holds = [];
+      resetSearchAdmissionForTests();
+    });
+
+    async function fillGate(app: ReturnType<typeof buildApp>) {
+      let first = holdSearch(app);
+      await first.held;
+      let second = holdSearch(app);
+      await second.held;
+      assert_inFlight(2);
+      return [first.response, second.response];
+    }
+
+    function assert_inFlight(expected: number) {
+      QUnit.assert.strictEqual(
+        getSearchInFlight(),
+        expected,
+        `inFlight=${expected}`,
+      );
+    }
+
+    test('a search arriving above the ceiling is shed with 429 and Retry-After', async function (assert) {
+      let app = buildApp();
+      let held = await fillGate(app);
+      let shedBefore = getSearchShedCount();
+
+      let shed = await send(app, '/_federated-search');
+      assert.strictEqual(shed.status, 429);
+      assert.strictEqual(shed.headers['retry-after'], '1');
+      assert.strictEqual(
+        shed.headers['access-control-allow-origin'],
+        '*',
+        'a cross-origin client can read the shed',
+      );
+      assert.strictEqual(shed.body.errors[0].status, '429');
+      assert.strictEqual(shed.body.errors[0].title, 'Too Many Requests');
+      assert.strictEqual(getSearchShedCount(), shedBefore + 1);
+      assert_inFlight(2);
+
+      for (let release of holds) {
+        release();
+      }
+      let responses = await Promise.all(held);
+      assert.deepEqual(
+        responses.map((r) => r.status),
+        [200, 200],
+        'the held searches complete normally',
+      );
+      assert_inFlight(0);
+    });
+
+    test('a waiting search is admitted when a slot frees within the wait', async function (assert) {
+      setSearchAdmissionForTests({ limit: 2, waitMs: 2000 });
+      let app = buildApp();
+      let held = await fillGate(app);
+
+      let waiting = send(app, '/_federated-search');
+      // Long enough for the request to reach the gate and queue, well short
+      // of its wait.
+      await wait(50);
+      let stillWaiting = await settledWithin(waiting, 20);
+      assert.false(stillWaiting.settled, 'queued behind the full gate');
+      holds.shift()!();
+      let response = await waiting;
+      assert.strictEqual(response.status, 200, 'served, not shed');
+      assert.strictEqual(getSearchShedCount(), 0);
+
+      holds.shift()!();
+      await Promise.all(held);
+      assert_inFlight(0);
+    });
+
+    test('the per-realm _search endpoint is gated too', async function (assert) {
+      let app = buildApp();
+      let held = await fillGate(app);
+      let shed = await send(app, '/some-realm/_search');
+      assert.strictEqual(shed.status, 429);
+      for (let release of holds) {
+        release();
+      }
+      await Promise.all(held);
+    });
+
+    test('a preflight to a search path is neither counted nor shed', async function (assert) {
+      let app = buildApp();
+      let held = await fillGate(app);
+      let preflight = await supertest(app).options('/_federated-search');
+      assert.strictEqual(preflight.status, 204);
+      assert_inFlight(2);
+      for (let release of holds) {
+        release();
+      }
+      await Promise.all(held);
+    });
+
+    test('a non-search request is not counted', async function (assert) {
+      let app = buildApp();
+      let { response, held } = holdSearch(app, '/some-realm/cards');
+      await held;
+      assert_inFlight(0);
+      holds.shift()!();
+      assert.strictEqual((await response).status, 200);
+    });
+
+    test('indexing traffic is admitted past a full gate', async function (assert) {
+      let app = buildApp();
+      let held = await fillGate(app);
+
+      let byJobId = await send(app, '/_federated-search', {
+        'x-boxel-job-id': '42.7',
+      });
+      assert.strictEqual(byJobId.status, 200, 'a job-stamped search runs');
+
+      let duringPrerender = await send(app, '/_federated-search', {
+        'x-boxel-during-prerender': '1',
+      });
+      assert.strictEqual(
+        duringPrerender.status,
+        200,
+        'an in-render search runs',
+      );
+      assert.strictEqual(getSearchShedCount(), 0);
+      assert_inFlight(2);
+
+      for (let release of holds) {
+        release();
+      }
+      await Promise.all(held);
+      assert_inFlight(0);
+    });
+
+    test('indexing traffic counts toward the load interactive arrivals see', async function (assert) {
+      let app = buildApp();
+      // One interactive hold plus one indexing hold fills a gate of two.
+      let first = holdSearch(app);
+      await first.held;
+      let indexing = holdSearch(app, '/_federated-search', {
+        'x-boxel-job-id': '42.7',
+      });
+      await indexing.held;
+      assert_inFlight(2);
+
+      let shed = await send(app, '/_federated-search');
+      assert.strictEqual(shed.status, 429, 'the gate is full');
+
+      for (let release of holds) {
+        release();
+      }
+      await Promise.all([first.response, indexing.response]);
+      assert_inFlight(0);
+    });
+  });
+});

--- a/packages/realm-server/tests/search-admission-test.ts
+++ b/packages/realm-server/tests/search-admission-test.ts
@@ -322,6 +322,25 @@ module(basename(import.meta.filename), function () {
       await Promise.all(held);
     });
 
+    test('every spelling of a search path the router accepts is gated', async function (assert) {
+      let app = buildApp();
+      let held = await fillGate(app);
+      for (let path of [
+        '/_federated-search/',
+        '/_FEDERATED-SEARCH',
+        '/some-realm/_search/',
+        '/some-realm/_SEARCH',
+      ]) {
+        let shed = await send(app, path);
+        assert.strictEqual(shed.status, 429, `${path} is shed`);
+      }
+      for (let release of holds) {
+        release();
+      }
+      await Promise.all(held);
+      assert_inFlight(0);
+    });
+
     test('a preflight to a search path is neither counted nor shed', async function (assert) {
       let app = buildApp();
       let held = await fillGate(app);

--- a/packages/runtime-common/search-bounds.ts
+++ b/packages/runtime-common/search-bounds.ts
@@ -36,6 +36,14 @@ const log = logger('search-bounds');
 //     surface: the host federates widely and runs its own searches freely.
 //   - Time budget (SEARCH_TIME_BUDGET_MS) — server-side only: a wall-clock
 //     cutoff of the server's own work can't live anywhere else.
+//   - In-flight ceiling (SERVER_MAX_IN_FLIGHT_SEARCHES, with
+//     SEARCH_ADMISSION_WAIT_MS) — server-side only, and unlike the others a
+//     bound on the process rather than on a request: how many searches it runs
+//     at once, across every caller. Each in-flight search holds tens of MB of
+//     heap while its result set is assembled, so this is the number that
+//     decides whether a burst exhausts the heap. Enforced at admission in the
+//     realm-server's request middleware; arrivals above the ceiling wait
+//     briefly for a slot and are then shed with 429 + Retry-After.
 //
 // All bounds are exported consts, overridable via env for ops tuning.
 // ---------------------------------------------------------------------------
@@ -46,6 +54,8 @@ const DEFAULT_SERVER_ABSOLUTE_MAX_PAGE_SIZE = 2_000;
 const DEFAULT_MAX_REALMS_PER_SEARCH_REQUEST = 2;
 const DEFAULT_SEARCH_TIME_BUDGET_MS = 30_000;
 const DEFAULT_SEARCH_CONCURRENCY_CAP = 2;
+const DEFAULT_SERVER_MAX_IN_FLIGHT_SEARCHES = 30;
+const DEFAULT_SEARCH_ADMISSION_WAIT_MS = 1_000;
 
 const MIN_PAGE_SIZE = 1;
 const MIN_REALMS = 1;
@@ -140,6 +150,30 @@ export const SEARCH_CONCURRENCY_CAP = parsePositiveInt(
   env.SEARCH_CONCURRENCY_CAP,
   DEFAULT_SEARCH_CONCURRENCY_CAP,
   MIN_CONCURRENCY,
+);
+
+// Max searches the realm-server process runs at once, across every caller.
+// Enforced server-side at admission (see the realm-server's
+// `search-inflight.ts`). Sized against the per-search heap cost: a few dozen
+// concurrent federated searches exhaust a 2 GB heap, so the default keeps a
+// process on the default heap alive and leaves headroom on a larger one.
+// Indexing traffic is admitted regardless of this ceiling (it is bounded
+// upstream by the prerender pool), so the effective room for interactive
+// searches is whatever indexing isn't using.
+export const SERVER_MAX_IN_FLIGHT_SEARCHES = parsePositiveInt(
+  env.SERVER_MAX_IN_FLIGHT_SEARCHES,
+  DEFAULT_SERVER_MAX_IN_FLIGHT_SEARCHES,
+  MIN_CONCURRENCY,
+);
+
+// How long a search arriving above SERVER_MAX_IN_FLIGHT_SEARCHES waits for a
+// slot before it is shed. Long enough that a burst which clears in well under
+// a second is served rather than rejected; short enough that a saturated
+// process answers quickly instead of parking connections. 0 sheds at once.
+export const SEARCH_ADMISSION_WAIT_MS = parsePositiveInt(
+  env.SEARCH_ADMISSION_WAIT_MS,
+  DEFAULT_SEARCH_ADMISSION_WAIT_MS,
+  0,
 );
 
 // The effective values the enforcement functions read. They default to the


### PR DESCRIPTION
## What this does

The realm-server now bounds how many searches it runs at once. A `POST`/`QUERY` to `/_federated-search` or a realm's `/_search` passes through an admission gate before its body is parsed:

- up to `SERVER_MAX_IN_FLIGHT_SEARCHES` (default 30) searches run concurrently;
- an arrival above that waits up to `SEARCH_ADMISSION_WAIT_MS` (default 1000) for a slot, served in arrival order;
- a request still waiting when its time is up is shed with `429 Too Many Requests`, `Retry-After: 1`, and a JSON:API-shaped error body — having cost the process nothing beyond reading its headers.

Indexing traffic (a request carrying a prerender job id or the during-prerender header) is admitted unconditionally. Shedding an in-render search would write a render error into the index, and that lane is already bounded upstream by the prerender pool's page count. It still counts toward the in-flight total, so interactive arrivals wait behind it and see the true load.

The host's search fetch treats a 429 from this gate as transient: it waits the `Retry-After` interval (with jitter, capped at 5 s) and retries up to three times before surfacing the error, so a burst that clears within a few seconds reads as a short delay rather than a broken query-backed field.

## Why this shape

Each in-flight federated search holds tens of MB of heap while its result set is assembled, and the process is a single event loop. When searches slow down under load, more of them overlap, and a few dozen concurrent searches are enough to exhaust a 2 GB heap. Both production replicas see the same load through round-robin, so they die together and the service is gone for the minutes ECS takes to replace them. The existing search bounds (page size, realms, time budget) cap the cost of one request; none of them caps how many requests run at once, and the client-side `SEARCH_CONCURRENCY_CAP` only throttles card-initiated searches within one browser tab. Concurrency is the quantity that decides whether the heap survives, so that is what the gate bounds.

Admission happens in its own middleware, mounted after CORS and before the body parser: after CORS so a shed response carries the headers a cross-origin client needs to read its status and `Retry-After`; before the body parser so a shed does no work. Only `POST`/`QUERY` are gated, so a CORS preflight to a search path is neither counted nor shed.

The in-flight counter that already fed the `realm:health` sampler line is now the gate's own count, so `inFlightSearch=` in that line is unchanged. Each shed logs one `realm:search-admission` warning with the wait, the in-flight count, the limit and the running shed total.

## Out of scope

- A separate ceiling for the indexing lane. It is bounded by the prerender pool today; a cap of its own can be added to the same gate if that bound proves too loose.
- Reducing the per-search heap cost itself (streaming or incremental assembly of the result document).
- Sizing per environment. The default of 30 fits the default 2 GB heap; an environment with a larger heap ceiling can raise `SERVER_MAX_IN_FLIGHT_SEARCHES` in its task definition.

## Test plan

- `packages/realm-server/tests/search-admission-test.ts`: the gate admits up to the limit, queues waiters in arrival order, sheds after the bounded wait, treats a zero wait as an immediate shed, hands back exactly one slot per release, admits unconditionally past the limit, and admits queued waiters when the limit rises. Over HTTP with the production middleware order (logging, CORS, admission): a shed is a 429 with `Retry-After: 1` and CORS headers; a waiter is served when a slot frees within the wait; the per-realm `_search` path is gated; a preflight and a non-search request are neither counted nor shed; job-id and during-prerender requests run past a full gate and count toward the load others see.
- `packages/host/tests/integration/resources/search-test.ts`: a search answered with 429 and `Retry-After` is sent again and the retry's result is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
