### PR TITLE
Card operation core: types, dispatch, the read executor, and query lowering

### DIFF
--- a/packages/realm-server/tests/card-operations-core-test.ts
+++ b/packages/realm-server/tests/card-operations-core-test.ts
@@ -199,9 +199,12 @@ module(basename(import.meta.filename), function () {
         'a file target reads as its metadata document, not as a card',
       );
 
+      // Against the card+json GET rather than the file-meta endpoint: the
+      // card+json handler is the surface that will delegate here, so it is the
+      // one the read has to reproduce.
       let response = await realmRequest
         .get('/sample.md')
-        .set('Accept', SupportedMimeType.FileMeta);
+        .set('Accept', SupportedMimeType.CardJson);
       assert.strictEqual(
         response.status,
         200,
@@ -210,7 +213,28 @@ module(basename(import.meta.filename), function () {
       assert.deepEqual(
         document,
         JSON.parse(response.text),
-        'the read operation assembles the same document the file-meta GET returns',
+        'the read operation assembles the same document the card+json GET returns for a file',
+      );
+    });
+
+    test('a read of the realm root serves the index card', async function (assert) {
+      let response = await realmRequest
+        .get('/')
+        .set('Accept', SupportedMimeType.CardJson);
+      assert.strictEqual(
+        response.status,
+        200,
+        `HTTP 200 status: ${response.text}`,
+      );
+
+      let result = await runOperation(
+        testRealm.operationCore,
+        request({ kind: 'instance', url: testRealmHref }, 'read'),
+      );
+      assert.deepEqual(
+        documentOf(result),
+        JSON.parse(response.text),
+        'the realm root resolves to the index card, as it does over HTTP',
       );
     });
 
@@ -342,6 +366,77 @@ module(basename(import.meta.filename), function () {
       assert.ok(
         error.detail.includes('status'),
         `the refusal names the missing param: ${error.detail}`,
+      );
+    });
+
+    test('a card marker resolves to the identity it wraps', function (assert) {
+      let definition = savedSearch();
+      definition.query!.filter = {
+        'item.on': personRef,
+        eq: {
+          'item.owner': { $ref: 'card', value: { $ref: 'actor', key: 'id' } },
+        },
+      };
+      let query = lowerQueryOperation(definition, {
+        actor: '@test-actor:localhost',
+        params: { status: 'open' },
+      });
+      assert.deepEqual(query.filter, {
+        'item.on': personRef,
+        eq: { 'item.owner': '@test-actor:localhost' },
+      });
+    });
+
+    test('a keyed actor reference needs the actor card, so it is refused', async function (assert) {
+      let definition = savedSearch();
+      definition.query!.filter = {
+        'item.on': personRef,
+        eq: { 'item.ownerName': { $ref: 'actor', key: 'name' } },
+      };
+      let error = await refusalFrom(async () =>
+        lowerQueryOperation(definition, {
+          actor: '@test-actor:localhost',
+          params: { status: 'open' },
+        }),
+      );
+      assert.strictEqual(error.code, 'invalid-params');
+      assert.ok(
+        error.detail.includes('identity'),
+        `the refusal says why: ${error.detail}`,
+      );
+    });
+
+    test('a marker nothing knows how to resolve is refused', async function (assert) {
+      let definition = savedSearch();
+      definition.query!.filter = {
+        'item.on': personRef,
+        eq: { 'item.title': { $ref: 'nonsense' } as never },
+      };
+      let error = await refusalFrom(async () =>
+        lowerQueryOperation(definition, {
+          actor: '@test-actor:localhost',
+          params: { status: 'open' },
+        }),
+      );
+      assert.strictEqual(error.code, 'invalid-params');
+    });
+
+    test('a param key every object answers to is not a declared param', async function (assert) {
+      let definition = savedSearch();
+      definition.query!.filter = {
+        'item.on': personRef,
+        eq: { 'item.title': { $ref: 'params', key: '__proto__' } },
+      };
+      let error = await refusalFrom(async () =>
+        lowerQueryOperation(definition, {
+          actor: '@test-actor:localhost',
+          params: { status: 'open' },
+        }),
+      );
+      assert.strictEqual(
+        error.code,
+        'invalid-params',
+        'a prototype member is not a param, so nothing of it reaches the query',
       );
     });
 

--- a/packages/realm-server/tests/card-operations-core-test.ts
+++ b/packages/realm-server/tests/card-operations-core-test.ts
@@ -1,0 +1,367 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import type { Test, SuperTest } from 'supertest';
+import type { RealmHttpServer as Server } from '../server.ts';
+import type { DirResult } from 'tmp';
+import type { Realm } from '@cardstack/runtime-common';
+import { SupportedMimeType, baseRealm, rri } from '@cardstack/runtime-common';
+import {
+  isDocumentResult,
+  isHeadResult,
+  isOperationFailure,
+  lowerQueryOperation,
+  runOperation,
+  type OperationCore,
+  type OperationDefinition,
+  type OperationHeadResult,
+  type OperationRequest,
+  type OperationResult,
+  type OperationTarget,
+} from '@cardstack/runtime-common/card-operations';
+import {
+  setupPermissionedRealmCached,
+  closeServer,
+  withRealmPath,
+  type RealmRequest,
+} from './helpers/index.ts';
+import { resetCatalogRealms } from '../handlers/handle-fetch-catalog-realms.ts';
+import type { PgAdapter } from '@cardstack/postgres';
+
+// The operation core, exercised the way the HTTP surfaces will once they route
+// to it: obtain the core from a realm and call `runOperation` directly. Nothing
+// is routed here yet, so these are the only callers.
+
+function request(
+  target: OperationTarget,
+  name: string,
+  params?: Record<string, unknown>,
+): OperationRequest {
+  return {
+    target,
+    name,
+    ...(params ? { params } : {}),
+    actor: '@node-test_realm:localhost',
+    clientRequestId: 'card-operations-core-test',
+  };
+}
+
+// Narrow a result to the shape the mode under test promises, raising rather
+// than letting a wrong shape read as a passing assertion further down.
+function documentOf(result: OperationResult) {
+  if (!isDocumentResult(result)) {
+    throw new Error(
+      `expected a document result, got ${JSON.stringify(result)}`,
+    );
+  }
+  return result.document;
+}
+
+function headersOf(result: OperationResult): OperationHeadResult {
+  if (!isHeadResult(result)) {
+    throw new Error(`expected a headers result, got ${JSON.stringify(result)}`);
+  }
+  return result;
+}
+
+// The failure a call is expected to produce. Rethrows anything that is not an
+// operation failure so a genuine bug reports itself rather than being read as
+// the refusal under test.
+async function refusalFrom(run: () => Promise<unknown>) {
+  try {
+    await run();
+  } catch (err) {
+    if (isOperationFailure(err)) {
+      return err.error;
+    }
+    throw err;
+  }
+  throw new Error('expected the operation to be refused, but it succeeded');
+}
+
+module(basename(import.meta.filename), function () {
+  module('card operations | the operation core', function (hooks) {
+    let realmURL = new URL('http://127.0.0.1:4444/test/');
+    let testRealmHref = realmURL.href;
+    let testRealm: Realm;
+    let testRealmHttpServer: Server;
+    let realmRequest: RealmRequest;
+
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      testRealmHttpServer: Server;
+      request: SuperTest<Test>;
+      dir: DirResult;
+      dbAdapter: PgAdapter;
+    }) {
+      testRealm = args.testRealm;
+      testRealmHttpServer = args.testRealmHttpServer;
+      realmRequest = withRealmPath(args.request, realmURL);
+    }
+
+    hooks.afterEach(async function () {
+      await closeServer(testRealmHttpServer);
+      resetCatalogRealms();
+    });
+
+    setupPermissionedRealmCached(hooks, {
+      fixture: 'realistic',
+      realmURL,
+      permissions: {
+        '*': ['read'],
+        '@node-test_realm:localhost': ['read', 'realm-owner'],
+      },
+      onRealmSetup,
+    });
+
+    test('a read returns the document the card+json GET serves', async function (assert) {
+      let response = await realmRequest
+        .get('/person-1')
+        .set('Accept', SupportedMimeType.CardJson);
+      assert.strictEqual(
+        response.status,
+        200,
+        `HTTP 200 status: ${response.text}`,
+      );
+
+      let result = await runOperation(
+        testRealm.operationCore,
+        request({ kind: 'instance', url: `${testRealmHref}person-1` }, 'read'),
+      );
+      assert.deepEqual(
+        documentOf(result),
+        JSON.parse(response.text),
+        'the read operation assembles the same document the GET returns',
+      );
+    });
+
+    test('a headers-only read peeks the index row and never assembles a document', async function (assert) {
+      let core = testRealm.operationCore;
+      let cardDocumentCalls = 0;
+      let instanceCalls = 0;
+      let spied: OperationCore = {
+        ...core,
+        indexQueryEngine: {
+          cardDocument: (...args) => {
+            cardDocumentCalls++;
+            return core.indexQueryEngine.cardDocument(...args);
+          },
+          instance: (...args) => {
+            instanceCalls++;
+            return core.indexQueryEngine.instance(...args);
+          },
+          file: (...args) => core.indexQueryEngine.file(...args),
+        },
+      };
+
+      let result = await runOperation(
+        spied,
+        request({ kind: 'instance', url: `${testRealmHref}person-1` }, 'read'),
+        { headersOnly: true },
+      );
+      assert.strictEqual(
+        cardDocumentCalls,
+        0,
+        'the headers-only mode never reaches cardDocument',
+      );
+      assert.strictEqual(
+        instanceCalls,
+        1,
+        'dispatch and the executor share one read of the index row',
+      );
+      let headers = headersOf(result);
+      assert.strictEqual(
+        typeof headers.generation,
+        'number',
+        'the index-data generation is reported',
+      );
+      assert.notEqual(
+        headers.indexedAt,
+        null,
+        'the validator base is reported',
+      );
+      assert.notEqual(
+        headers.lastModified,
+        null,
+        'the modification time is reported',
+      );
+    });
+
+    test('a read of a file answers with its file-meta document', async function (assert) {
+      let result = await runOperation(
+        testRealm.operationCore,
+        request({ kind: 'instance', url: `${testRealmHref}sample.md` }, 'read'),
+      );
+      let document = documentOf(result);
+      assert.strictEqual(
+        document.data.type,
+        'file-meta',
+        'a file target reads as its metadata document, not as a card',
+      );
+
+      let response = await realmRequest
+        .get('/sample.md')
+        .set('Accept', SupportedMimeType.FileMeta);
+      assert.strictEqual(
+        response.status,
+        200,
+        `HTTP 200 status: ${response.text}`,
+      );
+      assert.deepEqual(
+        document,
+        JSON.parse(response.text),
+        'the read operation assembles the same document the file-meta GET returns',
+      );
+    });
+
+    test('a name that is neither declared nor a base operation is refused', async function (assert) {
+      let error = await refusalFrom(() =>
+        runOperation(
+          testRealm.operationCore,
+          request(
+            { kind: 'instance', url: `${testRealmHref}person-1` },
+            'addComment',
+          ),
+        ),
+      );
+      assert.strictEqual(error.code, 'unknown-operation');
+      assert.strictEqual(error.status, 404);
+      assert.ok(
+        error.detail.includes('addComment'),
+        `the refusal names the operation: ${error.detail}`,
+      );
+    });
+
+    test('a base operation a file does not carry is refused', async function (assert) {
+      let error = await refusalFrom(() =>
+        runOperation(
+          testRealm.operationCore,
+          request(
+            { kind: 'instance', url: `${testRealmHref}sample.md` },
+            'transform',
+          ),
+        ),
+      );
+      assert.strictEqual(error.code, 'operation-not-allowed');
+      assert.strictEqual(error.status, 405);
+      assert.ok(
+        error.detail.includes('read'),
+        `the refusal names what a file does carry: ${error.detail}`,
+      );
+    });
+
+    test('a target with no index row and no source is not found', async function (assert) {
+      let error = await refusalFrom(() =>
+        runOperation(
+          testRealm.operationCore,
+          request(
+            { kind: 'instance', url: `${testRealmHref}does-not-exist` },
+            'read',
+          ),
+        ),
+      );
+      assert.strictEqual(error.code, 'target-not-found');
+      assert.strictEqual(error.status, 404);
+    });
+
+    test('a target outside the realm is not this core to serve', async function (assert) {
+      let error = await refusalFrom(() =>
+        runOperation(
+          testRealm.operationCore,
+          request(
+            { kind: 'instance', url: 'http://127.0.0.1:4444/other/person-1' },
+            'read',
+          ),
+        ),
+      );
+      assert.strictEqual(error.code, 'target-not-found');
+    });
+  });
+
+  // Invocation-time query lowering is a pure function over a stored template,
+  // so it needs no realm: the whole input is the definition plus what the
+  // invocation supplies.
+  module('card operations | lowering a declared query', function () {
+    let personRef = {
+      module: rri('http://127.0.0.1:4444/test/person'),
+      name: 'Person',
+    };
+    let stringRef = { module: rri(`${baseRealm.url}string`), name: 'default' };
+
+    function savedSearch(): OperationDefinition {
+      return {
+        base: 'query',
+        deterministic: true,
+        params: { status: { kind: 'field', codeRef: stringRef } },
+        query: {
+          filter: {
+            'item.on': personRef,
+            every: [
+              { eq: { 'item.owner.id': { $ref: 'actor', key: 'id' } } },
+              { eq: { 'item.status': { $ref: 'params', key: 'status' } } },
+            ],
+          },
+        },
+      } satisfies OperationDefinition;
+    }
+
+    test('markers resolve to the values the invocation supplies', function (assert) {
+      let query = lowerQueryOperation(savedSearch(), {
+        actor: '@test-actor:localhost',
+        params: { status: 'open' },
+        realms: ['http://127.0.0.1:4444/test/'],
+      });
+      assert.deepEqual(query, {
+        filter: {
+          'item.on': personRef,
+          every: [
+            { eq: { 'item.owner.id': '@test-actor:localhost' } },
+            { eq: { 'item.status': 'open' } },
+          ],
+        },
+        realms: ['http://127.0.0.1:4444/test/'],
+      });
+    });
+
+    test('an authored realm scope is kept over the invocation default', function (assert) {
+      let definition = savedSearch();
+      definition.query!.realms = ['http://127.0.0.1:4444/authored/'];
+      let query = lowerQueryOperation(definition, {
+        actor: '@test-actor:localhost',
+        params: { status: 'open' },
+        realms: ['http://127.0.0.1:4444/test/'],
+      });
+      assert.deepEqual(query.realms, ['http://127.0.0.1:4444/authored/']);
+    });
+
+    test('a param the invocation did not supply is refused', async function (assert) {
+      let error = await refusalFrom(async () =>
+        lowerQueryOperation(savedSearch(), { actor: '@test-actor:localhost' }),
+      );
+      assert.strictEqual(error.code, 'invalid-params');
+      assert.ok(
+        error.detail.includes('status'),
+        `the refusal names the missing param: ${error.detail}`,
+      );
+    });
+
+    test('instance() has no target to resolve against in a query', async function (assert) {
+      let definition = savedSearch();
+      definition.query!.filter = {
+        'item.on': personRef,
+        eq: { 'item.title': { $ref: 'instance', key: 'title' } },
+      };
+      let error = await refusalFrom(async () =>
+        lowerQueryOperation(definition, {
+          actor: '@test-actor:localhost',
+          params: { status: 'open' },
+        }),
+      );
+      assert.strictEqual(error.code, 'invalid-params');
+      assert.ok(
+        error.detail.includes('instance()'),
+        `the refusal names the marker: ${error.detail}`,
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/card-operations-core-test.ts
+++ b/packages/realm-server/tests/card-operations-core-test.ts
@@ -440,6 +440,43 @@ module(basename(import.meta.filename), function () {
       );
     });
 
+    test('a substituted value the realm would refuse is refused here', async function (assert) {
+      // Lowering checks a declared query against the realm's grammar only
+      // where it can: a template still holding a marker stands in for a value
+      // the realm types concretely, so the check is deferred to the invocation
+      // that supplies it. This is that check.
+      let definition = savedSearch();
+      definition.query!.filter = {
+        'item.on': personRef,
+        matches: { $ref: 'params', key: 'status' },
+      };
+      let error = await refusalFrom(async () =>
+        lowerQueryOperation(definition, {
+          actor: '@test-actor:localhost',
+          params: { status: 42 },
+        }),
+      );
+      assert.strictEqual(error.code, 'invalid-params');
+      assert.ok(
+        error.detail.includes('matches must be a string'),
+        `the refusal carries the grammar's own reason: ${error.detail}`,
+      );
+
+      // A list operand is the other half of the same rule.
+      let listy = savedSearch();
+      listy.query!.filter = {
+        'item.on': personRef,
+        in: { 'item.status': { $ref: 'params', key: 'status' } },
+      };
+      let listError = await refusalFrom(async () =>
+        lowerQueryOperation(listy, {
+          actor: '@test-actor:localhost',
+          params: { status: 'open' },
+        }),
+      );
+      assert.strictEqual(listError.code, 'invalid-params');
+    });
+
     test('instance() has no target to resolve against in a query', async function (assert) {
       let definition = savedSearch();
       definition.query!.filter = {

--- a/packages/realm-server/tests/card-operations-dispatch-test.ts
+++ b/packages/realm-server/tests/card-operations-dispatch-test.ts
@@ -90,6 +90,18 @@ module(basename(import.meta.filename), function () {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });
 
+    test('both read modes answer for a file whose extension is not registered', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a malformed type realm is a refusal, not a raw throw', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a read refuses any clause it does not carry out', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
     test('the row peek is memoized for one invocation and no longer', async function (assert) {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });

--- a/packages/realm-server/tests/card-operations-dispatch-test.ts
+++ b/packages/realm-server/tests/card-operations-dispatch-test.ts
@@ -42,10 +42,6 @@ module(basename(import.meta.filename), function () {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });
 
-    test('a target outside the realm is refused before anything is read', async function (assert) {
-      await runSharedTest(cardOperationsDispatchTests, assert, {});
-    });
-
     test('a type nobody can resolve is refused as a missing target', async function (assert) {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });
@@ -82,7 +78,15 @@ module(basename(import.meta.filename), function () {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });
 
-    test('a card named by its source spelling is a card, not a file', async function (assert) {
+    test('a card source spelling names the source, not the card', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a file def declaration is resolved the same as a card def one', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a foreign target is refused without reading the index', async function (assert) {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });
 

--- a/packages/realm-server/tests/card-operations-dispatch-test.ts
+++ b/packages/realm-server/tests/card-operations-dispatch-test.ts
@@ -1,0 +1,61 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { runSharedTest } from '@cardstack/runtime-common/helpers';
+import cardOperationsDispatchTests from '@cardstack/runtime-common/tests/card-operations-dispatch-test';
+
+module(basename(import.meta.filename), function () {
+  module('card operations dispatch', function () {
+    test('a base operation with no declaration resolves to its built-in behavior', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a declaration wins over the built-in of the same name', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a name that is neither declared nor a base operation is refused', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a def type that does not carry the behavior refuses it', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a declaration lowering flagged invalid reports its findings', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a read serves the indexed document with its generation joined on', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a headers-only read shares dispatch read of the index row', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('an errored index row carries its own status through', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a read tells a missing card from one still being indexed', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a target outside the realm is refused before anything is read', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a type nobody can resolve is refused as a missing target', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a card whose type entry is unreadable still reads', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('the row peek is memoized for one invocation and no longer', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+  });
+});

--- a/packages/realm-server/tests/card-operations-dispatch-test.ts
+++ b/packages/realm-server/tests/card-operations-dispatch-test.ts
@@ -78,6 +78,14 @@ module(basename(import.meta.filename), function () {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });
 
+    test('a declared operation resolves the same however the target is spelled', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a card named by its source spelling is a card, not a file', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
     test('the row peek is memoized for one invocation and no longer', async function (assert) {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });

--- a/packages/realm-server/tests/card-operations-dispatch-test.ts
+++ b/packages/realm-server/tests/card-operations-dispatch-test.ts
@@ -54,6 +54,30 @@ module(basename(import.meta.filename), function () {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });
 
+    test('a target is canonicalized before anything is read', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a declared read the executor cannot carry out is refused', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a payload missing a declared param is refused before any behavior runs', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a name every object answers to is unknown, not a dispatchable operation', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a headers-only read of a file answers from the file row', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
+    test('a read needs an instance to read', async function (assert) {
+      await runSharedTest(cardOperationsDispatchTests, assert, {});
+    });
+
     test('the row peek is memoized for one invocation and no longer', async function (assert) {
       await runSharedTest(cardOperationsDispatchTests, assert, {});
     });

--- a/packages/runtime-common/card-operations/dispatch.ts
+++ b/packages/runtime-common/card-operations/dispatch.ts
@@ -1,0 +1,442 @@
+import { RealmPaths, type LocalPath } from '../paths.ts';
+import { urlNamesFile } from '../file-def-code-ref.ts';
+import { readOperation } from './read.ts';
+import {
+  OperationFailure,
+  type BaseOperation,
+  type OperationDefinition,
+  type OperationResult,
+  type OperationRequest,
+  type OperationTarget,
+} from './types.ts';
+import type { CodeRef, ResolvedCodeRef } from '../code-ref.ts';
+import type { Definition } from '../definitions.ts';
+import type { SingleFileMetaDocument } from '../document-types.ts';
+import type { LooseCardResource, FileMetaResource } from '../resource-types.ts';
+import type { InstanceOrError, IndexedFile } from '../index-query-engine.ts';
+import type { SearchResult } from '../realm-index-query-engine.ts';
+
+// ============================================================================
+// Running an operation.
+//
+// Dispatch answers one question — "given a target and a name, which built-in
+// behavior is this, and is the target allowed to carry it out?" — and then
+// hands the request to that behavior's executor. Everything it consults is
+// data: the target's stored JSON names its type, the type's definition-cache
+// entry carries the lowered operation, and the executor works from the search
+// index. No card JavaScript is loaded anywhere on this path, which is the
+// property the whole design exists to hold: card modules are author-written
+// and the realm is a trusted context.
+// ============================================================================
+
+// The realm's collaborators, narrowed to what an operation actually uses. The
+// core is handed these rather than a `Realm` so it stays testable in isolation
+// and, more importantly, so it cannot reach the realm's fetch layer: a
+// `VirtualNetwork` resolves author-controlled identifiers, and none of that
+// belongs behind an operation. Where a behavior does need a resolution the
+// realm owns, the realm supplies it as a plain function below.
+export interface OperationCore {
+  // The realm every target of this core belongs to. Local paths are derived
+  // from it, so a target outside it is not this core's to serve.
+  realmURL: string;
+  definitionLookup: OperationDefinitionLookup;
+  indexQueryEngine: OperationIndexQueryEngine;
+  // The target's source file as stored on disk, by local path. The index is
+  // what a read serves, so this is how a behavior distinguishes "no such card"
+  // from "the write landed and the index row is still coming".
+  readSource(localPath: LocalPath): Promise<string | undefined>;
+  // Whether the realm's ignore rules exclude this URL. An ignored path is
+  // never visited, so no amount of waiting produces an index row for it.
+  isIgnored(url: URL): Promise<boolean>;
+  // The file-meta document for a path that holds bytes rather than a card,
+  // preferring the indexed row and falling back to the file on disk — a file's
+  // read is its metadata surface, so it answers with everything the row
+  // carries. Undefined when the path is not a servable file, including when a
+  // sibling `.json` makes it a card's source rather than a file.
+  fileMetaDocument(
+    localPath: LocalPath,
+  ): Promise<SingleFileMetaDocument | undefined>;
+  // A code ref with its module absolutized against `relativeTo`. The realm
+  // owns identifier resolution, so it hands the resolved ref down rather than
+  // letting an operation resolve one itself.
+  resolveCodeRef(
+    codeRef: CodeRef,
+    relativeTo: URL,
+  ): ResolvedCodeRef | undefined;
+  // Rewrite a document's instance ids into canonical prefix form, in place.
+  // The mapping lives in the realm's fetch layer, so this arrives as a bound
+  // function for the same reason `resolveCodeRef` does.
+  unresolveInstanceIds(doc: {
+    data: LooseCardResource | FileMetaResource;
+    included?: (LooseCardResource | FileMetaResource)[];
+  }): void;
+  fetch: typeof globalThis.fetch;
+}
+
+// `CachingDefinitionLookup`, narrowed to the one read an operation makes.
+export interface OperationDefinitionLookup {
+  lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition | undefined>;
+}
+
+// `RealmIndexQueryEngine`, narrowed to the reads an operation makes.
+export interface OperationIndexQueryEngine {
+  cardDocument(
+    url: URL,
+    opts?: { loadLinks?: boolean },
+  ): Promise<SearchResult | undefined>;
+  instance(
+    url: URL,
+    opts?: { includeErrors?: true },
+  ): Promise<InstanceOrError | undefined>;
+  file(url: URL): Promise<IndexedFile | undefined>;
+}
+
+export interface RunOperationOptions {
+  // A `read` that needs only the values the card+json response headers are
+  // computed from, and no document. Ignored by every other behavior.
+  headersOnly?: true;
+}
+
+// One request's memo of the index-row peek. Dispatch reads a target's row to
+// learn its type, and a behavior often wants the same row — a headers-only
+// read wants nothing else. Both go through here so one invocation costs one
+// read of a row rather than one per reader, and so every reader sees the same
+// snapshot of it. The memo lives for the invocation and no longer: a core is
+// long-lived and must never hold a card's row across requests.
+export interface OperationScope {
+  peekInstance(url: URL): Promise<InstanceOrError | undefined>;
+}
+
+export function newOperationScope(core: OperationCore): OperationScope {
+  let rows = new Map<string, Promise<InstanceOrError | undefined>>();
+  return {
+    peekInstance(url: URL) {
+      let cached = rows.get(url.href);
+      if (!cached) {
+        // Always with errors: an errored row is still a row, and the readers
+        // that care about the difference check `type` themselves. Asking one
+        // way keeps the memo to a single entry per URL.
+        cached = core.indexQueryEngine.instance(url, { includeErrors: true });
+        rows.set(url.href, cached);
+      }
+      return cached;
+    },
+  };
+}
+
+// The def types, as the operation core distinguishes them. `Definition.type`
+// draws only the card/field line, because that is the line every other
+// consumer of a definition entry cares about — a file def's entry says
+// `field-def`, since `FileDef` descends from `BaseDef` rather than `CardDef`.
+// The distinction that matters here is drawn from the target instead, which is
+// also the more reliable signal: a URL naming a registered file extension is
+// the same test the realm's own read paths use to tell a file from a card.
+type DefKind = 'card-def' | 'file-def' | 'field-def';
+
+// Exhaustive over `BaseOperation` on purpose: a seventh built-in behavior has
+// to say here whether a card carries it, rather than defaulting to "no".
+const CARD_DEF_OPERATIONS: Readonly<Record<BaseOperation, true>> = {
+  read: true,
+  create: true,
+  update: true,
+  delete: true,
+  query: true,
+  transform: true,
+};
+
+const ALLOWED_BASE_OPERATIONS: Readonly<
+  Record<DefKind, Partial<Record<BaseOperation, true>>>
+> = {
+  'card-def': CARD_DEF_OPERATIONS,
+  // A file's metadata is derived from its bytes and read-only: there is no
+  // JSON:API mutation surface for anything else to reach.
+  'file-def': { read: true },
+  // A field's instances have no URL, so nothing is invocable on one. Field
+  // data is reached through the operations of the card that contains it.
+  'field-def': {},
+};
+
+function isBaseOperation(name: string): name is BaseOperation {
+  return Object.prototype.hasOwnProperty.call(CARD_DEF_OPERATIONS, name);
+}
+
+// Which built-in behavior `name` means for `target`, as the definition the
+// executor works from.
+//
+// A declaration wins over the built-in of the same name — that is how an
+// author specializes `read` or rebinds `delete` onto `transform` — so the
+// type's entry is consulted whichever name arrived. A type whose entry cannot
+// be read is not fatal for a base name against an instance target: the card
+// is in the index, the built-in behavior does not consult its definition, and
+// refusing here would make a broken module's cards unreadable.
+export async function resolveOperation(
+  core: OperationCore,
+  target: OperationTarget,
+  name: string,
+  scope: OperationScope = newOperationScope(core),
+): Promise<OperationDefinition> {
+  let definition = await definitionFor(core, target, scope);
+  if (target.kind === 'type' && !definition) {
+    // Nothing else can be said about a type nobody can resolve: whether it
+    // carries the operation is a question about a definition that is not
+    // there.
+    throw new OperationFailure({
+      status: 404,
+      code: 'target-not-found',
+      title: 'Unknown type',
+      detail: `no definition for ${JSON.stringify(target.codeRef)} in realm ${target.realm}`,
+    });
+  }
+  let kind = defKindFor(target, definition);
+  let declared = definition?.operations?.[name];
+  if (declared) {
+    if (declared.invalid) {
+      throw new OperationFailure({
+        id: targetId(target),
+        status: 422,
+        code: 'invalid-operation',
+        title: 'Invalid operation',
+        detail:
+          `operation "${name}" is declared but could not be lowered to a ` +
+          `runnable form: ${describeIssues(declared)}`,
+        meta: { issues: declared.issues ?? [] },
+      });
+    }
+    if (!ALLOWED_BASE_OPERATIONS[kind][declared.base]) {
+      throw notAllowed(target, name, kind, declared.base);
+    }
+    return declared;
+  }
+  if (!isBaseOperation(name)) {
+    throw new OperationFailure({
+      id: targetId(target),
+      status: 404,
+      code: 'unknown-operation',
+      title: 'Unknown operation',
+      detail: `there is no operation named "${name}" on ${describeTarget(target)}`,
+    });
+  }
+  if (!ALLOWED_BASE_OPERATIONS[kind][name]) {
+    throw notAllowed(target, name, kind, name);
+  }
+  // The built-in behavior, undeclared. It has no program and no params, and
+  // its result is fixed by the behavior itself, so it is deterministic by
+  // construction.
+  return { base: name, deterministic: true };
+}
+
+export async function runOperation(
+  core: OperationCore,
+  request: OperationRequest,
+  opts: RunOperationOptions = {},
+): Promise<OperationResult> {
+  let scope = newOperationScope(core);
+  let definition = await resolveOperation(
+    core,
+    request.target,
+    request.name,
+    scope,
+  );
+  switch (definition.base) {
+    case 'read':
+      return await readOperation(core, request, definition, opts, scope);
+    case 'query':
+      // A declared query is a saved search, not work the realm carries out
+      // here: an invocation resolves its markers with `lowerQueryOperation`
+      // and runs the result on the search engine, which is the one place a
+      // query is planned and executed.
+      throw new OperationFailure({
+        id: targetId(request.target),
+        status: 500,
+        code: 'internal-error',
+        title: 'Operation not executable here',
+        detail:
+          `operation "${request.name}" is a query; resolve it with ` +
+          `lowerQueryOperation and run it on the search engine`,
+      });
+    case 'create':
+    case 'update':
+    case 'delete':
+    case 'transform':
+      throw new OperationFailure({
+        id: targetId(request.target),
+        status: 500,
+        code: 'internal-error',
+        title: 'Operation not executable here',
+        detail: `no executor for base operation "${definition.base}"`,
+      });
+  }
+}
+
+// One `RealmPaths` per core. It is derived entirely from the realm URL, which
+// does not change over a core's life, so rebuilding it on every operation
+// would be pure waste on the hottest path the realm has.
+const pathsByCore = new WeakMap<OperationCore, RealmPaths>();
+
+export function pathsFor(core: OperationCore): RealmPaths {
+  let paths = pathsByCore.get(core);
+  if (!paths) {
+    paths = new RealmPaths(new URL(core.realmURL));
+    pathsByCore.set(core, paths);
+  }
+  return paths;
+}
+
+// The local path a target addresses within this core's realm. A target outside
+// it is not this core's to serve, and says so as a missing target rather than
+// as an internal failure.
+export function localPathFor(core: OperationCore, url: URL): LocalPath {
+  try {
+    return pathsFor(core).local(url);
+  } catch {
+    throw new OperationFailure({
+      id: url.href,
+      status: 404,
+      code: 'target-not-found',
+      title: 'Not found',
+      detail: `realm ${core.realmURL} does not contain ${url.href}`,
+    });
+  }
+}
+
+export function instanceTargetURL(request: OperationRequest): URL {
+  let { target } = request;
+  if (target.kind !== 'instance') {
+    throw new OperationFailure({
+      status: 400,
+      code: 'invalid-params',
+      title: 'Invalid target',
+      detail: `operation "${request.name}" runs against an existing card, so it needs an instance target`,
+    });
+  }
+  try {
+    return new URL(target.url);
+  } catch {
+    throw new OperationFailure({
+      id: target.url,
+      status: 400,
+      code: 'invalid-params',
+      title: 'Invalid target',
+      detail: `target "${target.url}" is not a URL`,
+    });
+  }
+}
+
+// The type entry a target's operations are declared on. Undefined where it
+// cannot be read — an unresolvable ref, an index row with no `adoptsFrom`, an
+// unreachable module. Callers decide what that means for them.
+async function definitionFor(
+  core: OperationCore,
+  target: OperationTarget,
+  scope: OperationScope,
+): Promise<Definition | undefined> {
+  let codeRef: CodeRef | undefined;
+  let relativeTo: URL;
+  if (target.kind === 'type') {
+    codeRef = target.codeRef;
+    relativeTo = new URL(target.realm);
+  } else {
+    let url = parseTargetURL(target.url);
+    if (!url || urlNamesFile(url)) {
+      // A file's type is derived from its extension and declares no
+      // operations, so there is nothing to look up.
+      return undefined;
+    }
+    relativeTo = url;
+    codeRef = await adoptsFromOf(scope, url);
+  }
+  if (!codeRef) {
+    return undefined;
+  }
+  let resolved = core.resolveCodeRef(codeRef, relativeTo);
+  if (!resolved) {
+    return undefined;
+  }
+  try {
+    return await core.definitionLookup.lookupDefinition(resolved);
+  } catch {
+    return undefined;
+  }
+}
+
+// The type a stored card names, read off the index row rather than the source
+// file: the row is the realm's canonical view and the peek costs no link
+// expansion.
+async function adoptsFromOf(
+  scope: OperationScope,
+  url: URL,
+): Promise<CodeRef | undefined> {
+  let row = await scope.peekInstance(url);
+  if (row?.type !== 'instance') {
+    return undefined;
+  }
+  return row.instance.meta?.adoptsFrom;
+}
+
+function defKindFor(
+  target: OperationTarget,
+  definition: Definition | undefined,
+): DefKind {
+  if (target.kind === 'instance') {
+    // Anything addressable by URL that is not a file is a card. Fields have no
+    // URL, so an instance target can never be one, and a card whose type entry
+    // is unreadable is still a card — which is what keeps a broken module's
+    // cards readable.
+    let url = parseTargetURL(target.url);
+    return url && urlNamesFile(url) ? 'file-def' : 'card-def';
+  }
+  // A type target has nothing but its ref to go on, so an entry that cannot be
+  // read leaves the kind genuinely unknown. That is reported where the ref is
+  // resolved rather than being read as a field def here.
+  return definition!.type;
+}
+
+function parseTargetURL(url: string): URL | undefined {
+  try {
+    return new URL(url);
+  } catch {
+    return undefined;
+  }
+}
+
+function notAllowed(
+  target: OperationTarget,
+  name: string,
+  kind: DefKind,
+  base: BaseOperation,
+): OperationFailure {
+  return new OperationFailure({
+    id: targetId(target),
+    status: 405,
+    code: 'operation-not-allowed',
+    title: 'Operation not allowed',
+    detail:
+      `operation "${name}" is a "${base}", which ${describeTarget(target)} ` +
+      `does not carry: a ${kind} allows ${describeAllowed(kind)}`,
+  });
+}
+
+function describeAllowed(kind: DefKind): string {
+  let allowed = Object.keys(ALLOWED_BASE_OPERATIONS[kind]);
+  return allowed.length > 0 ? allowed.join(', ') : 'no operations';
+}
+
+function describeTarget(target: OperationTarget): string {
+  return target.kind === 'instance'
+    ? target.url
+    : JSON.stringify(target.codeRef);
+}
+
+function targetId(target: OperationTarget): string | undefined {
+  return target.kind === 'instance' ? target.url : undefined;
+}
+
+function describeIssues(definition: OperationDefinition): string {
+  let issues = definition.issues ?? [];
+  if (issues.length === 0) {
+    return 'no findings were recorded';
+  }
+  return issues
+    .map((issue) => `${issue.code} at ${issue.path} — ${issue.message}`)
+    .join('; ');
+}

--- a/packages/runtime-common/card-operations/dispatch.ts
+++ b/packages/runtime-common/card-operations/dispatch.ts
@@ -31,10 +31,15 @@ import type { SearchResult } from '../realm-index-query-engine.ts';
 
 // The realm's collaborators, narrowed to what an operation actually uses. The
 // core is handed these rather than a `Realm` so it stays testable in isolation
-// and, more importantly, so it cannot reach the realm's fetch layer: a
-// `VirtualNetwork` resolves author-controlled identifiers, and none of that
-// belongs behind an operation. Where a behavior does need a resolution the
-// realm owns, the realm supplies it as a plain function below.
+// and, more importantly, so no operation resolves an identifier itself: a
+// `VirtualNetwork` resolves author-controlled ones, and steering a lookup is
+// not something author-written code should be able to do in a trusted context.
+// So the two resolutions a behavior needs arrive already done, as plain
+// functions the realm binds to its own fetch layer.
+//
+// Nothing here is a network capability. A behavior that turns out to need one
+// should add it deliberately, in the narrowest form that behavior needs, and
+// say what it is for — not inherit a general `fetch`.
 export interface OperationCore {
   // The realm every target of this core belongs to. Local paths are derived
   // from it, so a target outside it is not this core's to serve.
@@ -48,11 +53,10 @@ export interface OperationCore {
   // Whether the realm's ignore rules exclude this URL. An ignored path is
   // never visited, so no amount of waiting produces an index row for it.
   isIgnored(url: URL): Promise<boolean>;
-  // The file-meta document for a path that holds bytes rather than a card,
-  // preferring the indexed row and falling back to the file on disk — a file's
-  // read is its metadata surface, so it answers with everything the row
-  // carries. Undefined when the path is not a servable file, including when a
-  // sibling `.json` makes it a card's source rather than a file.
+  // The file-meta document for a path that holds bytes rather than a card, as
+  // the card+json read serves it: derived from the bytes on disk. Undefined
+  // when the path is not a servable file, including when a sibling `.json`
+  // makes it a card's source rather than a file.
   fileMetaDocument(
     localPath: LocalPath,
   ): Promise<SingleFileMetaDocument | undefined>;
@@ -70,7 +74,6 @@ export interface OperationCore {
     data: LooseCardResource | FileMetaResource;
     included?: (LooseCardResource | FileMetaResource)[];
   }): void;
-  fetch: typeof globalThis.fetch;
 }
 
 // `CachingDefinitionLookup`, narrowed to the one read an operation makes.
@@ -82,7 +85,7 @@ export interface OperationDefinitionLookup {
 export interface OperationIndexQueryEngine {
   cardDocument(
     url: URL,
-    opts?: { loadLinks?: boolean },
+    opts?: { loadLinks?: boolean; skipQueryBackedExpansion?: boolean },
   ): Promise<SearchResult | undefined>;
   instance(
     url: URL,
@@ -95,6 +98,11 @@ export interface RunOperationOptions {
   // A `read` that needs only the values the card+json response headers are
   // computed from, and no document. Ignored by every other behavior.
   headersOnly?: true;
+  // Leave a query-backed field unexpanded. A render inside a prerender request
+  // must not recurse back into the search that would resolve one, so a read
+  // serving that request says so here — the same control the card+json GET
+  // applies from `isDuringPrerenderRequest`.
+  skipQueryBackedExpansion?: boolean;
 }
 
 // One request's memo of the index-row peek. Dispatch reads a target's row to
@@ -124,13 +132,25 @@ export function newOperationScope(core: OperationCore): OperationScope {
   };
 }
 
-// The def types, as the operation core distinguishes them. `Definition.type`
-// draws only the card/field line, because that is the line every other
-// consumer of a definition entry cares about — a file def's entry says
-// `field-def`, since `FileDef` descends from `BaseDef` rather than `CardDef`.
-// The distinction that matters here is drawn from the target instead, which is
-// also the more reliable signal: a URL naming a registered file extension is
-// the same test the realm's own read paths use to tell a file from a card.
+// The def types, as the operation core distinguishes them.
+//
+// The file/card line is drawn from the target URL, by the registered-extension
+// test `urlNamesFile` — not from `Definition.type`, which cannot express it: a
+// file def's entry says `field-def`, since `FileDef` descends from `BaseDef`
+// rather than `CardDef`, and dispatching off that would leave a file carrying
+// no operations at all rather than `read`.
+//
+// Reading the extension is a commitment made before the index is consulted,
+// which the card+json GET does not make — it asks for a card document first
+// and falls back to file metadata only when there is none. The two agree
+// because a card id never carries a registered extension, which is the same
+// assumption the index query engine's own file/instance split rests on. A
+// target that broke it would read as a file here and as a card there.
+//
+// A `type` target has only its ref, so its kind comes from the entry, and a
+// file def named that way therefore carries nothing. That is correct rather
+// than a gap: operations belong to cards, and the one operation a file has is
+// `read`, which needs an instance to read.
 type DefKind = 'card-def' | 'file-def' | 'field-def';
 
 // Exhaustive over `BaseOperation` on purpose: a seventh built-in behavior has
@@ -157,7 +177,24 @@ const ALLOWED_BASE_OPERATIONS: Readonly<
 };
 
 function isBaseOperation(name: string): name is BaseOperation {
-  return Object.prototype.hasOwnProperty.call(CARD_DEF_OPERATIONS, name);
+  return own(CARD_DEF_OPERATIONS, name) !== undefined;
+}
+
+// Read a record by a key that arrived over the wire. Every name-keyed lookup
+// on this path goes through here: a plain object answers `toString` and
+// `constructor` with something that is not an operation, and reading one of
+// those as a declaration gets as far as dispatching on a `base` of
+// `"undefined"`. The authoring API builds its own declaration records with a
+// null prototype for this reason, but a lowered one has been through JSON and
+// carries `Object.prototype` again.
+function own<T>(
+  record: Record<string, T> | undefined,
+  key: string,
+): T | undefined {
+  if (!record || !Object.prototype.hasOwnProperty.call(record, key)) {
+    return undefined;
+  }
+  return record[key];
 }
 
 // Which built-in behavior `name` means for `target`, as the definition the
@@ -188,7 +225,7 @@ export async function resolveOperation(
     });
   }
   let kind = defKindFor(target, definition);
-  let declared = definition?.operations?.[name];
+  let declared = own(definition?.operations, name);
   if (declared) {
     if (declared.invalid) {
       throw new OperationFailure({
@@ -202,7 +239,7 @@ export async function resolveOperation(
         meta: { issues: declared.issues ?? [] },
       });
     }
-    if (!ALLOWED_BASE_OPERATIONS[kind][declared.base]) {
+    if (!own(ALLOWED_BASE_OPERATIONS[kind], declared.base)) {
       throw notAllowed(target, name, kind, declared.base);
     }
     return declared;
@@ -216,7 +253,7 @@ export async function resolveOperation(
       detail: `there is no operation named "${name}" on ${describeTarget(target)}`,
     });
   }
-  if (!ALLOWED_BASE_OPERATIONS[kind][name]) {
+  if (!own(ALLOWED_BASE_OPERATIONS[kind], name)) {
     throw notAllowed(target, name, kind, name);
   }
   // The built-in behavior, undeclared. It has no program and no params, and
@@ -237,6 +274,7 @@ export async function runOperation(
     request.name,
     scope,
   );
+  validateParams(request, definition);
   switch (definition.base) {
     case 'read':
       return await readOperation(core, request, definition, opts, scope);
@@ -244,11 +282,13 @@ export async function runOperation(
       // A declared query is a saved search, not work the realm carries out
       // here: an invocation resolves its markers with `lowerQueryOperation`
       // and runs the result on the search engine, which is the one place a
-      // query is planned and executed.
+      // query is planned and executed. Reaching this with a perfectly valid
+      // declaration means the caller used the wrong entry point, so it is
+      // theirs to correct rather than a fault to page someone about.
       throw new OperationFailure({
         id: targetId(request.target),
-        status: 500,
-        code: 'internal-error',
+        status: 400,
+        code: 'wrong-entry-point',
         title: 'Operation not executable here',
         detail:
           `operation "${request.name}" is a query; resolve it with ` +
@@ -260,11 +300,44 @@ export async function runOperation(
     case 'transform':
       throw new OperationFailure({
         id: targetId(request.target),
-        status: 500,
+        status: 501,
         code: 'internal-error',
-        title: 'Operation not executable here',
+        title: 'Operation not implemented',
         detail: `no executor for base operation "${definition.base}"`,
       });
+    default:
+      // Unreachable while `base` holds a base-operation name, which the
+      // allow-table check above already required. Present because falling off
+      // an exhaustive switch returns `undefined`, which is not an
+      // `OperationResult` and which every result guard quietly reports false
+      // for — a wrong answer is worse than a refusal.
+      throw new OperationFailure({
+        id: targetId(request.target),
+        status: 500,
+        code: 'internal-error',
+        title: 'Unknown base operation',
+        detail: `operation "${request.name}" names a base operation the core does not implement`,
+      });
+  }
+}
+
+// The payload has to satisfy the schema the definition declares before any
+// behavior runs on it. A declared param with no value is the caller's mistake,
+// and finding out inside an executor means finding out after work has started.
+function validateParams(
+  request: OperationRequest,
+  definition: OperationDefinition,
+): void {
+  for (let key of Object.keys(definition.params ?? {})) {
+    if (own(request.params, key) === undefined) {
+      throw new OperationFailure({
+        id: targetId(request.target),
+        status: 400,
+        code: 'invalid-params',
+        title: 'Invalid params',
+        detail: `operation "${request.name}" requires a value for params("${key}")`,
+      });
+    }
   }
 }
 

--- a/packages/runtime-common/card-operations/dispatch.ts
+++ b/packages/runtime-common/card-operations/dispatch.ts
@@ -71,7 +71,9 @@ export interface OperationCore {
   // rather than in stored JSON, and the mapping resolves module specifiers, so
   // the realm supplies it bound for the same reason `resolveCodeRef` is. It
   // reads nothing — the answer is a table lookup on the extension, the same one
-  // that stamps `adoptsFrom` on the document a file read serves.
+  // that stamps `adoptsFrom` on the document a file read serves. The type it
+  // names is then looked up in the definition cache like any other, so a file
+  // read does cost a definition lookup even though this function costs none.
   fileDefCodeRef(url: URL): CodeRef;
   // Rewrite a document's instance ids into canonical prefix form, in place.
   // The mapping lives in the realm's fetch layer, so this arrives as a bound
@@ -111,9 +113,9 @@ export interface RunOperationOptions {
   skipQueryBackedExpansion?: boolean;
 }
 
-// One request's memo of the index-row peek. Dispatch reads a target's row to
-// learn its type, and a behavior often wants the same row — a headers-only
-// read wants nothing else. Both go through here so one invocation costs one
+// One request's memo of the index-row peek. Dispatch reads a card's row to
+// learn its type — a file's comes from its extension instead — and a behavior
+// often wants the same row, a headers-only read wanting nothing else. Both go through here so one invocation costs one
 // read of a row rather than one per reader, and so every reader sees the same
 // snapshot of it. The memo lives for the invocation and no longer: a core is
 // long-lived and must never hold a card's row across requests.
@@ -149,11 +151,11 @@ export function newOperationScope(core: OperationCore): OperationScope {
 // Reading the extension is a commitment made before the index is consulted,
 // which the card+json GET does not make — it asks for a card document first
 // and falls back to file metadata only when there is none. The two agree
-// because a card's *id* never carries a registered extension, the same
-// assumption the index query engine's own file/instance split rests on. The
-// one path that does is a card's `.json` source spelling, which is why a
-// target is canonicalized — stripped of that extension — before it reaches
-// here.
+// because a card's *id* never carries a registered extension — ids are minted
+// from a UUID — which is the same assumption the index query engine's own
+// file/instance split rests on. The one path that does carry one is a card's
+// `.json` source spelling, and that is classified as a file deliberately: it
+// names the card's stored bytes rather than the card.
 //
 // A `type` target has only its ref, so its kind comes from the entry, and a
 // file def named that way therefore carries nothing. That is correct rather
@@ -363,9 +365,10 @@ export function pathsFor(core: OperationCore): RealmPaths {
 }
 
 // The target as this realm addresses it. A card can be named with a trailing
-// slash, a query string, a fragment, or by its `.json` source, and the realm
-// root names the realm's index card — none of those are a different card, and
-// every one of them has to resolve to the same thing before anything reads it.
+// slash, a query string or a fragment, and the realm root names the realm's
+// index card — none of those are a different card, and every one of them has to
+// resolve to the same thing before anything reads it. A `.json` path is the
+// exception and is left as written; see below.
 //
 // This runs once, in `runOperation`, and everything downstream sees the result:
 // dispatch resolves the type from it, the row memo is keyed on it, and the
@@ -456,7 +459,19 @@ export function instanceTargetURL(request: OperationRequest): URL {
 // one would be a read taken on a question already settled. A URL that does not
 // parse is left alone — the executor has the better refusal for that.
 function assertInRealm(core: OperationCore, target: OperationTarget): void {
-  if (target.kind !== 'instance') {
+  if (target.kind === 'type') {
+    // A type target names the realm its operation is scoped to. Nothing reads
+    // it here, but it is resolved against later, so an unparseable one is the
+    // caller's mistake rather than something to throw out of a URL constructor
+    // deeper in.
+    if (!parseTargetURL(target.realm)) {
+      throw new OperationFailure({
+        status: 400,
+        code: 'invalid-params',
+        title: 'Invalid target',
+        detail: `target realm "${target.realm}" is not a URL`,
+      });
+    }
     return;
   }
   let url = parseTargetURL(target.url);

--- a/packages/runtime-common/card-operations/dispatch.ts
+++ b/packages/runtime-common/card-operations/dispatch.ts
@@ -143,9 +143,11 @@ export function newOperationScope(core: OperationCore): OperationScope {
 // Reading the extension is a commitment made before the index is consulted,
 // which the card+json GET does not make — it asks for a card document first
 // and falls back to file metadata only when there is none. The two agree
-// because a card id never carries a registered extension, which is the same
-// assumption the index query engine's own file/instance split rests on. A
-// target that broke it would read as a file here and as a card there.
+// because a card's *id* never carries a registered extension, the same
+// assumption the index query engine's own file/instance split rests on. The
+// one path that does is a card's `.json` source spelling, which is why a
+// target is canonicalized — stripped of that extension — before it reaches
+// here.
 //
 // A `type` target has only its ref, so its kind comes from the entry, and a
 // file def named that way therefore carries nothing. That is correct rather
@@ -267,17 +269,15 @@ export async function runOperation(
   request: OperationRequest,
   opts: RunOperationOptions = {},
 ): Promise<OperationResult> {
+  let target = canonicalizeTarget(core, request.target);
+  let canonical: OperationRequest =
+    target === request.target ? request : { ...request, target };
   let scope = newOperationScope(core);
-  let definition = await resolveOperation(
-    core,
-    request.target,
-    request.name,
-    scope,
-  );
-  validateParams(request, definition);
+  let definition = await resolveOperation(core, target, canonical.name, scope);
+  validateParams(canonical, definition);
   switch (definition.base) {
     case 'read':
-      return await readOperation(core, request, definition, opts, scope);
+      return await readOperation(core, canonical, definition, opts, scope);
     case 'query':
       // A declared query is a saved search, not work the realm carries out
       // here: an invocation resolves its markers with `lowerQueryOperation`
@@ -286,7 +286,7 @@ export async function runOperation(
       // declaration means the caller used the wrong entry point, so it is
       // theirs to correct rather than a fault to page someone about.
       throw new OperationFailure({
-        id: targetId(request.target),
+        id: targetId(canonical.target),
         status: 400,
         code: 'wrong-entry-point',
         title: 'Operation not executable here',
@@ -299,7 +299,7 @@ export async function runOperation(
     case 'delete':
     case 'transform':
       throw new OperationFailure({
-        id: targetId(request.target),
+        id: targetId(canonical.target),
         status: 501,
         code: 'internal-error',
         title: 'Operation not implemented',
@@ -312,7 +312,7 @@ export async function runOperation(
       // `OperationResult` and which every result guard quietly reports false
       // for — a wrong answer is worse than a refusal.
       throw new OperationFailure({
-        id: targetId(request.target),
+        id: targetId(canonical.target),
         status: 500,
         code: 'internal-error',
         title: 'Unknown base operation',
@@ -353,6 +353,58 @@ export function pathsFor(core: OperationCore): RealmPaths {
     pathsByCore.set(core, paths);
   }
   return paths;
+}
+
+// The target as this realm addresses it. A card can be named with a trailing
+// slash, a query string, a fragment, or by its `.json` source, and the realm
+// root names the realm's index card — none of those are a different card, and
+// every one of them has to resolve to the same thing before anything reads it.
+//
+// This runs once, in `runOperation`, and everything downstream sees the result:
+// dispatch resolves the type from it, the row memo is keyed on it, and the
+// executor reads it. Canonicalizing in only one of those places is worse than
+// canonicalizing in none, because the two then disagree about which card the
+// request names — the type is resolved for one card and the document assembled
+// for another.
+//
+// Idempotent, and deliberately tolerant: a URL that does not parse, or that
+// belongs to another realm, is returned untouched so the refusal for it comes
+// from the code that has something to say about it.
+export function canonicalizeTarget(
+  core: OperationCore,
+  target: OperationTarget,
+): OperationTarget {
+  if (target.kind !== 'instance') {
+    return target;
+  }
+  let url = parseTargetURL(target.url);
+  if (!url) {
+    return target;
+  }
+  let paths = pathsFor(core);
+  let localPath: LocalPath;
+  try {
+    localPath = paths.local(url);
+  } catch {
+    return target;
+  }
+  if (localPath === '') {
+    localPath = 'index' as LocalPath;
+  }
+  // A card addressed by its source file is the same card. The GET handler
+  // redirects that spelling; a read has no redirect to answer with, so it
+  // resolves to the card instead of looking for a file called `<name>.json`.
+  // The cost is that a genuine `.json` file cannot be named as a read target —
+  // the same blind spot `getCard` has, since its redirect lands on a path that
+  // `nonJsonFileExists` then declines. A file-meta surface delegating here
+  // would have to settle that first.
+  if (localPath.endsWith('.json')) {
+    localPath = (localPath.slice(0, -'.json'.length) || 'index') as LocalPath;
+  }
+  let canonical = paths.fileURL(localPath).href;
+  return canonical === target.url
+    ? target
+    : { kind: 'instance', url: canonical };
 }
 
 // The local path a target addresses within this core's realm. A target outside
@@ -411,8 +463,12 @@ async function definitionFor(
   } else {
     let url = parseTargetURL(target.url);
     if (!url || urlNamesFile(url)) {
-      // A file's type is derived from its extension and declares no
-      // operations, so there is nothing to look up.
+      // A file's type comes from its extension rather than from stored JSON,
+      // so there is no `adoptsFrom` to read without a second index read. A
+      // file therefore reaches only the built-in `read`: a `read` a file def
+      // subclass declares is not consulted. Nothing declares one today, and
+      // resolving one would mean reading the file row for its type before
+      // every file read.
       return undefined;
     }
     relativeTo = url;
@@ -478,6 +534,14 @@ function notAllowed(
   kind: DefKind,
   base: BaseOperation,
 ): OperationFailure {
+  // A type target's kind is inferred from an entry that cannot say `file-def`,
+  // so naming the kind there would report a file def as a field def. The
+  // target's own terms are accurate either way.
+  let because =
+    target.kind === 'instance'
+      ? `a ${kind} allows ${describeAllowed(kind)}`
+      : `a type carries only what its definition declares, and a "${base}" ` +
+        `runs against an instance`;
   return new OperationFailure({
     id: targetId(target),
     status: 405,
@@ -485,12 +549,12 @@ function notAllowed(
     title: 'Operation not allowed',
     detail:
       `operation "${name}" is a "${base}", which ${describeTarget(target)} ` +
-      `does not carry: a ${kind} allows ${describeAllowed(kind)}`,
+      `does not carry: ${because}`,
   });
 }
 
 function describeAllowed(kind: DefKind): string {
-  let allowed = Object.keys(ALLOWED_BASE_OPERATIONS[kind]);
+  let allowed = Object.keys(ALLOWED_BASE_OPERATIONS[kind] ?? {});
   return allowed.length > 0 ? allowed.join(', ') : 'no operations';
 }
 

--- a/packages/runtime-common/card-operations/dispatch.ts
+++ b/packages/runtime-common/card-operations/dispatch.ts
@@ -67,6 +67,12 @@ export interface OperationCore {
     codeRef: CodeRef,
     relativeTo: URL,
   ): ResolvedCodeRef | undefined;
+  // The type of the file at this URL. A file names its type by its extension
+  // rather than in stored JSON, and the mapping resolves module specifiers, so
+  // the realm supplies it bound for the same reason `resolveCodeRef` is. It
+  // reads nothing — the answer is a table lookup on the extension, the same one
+  // that stamps `adoptsFrom` on the document a file read serves.
+  fileDefCodeRef(url: URL): CodeRef;
   // Rewrite a document's instance ids into canonical prefix form, in place.
   // The mapping lives in the realm's fetch layer, so this arrives as a bound
   // function for the same reason `resolveCodeRef` does.
@@ -214,6 +220,7 @@ export async function resolveOperation(
   name: string,
   scope: OperationScope = newOperationScope(core),
 ): Promise<OperationDefinition> {
+  assertInRealm(core, target);
   let definition = await definitionFor(core, target, scope);
   if (target.kind === 'type' && !definition) {
     // Nothing else can be said about a type nobody can resolve: whether it
@@ -391,16 +398,13 @@ export function canonicalizeTarget(
   if (localPath === '') {
     localPath = 'index' as LocalPath;
   }
-  // A card addressed by its source file is the same card. The GET handler
-  // redirects that spelling; a read has no redirect to answer with, so it
-  // resolves to the card instead of looking for a file called `<name>.json`.
-  // The cost is that a genuine `.json` file cannot be named as a read target —
-  // the same blind spot `getCard` has, since its redirect lands on a path that
-  // `nonJsonFileExists` then declines. A file-meta surface delegating here
-  // would have to settle that first.
-  if (localPath.endsWith('.json')) {
-    localPath = (localPath.slice(0, -'.json'.length) || 'index') as LocalPath;
-  }
+  // A `.json` path is deliberately left alone. It names a card's stored source
+  // rather than the card, and the stored bytes of an instance are a different
+  // read from the instance itself — one this core does not serve yet. So the
+  // extension stands and the target routes as a file, which is where that read
+  // will live. Resolving it to the card instead would answer a question nobody
+  // asked, and would be the one spelling where the extension test and the rest
+  // of the core disagreed.
   let canonical = paths.fileURL(localPath).href;
   return canonical === target.url
     ? target
@@ -447,6 +451,20 @@ export function instanceTargetURL(request: OperationRequest): URL {
   }
 }
 
+// A target this realm does not contain is refused here, before anything reads
+// it: a foreign URL is not this core's to answer for, and peeking the index for
+// one would be a read taken on a question already settled. A URL that does not
+// parse is left alone — the executor has the better refusal for that.
+function assertInRealm(core: OperationCore, target: OperationTarget): void {
+  if (target.kind !== 'instance') {
+    return;
+  }
+  let url = parseTargetURL(target.url);
+  if (url) {
+    localPathFor(core, url);
+  }
+}
+
 // The type entry a target's operations are declared on. Undefined where it
 // cannot be read — an unresolvable ref, an index row with no `adoptsFrom`, an
 // unreachable module. Callers decide what that means for them.
@@ -462,17 +480,17 @@ async function definitionFor(
     relativeTo = new URL(target.realm);
   } else {
     let url = parseTargetURL(target.url);
-    if (!url || urlNamesFile(url)) {
-      // A file's type comes from its extension rather than from stored JSON,
-      // so there is no `adoptsFrom` to read without a second index read. A
-      // file therefore reaches only the built-in `read`: a `read` a file def
-      // subclass declares is not consulted. Nothing declares one today, and
-      // resolving one would mean reading the file row for its type before
-      // every file read.
+    if (!url) {
       return undefined;
     }
     relativeTo = url;
-    codeRef = await adoptsFromOf(scope, url);
+    // A file names its type by its extension; a card names its own in the
+    // stored JSON the index holds. Either way the type's entry is what carries
+    // the declarations, so a `read` declared on a file def subclass resolves
+    // the same as one declared on a card.
+    codeRef = urlNamesFile(url)
+      ? core.fileDefCodeRef(url)
+      : await adoptsFromOf(scope, url);
   }
   if (!codeRef) {
     return undefined;

--- a/packages/runtime-common/card-operations/index.ts
+++ b/packages/runtime-common/card-operations/index.ts
@@ -1,11 +1,44 @@
 export { lowerOperationDeclarations } from './lowering.ts';
 export type { LoweringContext } from './lowering.ts';
+export {
+  localPathFor,
+  instanceTargetURL,
+  newOperationScope,
+  resolveOperation,
+  runOperation,
+} from './dispatch.ts';
 export type {
+  OperationCore,
+  OperationDefinitionLookup,
+  OperationIndexQueryEngine,
+  OperationScope,
+  RunOperationOptions,
+} from './dispatch.ts';
+export { readOperation } from './read.ts';
+export { lowerQueryOperation } from './query.ts';
+export type { QueryInvocation } from './query.ts';
+export {
+  OperationFailure,
+  isDocumentResult,
+  isHeadResult,
+  isIdentityResult,
+  isOperationFailure,
+} from './types.ts';
+export type {
+  BaseOperation,
   LowerOperationDeclarationsResult,
   OperationDefinition,
+  OperationDocumentResult,
+  OperationError,
+  OperationErrorCode,
+  OperationHeadResult,
+  OperationIdentityResult,
   OperationLoweringIssue,
   OperationLoweringIssueCode,
   OperationParamDefinition,
   OperationProgram,
+  OperationRequest,
+  OperationResult,
+  OperationTarget,
   OperationTemplate,
 } from './types.ts';

--- a/packages/runtime-common/card-operations/index.ts
+++ b/packages/runtime-common/card-operations/index.ts
@@ -1,9 +1,11 @@
 export { lowerOperationDeclarations } from './lowering.ts';
 export type { LoweringContext } from './lowering.ts';
 export {
+  canonicalizeTarget,
   localPathFor,
   instanceTargetURL,
   newOperationScope,
+  pathsFor,
   resolveOperation,
   runOperation,
 } from './dispatch.ts';

--- a/packages/runtime-common/card-operations/query.ts
+++ b/packages/runtime-common/card-operations/query.ts
@@ -3,7 +3,10 @@ import {
   type OperationDefinition,
   type OperationQueryTemplate,
 } from './types.ts';
-import type { SearchEntryWireQuery } from '../search-entry.ts';
+import {
+  parseSearchEntryQueryFromPayload,
+  type SearchEntryWireQuery,
+} from '../search-entry.ts';
 
 // ============================================================================
 // Resolving a declared query at invocation time.
@@ -57,6 +60,22 @@ export function lowerQueryOperation(
   // alone.
   if (query.realms === undefined && invocation.realms?.length) {
     query.realms = [...invocation.realms];
+  }
+  // Lowering checked the declaration against the realm's grammar only where it
+  // could — a template still holding a marker stands in for a value the realm
+  // types concretely, so that check was deferred to here, where the value is
+  // known. This is where it lands. Without it a param supplying a number to
+  // `matches`, or a scalar where `in` wants a list, produces a query that
+  // fails in the search parser instead of as a refusal naming the payload.
+  try {
+    parseSearchEntryQueryFromPayload(query);
+  } catch (err: any) {
+    throw new OperationFailure({
+      status: 400,
+      code: 'invalid-params',
+      title: 'Invalid params',
+      detail: `the resolved query is not one the realm accepts — ${err?.message ?? String(err)}`,
+    });
   }
   return query;
 }

--- a/packages/runtime-common/card-operations/query.ts
+++ b/packages/runtime-common/card-operations/query.ts
@@ -1,0 +1,152 @@
+import {
+  OperationFailure,
+  type OperationDefinition,
+  type OperationQueryTemplate,
+} from './types.ts';
+import type { SearchEntryWireQuery } from '../search-entry.ts';
+
+// ============================================================================
+// Resolving a declared query at invocation time.
+//
+// Lowering leaves a declared query as an entry-wire query template: the shape
+// the realm's `_search` and `_federated-search` endpoints take, with markers
+// standing where a value is only known when someone invokes the operation.
+// This fills those in and yields a concrete wire query.
+//
+// It is a pure function, and it runs on both sides. The realm never executes a
+// query through the operation core — a query runs on the search engine, the
+// one place a query is planned — and the host resolves the same template
+// against the same rules so a saved search means the same thing wherever it is
+// evaluated.
+// ============================================================================
+
+export interface QueryInvocation {
+  // The invoking user's identity, as `actor()` resolves to. Only the identity
+  // is available: resolving any other member of the actor would mean loading
+  // the actor's card, which a query is not entitled to do.
+  actor: string;
+  // The payload, keyed the way the definition's `params` schema declares it.
+  params?: Record<string, unknown>;
+  // The realms to search when the declaration named none. An authored `realms`
+  // is a deliberate scope and is left alone.
+  realms?: string[];
+}
+
+export function lowerQueryOperation(
+  definition: OperationDefinition,
+  invocation: QueryInvocation,
+): SearchEntryWireQuery {
+  if (definition.base !== 'query' || !definition.query) {
+    throw new OperationFailure({
+      status: 400,
+      code: 'invalid-params',
+      title: 'Not a query operation',
+      detail: 'this operation declares no query to resolve',
+    });
+  }
+  let resolved = resolveMarkers(
+    definition.query,
+    definition,
+    invocation,
+    'query',
+  ) as OperationQueryTemplate;
+  let query = resolved as SearchEntryWireQuery;
+  if (!query.realms && invocation.realms?.length) {
+    query.realms = [...invocation.realms];
+  }
+  return query;
+}
+
+// Walk the template, replacing every marker with the value this invocation
+// supplies and leaving plain data untouched. A marker is a plain object
+// carrying a `$ref`, so the walk recognizes one structurally wherever it
+// sits — a filter operand, a `matches` term, a member of an `in` list.
+function resolveMarkers(
+  node: unknown,
+  definition: OperationDefinition,
+  invocation: QueryInvocation,
+  path: string,
+): unknown {
+  if (Array.isArray(node)) {
+    return node.map((entry, index) =>
+      resolveMarkers(entry, definition, invocation, `${path}[${index}]`),
+    );
+  }
+  if (!isPlainObject(node)) {
+    return node;
+  }
+  if (typeof node.$ref === 'string') {
+    return resolveMarker(node, definition, invocation, path);
+  }
+  return Object.fromEntries(
+    Object.entries(node).map(([key, value]) => [
+      key,
+      resolveMarkers(value, definition, invocation, `${path}.${key}`),
+    ]),
+  );
+}
+
+function resolveMarker(
+  marker: Record<string, unknown>,
+  definition: OperationDefinition,
+  invocation: QueryInvocation,
+  path: string,
+): unknown {
+  switch (marker.$ref) {
+    case 'params': {
+      let key = String(marker.key);
+      if (!definition.params || !(key in definition.params)) {
+        throw invalidParams(
+          path,
+          `references params("${key}"), which this operation does not declare`,
+        );
+      }
+      if (!invocation.params || !(key in invocation.params)) {
+        throw invalidParams(path, `requires a value for params("${key}")`);
+      }
+      return invocation.params[key];
+    }
+    case 'actor':
+      // A query compares against what the index holds, and what it holds for
+      // an actor is the actor's identity. A keyed `actor("name")` would need
+      // the actor's card loaded, so only the identity resolves.
+      if (marker.key !== undefined && marker.key !== 'id') {
+        throw invalidParams(
+          path,
+          `references actor("${String(marker.key)}"); a query can only compare against the actor's identity`,
+        );
+      }
+      return invocation.actor;
+    case 'card':
+      // The explicit "this is a card" spelling. In a query every card-valued
+      // slot is a comparison against a stored identity rather than a write, so
+      // what the marker wraps resolves to that identity and the wrapper adds
+      // nothing around it.
+      return resolveMarkers(marker.value, definition, invocation, path);
+    case 'instance':
+      // A query is rooted in a type, not in one card, so there is no target
+      // whose stored values `instance()` could read.
+      throw invalidParams(
+        path,
+        'references instance(), which a query has no target to resolve against',
+      );
+    default:
+      throw invalidParams(
+        path,
+        `references an unknown marker "${String(marker.$ref)}"`,
+      );
+  }
+}
+
+function invalidParams(path: string, detail: string): OperationFailure {
+  return new OperationFailure({
+    status: 400,
+    code: 'invalid-params',
+    title: 'Invalid params',
+    detail: `${path} ${detail}`,
+  });
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime-common/card-operations/query.ts
+++ b/packages/runtime-common/card-operations/query.ts
@@ -51,7 +51,11 @@ export function lowerQueryOperation(
     'query',
   ) as OperationQueryTemplate;
   let query = resolved as SearchEntryWireQuery;
-  if (!query.realms && invocation.realms?.length) {
+  // An authored `realms` is a deliberate scope and stands, empty included —
+  // `realms: []` says "these and no others", which is not the same as saying
+  // nothing. The invocation's scope fills only the slot a declaration left
+  // alone.
+  if (query.realms === undefined && invocation.realms?.length) {
     query.realms = [...invocation.realms];
   }
   return query;
@@ -94,17 +98,20 @@ function resolveMarker(
 ): unknown {
   switch (marker.$ref) {
     case 'params': {
+      // Own properties only. A key of `__proto__` or `toString` is answered by
+      // every plain object, so an `in` check would pass and substitute
+      // `Object.prototype` — or a native function — into a filter operand.
       let key = String(marker.key);
-      if (!definition.params || !(key in definition.params)) {
+      if (!hasOwn(definition.params, key)) {
         throw invalidParams(
           path,
           `references params("${key}"), which this operation does not declare`,
         );
       }
-      if (!invocation.params || !(key in invocation.params)) {
+      if (!hasOwn(invocation.params, key)) {
         throw invalidParams(path, `requires a value for params("${key}")`);
       }
-      return invocation.params[key];
+      return invocation.params![key];
     }
     case 'actor':
       // A query compares against what the index holds, and what it holds for
@@ -145,6 +152,15 @@ function invalidParams(path: string, detail: string): OperationFailure {
     title: 'Invalid params',
     detail: `${path} ${detail}`,
   });
+}
+
+function hasOwn(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): boolean {
+  return (
+    record !== undefined && Object.prototype.hasOwnProperty.call(record, key)
+  );
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/runtime-common/card-operations/query.ts
+++ b/packages/runtime-common/card-operations/query.ts
@@ -74,7 +74,11 @@ export function lowerQueryOperation(
       status: 400,
       code: 'invalid-params',
       title: 'Invalid params',
-      detail: `the resolved query is not one the realm accepts — ${err?.message ?? String(err)}`,
+      detail:
+        `the query this invocation resolves to is not one the realm ` +
+        `accepts — ${err?.message ?? String(err)}. The fault is in a supplied ` +
+        `value or in the declared query it was substituted into; after ` +
+        `substitution the two are the same query.`,
     });
   }
   return query;

--- a/packages/runtime-common/card-operations/read.ts
+++ b/packages/runtime-common/card-operations/read.ts
@@ -21,6 +21,7 @@ import type {
   RunOperationOptions,
 } from './dispatch.ts';
 import type { LocalPath } from '../paths.ts';
+import type { SingleFileMetaDocument } from '../document-types.ts';
 import type { SearchResultError } from '../realm-index-query-engine.ts';
 
 // ============================================================================
@@ -84,17 +85,18 @@ export async function readOperation(
 }
 
 // A declaration may specialize `read` — reshaping the payload with `input`,
-// projecting the result with `output`, running a `program`. None of that is
-// carried out here, and serving the plain document as though the declaration
-// said nothing hands the caller a well-formed answer to a different question.
-// Refusing says so.
+// projecting the result with `output`, running a `program` — and a declaration
+// rebound onto `read` may carry a clause that belongs to the base it came from.
+// None of it is carried out here, and serving the plain document as though the
+// declaration said nothing hands the caller a well-formed answer to a different
+// question. Refusing says so.
 function refuseUnservedStages(
   request: OperationRequest,
   definition: OperationDefinition,
 ): void {
-  let stages = (['program', 'input', 'output'] as const).filter(
-    (stage) => definition[stage] !== undefined,
-  );
+  let stages = (
+    ['program', 'input', 'output', 'fill', 'of', 'query'] as const
+  ).filter((stage) => definition[stage] !== undefined);
   if (stages.length === 0) {
     return;
   }
@@ -172,15 +174,7 @@ async function readHeaders(
       // Fall back to the bytes on disk the same way the document mode does —
       // a file the realm serves but has not indexed still has a modification
       // time to report.
-      let fileMeta = await fileMetaOrMissing(core, url, localPath);
-      let attributes = fileMeta.data.attributes;
-      return {
-        indexedAt: null,
-        lastModified: numberOrNull(attributes?.lastModified),
-        generation: null,
-        screenshots: null,
-        deps: null,
-      };
+      return headersFromDisk(await fileMetaOrMissing(core, url, localPath));
     }
     return {
       indexedAt: file.indexedAt,
@@ -192,6 +186,15 @@ async function readHeaders(
   }
   let row = await scope.peekInstance(url);
   if (row === undefined) {
+    // A path with no instance row may still hold bytes, and the extension test
+    // does not catch a file whose extension is not a registered one. The
+    // document mode falls back for exactly that case, so this one has to as
+    // well — otherwise the same path answers with a body and refuses its own
+    // headers.
+    let fileMeta = await core.fileMetaDocument(localPath);
+    if (fileMeta) {
+      return headersFromDisk(fileMeta);
+    }
     throw await missingTarget(core, url, localPath);
   }
   if (row.type !== 'instance') {
@@ -217,6 +220,20 @@ async function readHeaders(
     generation: row.generation,
     screenshots: row.screenshots,
     deps: row.deps,
+  };
+}
+
+// What a file's own metadata can say about its headers. There is no index row
+// behind these, so the values a row would carry are absent rather than guessed.
+function headersFromDisk(
+  document: SingleFileMetaDocument,
+): OperationHeadResult {
+  return {
+    indexedAt: null,
+    lastModified: numberOrNull(document.data.attributes?.lastModified),
+    generation: null,
+    screenshots: null,
+    deps: null,
   };
 }
 

--- a/packages/runtime-common/card-operations/read.ts
+++ b/packages/runtime-common/card-operations/read.ts
@@ -2,6 +2,7 @@ import { screenshotsMetaFromManifest } from '../capture-spec.ts';
 import { urlNamesFile } from '../file-def-code-ref.ts';
 import { isSingleCardDocument } from '../document-types.ts';
 import {
+  canonicalizeTarget,
   instanceTargetURL,
   localPathFor,
   newOperationScope,
@@ -37,20 +38,27 @@ import type { SearchResultError } from '../realm-index-query-engine.ts';
 //                answering a HEAD or a conditional GET and would throw the
 //                body away.
 //
-// The document mode's output is held to byte-for-byte agreement with what the
-// card+json GET handler serves, so the handler can delegate to it: the same
-// canonical URL, the same `links.self`, the same prefix-form ids, the same
-// freshly-joined `meta.generation` and `meta.screenshots`, the same disk-read
-// file-meta document for a path that holds bytes, and the same mapping from an
-// errored index row to an HTTP status.
+// The document mode's *body* is held to byte-for-byte agreement with what the
+// card+json GET handler serves: the same canonical URL, the same `links.self`,
+// the same prefix-form ids, the same freshly-joined `meta.generation` and
+// `meta.screenshots`, the same disk-read file-meta document for a path that
+// holds bytes, and the same mapping from an errored index row to an HTTP
+// status.
 //
-// Two things the handler does stay the handler's, and a caller that is not it
-// has to account for them. It drains in-flight incremental indexing before
-// reading, so a read here serves whatever the index currently holds rather
-// than waiting for a write that has landed on disk to be indexed. And it
-// answers the redirects — a `.json` spelling and a path that normalizes to a
-// different one both get a 302 rather than a body, where a read simply serves
-// the card the path resolves to.
+// The body, and not the response around it. Three things stay the handler's,
+// and a caller that is not it has to account for them:
+//
+//   * It drains in-flight incremental indexing before reading, so a read here
+//     serves whatever the index currently holds rather than waiting for a
+//     write that has landed on disk to be indexed.
+//   * It answers the redirects. A `.json` spelling and a path that normalizes
+//     to a different one both get a 302; a read has no redirect to give, so it
+//     serves the card the path resolves to.
+//   * It computes the 200's validator from the assembled document's own
+//     `deps` / `indexedAt` / `screenshots`, which this result does not carry —
+//     only the headers mode reports those. A caller wanting both a body and an
+//     ETag needs them threaded through, or it re-peeks and takes on the
+//     snapshot skew the handler avoids by reading them off the assembly.
 // ============================================================================
 
 export async function readOperation(
@@ -60,8 +68,13 @@ export async function readOperation(
   opts: RunOperationOptions = {},
   scope: OperationScope = newOperationScope(core),
 ): Promise<OperationDocumentResult | OperationHeadResult> {
+  // `runOperation` canonicalized the target already; doing it again is a no-op
+  // and keeps a direct caller of this executor addressing the same card
+  // dispatch would have.
+  let target = canonicalizeTarget(core, request.target);
+  let url = instanceTargetURL({ ...request, target });
   refuseUnservedStages(request, definition);
-  let { url, localPath } = canonicalTarget(core, request);
+  let localPath = localPathFor(core, url);
   if (opts.headersOnly) {
     return await readHeaders(core, url, localPath, scope);
   }
@@ -92,30 +105,6 @@ function refuseUnservedStages(
       `operation "${request.name}" specializes \`read\` with ` +
       `${stages.join(', ')}, which the read executor does not carry out`,
   });
-}
-
-// The path a target actually addresses, and the URL that path resolves back
-// to. Both matter: a target may be spelled with a query string, a fragment, a
-// trailing slash, or as the realm root — none of which name a different card,
-// and all of which would otherwise be carried into the index lookup and onto
-// `links.self`. Deriving the URL from the local path is what the card+json GET
-// does, and it is what makes `<realm>/` resolve to the realm's index card.
-function canonicalTarget(
-  core: OperationCore,
-  request: OperationRequest,
-): { url: URL; localPath: LocalPath } {
-  let localPath = localPathFor(core, instanceTargetURL(request));
-  if (localPath === '') {
-    localPath = 'index' as LocalPath;
-  }
-  // A card addressed by its source file is the same card. The GET handler
-  // redirects that spelling to the canonical one; a read has no redirect to
-  // answer with, so it resolves to the same card instead of looking for a file
-  // called `<name>.json`.
-  if (localPath.endsWith('.json')) {
-    localPath = (localPath.slice(0, -'.json'.length) || 'index') as LocalPath;
-  }
-  return { url: pathsFor(core).fileURL(localPath), localPath };
 }
 
 async function readDocument(
@@ -204,10 +193,12 @@ async function readHeaders(
     throw await missingTarget(core, url, localPath);
   }
   if (row.type !== 'instance') {
-    // The peek carries the error itself but none of the salvage the assembled
-    // document's error result carries alongside it — there is no last-known
-    // -good rendering on a row nobody assembled. The status mapping is what
-    // this mode needs, and that comes from the error alone.
+    // Only the status is wanted here, and that comes from the error alone. The
+    // salvage the assembled document's error result carries — the last known
+    // good rendering, its scoped CSS, the card's title — is reachable from
+    // this same row, so a caller that needs it (a conditional GET falling
+    // through to a body) must assemble the document rather than read it off
+    // this refusal.
     throw errorRowFailure(url, {
       type: 'error',
       error: {

--- a/packages/runtime-common/card-operations/read.ts
+++ b/packages/runtime-common/card-operations/read.ts
@@ -37,38 +37,99 @@ import type { SearchResultError } from '../realm-index-query-engine.ts';
 //                answering a HEAD or a conditional GET and would throw the
 //                body away.
 //
-// The document mode's output is held to byte-for-byte agreement with the GET
-// handler, so the handler can delegate to it: the same `links.self`, the same
-// prefix-form ids, the same freshly-joined `meta.generation` and
-// `meta.screenshots`, and the same mapping from an errored index row to an
-// HTTP status.
+// The document mode's output is held to byte-for-byte agreement with what the
+// card+json GET handler serves, so the handler can delegate to it: the same
+// canonical URL, the same `links.self`, the same prefix-form ids, the same
+// freshly-joined `meta.generation` and `meta.screenshots`, the same disk-read
+// file-meta document for a path that holds bytes, and the same mapping from an
+// errored index row to an HTTP status.
+//
+// Two things the handler does stay the handler's, and a caller that is not it
+// has to account for them. It drains in-flight incremental indexing before
+// reading, so a read here serves whatever the index currently holds rather
+// than waiting for a write that has landed on disk to be indexed. And it
+// answers the redirects — a `.json` spelling and a path that normalizes to a
+// different one both get a 302 rather than a body, where a read simply serves
+// the card the path resolves to.
 // ============================================================================
 
 export async function readOperation(
   core: OperationCore,
   request: OperationRequest,
-  _definition: OperationDefinition,
+  definition: OperationDefinition,
   opts: RunOperationOptions = {},
   scope: OperationScope = newOperationScope(core),
 ): Promise<OperationDocumentResult | OperationHeadResult> {
-  let url = instanceTargetURL(request);
-  let localPath = localPathFor(core, url);
+  refuseUnservedStages(request, definition);
+  let { url, localPath } = canonicalTarget(core, request);
   if (opts.headersOnly) {
     return await readHeaders(core, url, localPath, scope);
   }
-  return await readDocument(core, url, localPath);
+  return await readDocument(core, url, localPath, opts);
+}
+
+// A declaration may specialize `read` — reshaping the payload with `input`,
+// projecting the result with `output`, running a `program`. None of that is
+// carried out here, and serving the plain document as though the declaration
+// said nothing hands the caller a well-formed answer to a different question.
+// Refusing says so.
+function refuseUnservedStages(
+  request: OperationRequest,
+  definition: OperationDefinition,
+): void {
+  let stages = (['program', 'input', 'output'] as const).filter(
+    (stage) => definition[stage] !== undefined,
+  );
+  if (stages.length === 0) {
+    return;
+  }
+  throw new OperationFailure({
+    id: request.target.kind === 'instance' ? request.target.url : undefined,
+    status: 501,
+    code: 'internal-error',
+    title: 'Operation not implemented',
+    detail:
+      `operation "${request.name}" specializes \`read\` with ` +
+      `${stages.join(', ')}, which the read executor does not carry out`,
+  });
+}
+
+// The path a target actually addresses, and the URL that path resolves back
+// to. Both matter: a target may be spelled with a query string, a fragment, a
+// trailing slash, or as the realm root — none of which name a different card,
+// and all of which would otherwise be carried into the index lookup and onto
+// `links.self`. Deriving the URL from the local path is what the card+json GET
+// does, and it is what makes `<realm>/` resolve to the realm's index card.
+function canonicalTarget(
+  core: OperationCore,
+  request: OperationRequest,
+): { url: URL; localPath: LocalPath } {
+  let localPath = localPathFor(core, instanceTargetURL(request));
+  if (localPath === '') {
+    localPath = 'index' as LocalPath;
+  }
+  // A card addressed by its source file is the same card. The GET handler
+  // redirects that spelling to the canonical one; a read has no redirect to
+  // answer with, so it resolves to the same card instead of looking for a file
+  // called `<name>.json`.
+  if (localPath.endsWith('.json')) {
+    localPath = (localPath.slice(0, -'.json'.length) || 'index') as LocalPath;
+  }
+  return { url: pathsFor(core).fileURL(localPath), localPath };
 }
 
 async function readDocument(
   core: OperationCore,
   url: URL,
   localPath: LocalPath,
+  opts: RunOperationOptions,
 ): Promise<OperationDocumentResult> {
   if (urlNamesFile(url)) {
     return { document: await fileMetaOrMissing(core, url, localPath) };
   }
   let result = await core.indexQueryEngine.cardDocument(url, {
     loadLinks: true,
+    skipQueryBackedExpansion: opts.skipQueryBackedExpansion ?? false,
   });
   if (result === undefined) {
     // A path with no instance row may still hold bytes: a file asked for as
@@ -127,13 +188,15 @@ async function readHeaders(
         lastModified: numberOrNull(attributes?.lastModified),
         generation: null,
         screenshots: null,
+        deps: null,
       };
     }
     return {
-      indexedAt: null,
+      indexedAt: file.indexedAt,
       lastModified: file.lastModified,
       generation: file.generation,
       screenshots: file.screenshots,
+      deps: file.deps,
     };
   }
   let row = await scope.peekInstance(url);
@@ -141,6 +204,10 @@ async function readHeaders(
     throw await missingTarget(core, url, localPath);
   }
   if (row.type !== 'instance') {
+    // The peek carries the error itself but none of the salvage the assembled
+    // document's error result carries alongside it — there is no last-known
+    // -good rendering on a row nobody assembled. The status mapping is what
+    // this mode needs, and that comes from the error alone.
     throw errorRowFailure(url, {
       type: 'error',
       error: {
@@ -156,6 +223,7 @@ async function readHeaders(
     lastModified: row.lastModified,
     generation: row.generation,
     screenshots: row.screenshots,
+    deps: row.deps,
   };
 }
 

--- a/packages/runtime-common/card-operations/read.ts
+++ b/packages/runtime-common/card-operations/read.ts
@@ -1,0 +1,263 @@
+import { screenshotsMetaFromManifest } from '../capture-spec.ts';
+import { urlNamesFile } from '../file-def-code-ref.ts';
+import { isSingleCardDocument } from '../document-types.ts';
+import {
+  instanceTargetURL,
+  localPathFor,
+  newOperationScope,
+  pathsFor,
+} from './dispatch.ts';
+import {
+  OperationFailure,
+  type OperationDefinition,
+  type OperationDocumentResult,
+  type OperationHeadResult,
+  type OperationRequest,
+} from './types.ts';
+import type {
+  OperationCore,
+  OperationScope,
+  RunOperationOptions,
+} from './dispatch.ts';
+import type { LocalPath } from '../paths.ts';
+import type { SearchResultError } from '../realm-index-query-engine.ts';
+
+// ============================================================================
+// The `read` executor.
+//
+// A read serves the realm's indexed view of a target: the same JSON:API
+// document the card+json GET returns, assembled from the search index without
+// instantiating the card. Two modes, and the difference between them is the
+// point of having two:
+//
+//   * document — the full body, link expansion included.
+//   * headers  — the four values the card+json response headers are computed
+//                from, via the index-row peek alone. No card document is
+//                assembled and no link is expanded, because the caller is
+//                answering a HEAD or a conditional GET and would throw the
+//                body away.
+//
+// The document mode's output is held to byte-for-byte agreement with the GET
+// handler, so the handler can delegate to it: the same `links.self`, the same
+// prefix-form ids, the same freshly-joined `meta.generation` and
+// `meta.screenshots`, and the same mapping from an errored index row to an
+// HTTP status.
+// ============================================================================
+
+export async function readOperation(
+  core: OperationCore,
+  request: OperationRequest,
+  _definition: OperationDefinition,
+  opts: RunOperationOptions = {},
+  scope: OperationScope = newOperationScope(core),
+): Promise<OperationDocumentResult | OperationHeadResult> {
+  let url = instanceTargetURL(request);
+  let localPath = localPathFor(core, url);
+  if (opts.headersOnly) {
+    return await readHeaders(core, url, localPath, scope);
+  }
+  return await readDocument(core, url, localPath);
+}
+
+async function readDocument(
+  core: OperationCore,
+  url: URL,
+  localPath: LocalPath,
+): Promise<OperationDocumentResult> {
+  if (urlNamesFile(url)) {
+    return { document: await fileMetaOrMissing(core, url, localPath) };
+  }
+  let result = await core.indexQueryEngine.cardDocument(url, {
+    loadLinks: true,
+  });
+  if (result === undefined) {
+    // A path with no instance row may still hold bytes: a file asked for as
+    // card+json answers with its metadata document rather than its content, so
+    // the caller receives JSON it can discriminate on `data.type`.
+    let fileMeta = await core.fileMetaDocument(localPath);
+    if (fileMeta) {
+      return { document: fileMeta };
+    }
+    throw await missingTarget(core, url, localPath);
+  }
+  if (result.type === 'error') {
+    throw errorRowFailure(url, result);
+  }
+  let { doc } = result;
+  doc.data.links = { self: url.href };
+  core.unresolveInstanceIds(doc);
+  // The index-data generation and the declared-screenshot manifest are joined
+  // at serve time onto a fresh `meta` — never a mutation of the cached
+  // pristine doc's own. The generation lets a consumer tell fresh index data
+  // from stale; the manifest is never written back into the index row or the
+  // source file.
+  doc.data.meta = {
+    ...doc.data.meta,
+    generation: result.generation,
+    ...(result.screenshots
+      ? {
+          screenshots: screenshotsMetaFromManifest(result.screenshots, {
+            realmURL: core.realmURL,
+            instanceLocalPath: localPath,
+          }),
+        }
+      : {}),
+  };
+  return { document: doc };
+}
+
+// The peek, and nothing else. `cardDocument` is deliberately not reached here:
+// it expands links, and a caller computing headers pays for a body it discards.
+async function readHeaders(
+  core: OperationCore,
+  url: URL,
+  localPath: LocalPath,
+  scope: OperationScope,
+): Promise<OperationHeadResult> {
+  if (urlNamesFile(url)) {
+    let file = await core.indexQueryEngine.file(url);
+    if (!file) {
+      // Fall back to the bytes on disk the same way the document mode does —
+      // a file the realm serves but has not indexed still has a modification
+      // time to report.
+      let fileMeta = await fileMetaOrMissing(core, url, localPath);
+      let attributes = fileMeta.data.attributes;
+      return {
+        indexedAt: null,
+        lastModified: numberOrNull(attributes?.lastModified),
+        generation: null,
+        screenshots: null,
+      };
+    }
+    return {
+      indexedAt: null,
+      lastModified: file.lastModified,
+      generation: file.generation,
+      screenshots: file.screenshots,
+    };
+  }
+  let row = await scope.peekInstance(url);
+  if (row === undefined) {
+    throw await missingTarget(core, url, localPath);
+  }
+  if (row.type !== 'instance') {
+    throw errorRowFailure(url, {
+      type: 'error',
+      error: {
+        errorDetail: row.error,
+        scopedCssUrls: [],
+        lastKnownGoodHtml: null,
+        cardTitle: null,
+      },
+    });
+  }
+  return {
+    indexedAt: row.indexedAt,
+    lastModified: row.lastModified,
+    generation: row.generation,
+    screenshots: row.screenshots,
+  };
+}
+
+async function fileMetaOrMissing(
+  core: OperationCore,
+  url: URL,
+  localPath: LocalPath,
+) {
+  let document = await core.fileMetaDocument(localPath);
+  if (!document) {
+    throw await missingTarget(core, url, localPath);
+  }
+  return document;
+}
+
+// The index has a row for this card, it just cannot be served cleanly, so the
+// underlying error's own HTTP status carries through when it is a real one —
+// auth, validation, an upstream 5xx — instead of everything flattening to 500.
+//
+// 404 is the one status never mirrored: an existing-but-errored card is not
+// "not found". That code is reserved for a missing index row, so that a 404
+// from a read is an unambiguous "this card no longer exists". A recorded 404
+// (an error whose cause was a missing linked instance, say) therefore falls
+// back to 500, as do non-HTTP failures recorded as status 0 and any
+// out-of-range value.
+function errorRowFailure(
+  url: URL,
+  result: SearchResultError,
+): OperationFailure {
+  let { errorDetail } = result.error;
+  let status =
+    errorDetail.status >= 400 &&
+    errorDetail.status <= 599 &&
+    errorDetail.status !== 404
+      ? errorDetail.status
+      : 500;
+  return new OperationFailure({
+    id: url.href,
+    status,
+    code: 'target-errored',
+    title: errorDetail.title ?? 'Error',
+    detail: `cannot read ${url.href} from index: ${errorDetail.title} - ${errorDetail.message}`,
+    meta: {
+      lastKnownGoodHtml: result.error.lastKnownGoodHtml,
+      cardTitle: result.error.cardTitle,
+      scopedCssUrls: result.error.scopedCssUrls,
+      stack: errorDetail.stack,
+    },
+  });
+}
+
+// No index row, so there is no document to serve. Which absence this is
+// depends on the source file: a write lands on the realm's file system first
+// and is indexed after, so a card whose `.json` is already on disk is one this
+// realm has not caught up with rather than one that does not exist. Saying so
+// lets a caller hold a placeholder until the realm broadcasts the index event
+// for it, instead of concluding the card is gone.
+async function missingTarget(
+  core: OperationCore,
+  url: URL,
+  localPath: LocalPath,
+): Promise<OperationFailure> {
+  let notFound = new OperationFailure({
+    id: url.href,
+    status: 404,
+    code: 'target-not-found',
+    title: 'Not found',
+    detail: `${url.href} does not exist in realm ${core.realmURL}`,
+  });
+  let sourcePath = `${localPath}.json` as LocalPath;
+  // An ignored path is never visited, so no amount of waiting produces an
+  // index row for it.
+  if (await core.isIgnored(pathsFor(core).fileURL(sourcePath))) {
+    return notFound;
+  }
+  let source = await core.readSource(sourcePath);
+  if (source === undefined) {
+    return notFound;
+  }
+  // The promise that a row is coming has to match what the indexer will
+  // actually make one for: a `.json` whose `data` is a single card resource. A
+  // collection document never becomes an instance row, and neither does
+  // anything else — those are genuinely not cards, not cards in waiting.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return notFound;
+  }
+  if (!isSingleCardDocument(parsed)) {
+    return notFound;
+  }
+  return new OperationFailure({
+    id: url.href,
+    status: 404,
+    code: 'target-not-indexed',
+    title: 'Not indexed yet',
+    detail: `${url.href} has not finished indexing`,
+    meta: { awaitingIndex: true },
+  });
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}

--- a/packages/runtime-common/card-operations/read.ts
+++ b/packages/runtime-common/card-operations/read.ts
@@ -51,9 +51,11 @@ import type { SearchResultError } from '../realm-index-query-engine.ts';
 //   * It drains in-flight incremental indexing before reading, so a read here
 //     serves whatever the index currently holds rather than waiting for a
 //     write that has landed on disk to be indexed.
-//   * It answers the redirects. A `.json` spelling and a path that normalizes
-//     to a different one both get a 302; a read has no redirect to give, so it
-//     serves the card the path resolves to.
+//   * It answers the redirects, and for the `.json` spelling it redirects to
+//     the card. A read has no redirect to give, and treats that spelling as
+//     what it literally names — the card's stored source, a file-def target —
+//     so the two diverge there by intent rather than by omission. A path that
+//     merely normalizes to a different one is served, not redirected.
 //   * It computes the 200's validator from the assembled document's own
 //     `deps` / `indexedAt` / `screenshots`, which this result does not carry —
 //     only the headers mode reports those. A caller wanting both a body and an

--- a/packages/runtime-common/card-operations/types.ts
+++ b/packages/runtime-common/card-operations/types.ts
@@ -212,6 +212,12 @@ export type BaseOperation = BaseOperationName;
 // state. A `type` target names a class instead, for the operations that have
 // no instance to bind to yet: a plain `create` mints a card of that type in
 // that realm, and a `query` is rooted in the type it searches for.
+//
+// `url` is an absolute, unmapped URL. A result's ids are canonicalized to
+// registered-prefix form on the way out (`@cardstack/skills/foo`), so an id
+// read off one response is not usable as the next request's target without
+// resolving it back — which the caller does, since resolving a prefix is the
+// realm's own fetch-layer concern and no operation reaches that.
 export type OperationTarget =
   | { kind: 'instance'; url: string }
   | { kind: 'type'; codeRef: CodeRef; realm: string };

--- a/packages/runtime-common/card-operations/types.ts
+++ b/packages/runtime-common/card-operations/types.ts
@@ -1,4 +1,9 @@
 import type { CodeRef } from '../code-ref.ts';
+import type { ScreenshotManifest } from '../capture-spec.ts';
+import type {
+  SingleCardDocument,
+  SingleFileMetaDocument,
+} from '../document-types.ts';
 import type {
   SearchEntryWireFilter,
   SearchEntryWireQuery,
@@ -184,4 +189,178 @@ export interface LowerOperationDeclarationsResult {
   // same issues are on the operations that carry them; this is the flat view
   // a module's diagnostics are built from.
   issues: OperationLoweringIssue[];
+}
+
+// ============================================================================
+// Invoking an operation.
+//
+// Everything above describes an operation as it is *stored*. What follows
+// describes one being *run*: what a caller names, what comes back, and how a
+// refusal is spelled. The two are separate on purpose — a stored definition is
+// built once when a module is indexed, while a request carries the actor and
+// the payload, which are known only at invocation.
+// ============================================================================
+
+// The six built-in behaviors, under the operation runtime's own name. The
+// authoring API owns the list because that is where a declaration names one;
+// re-stating it here lets a consumer of the runtime types stay clear of the
+// card authoring surface, which only loads inside a card module.
+export type BaseOperation = BaseOperationName;
+
+// What an operation runs against. An `instance` target is an existing card or
+// file, addressed by URL — the identity of a thing that already has stored
+// state. A `type` target names a class instead, for the operations that have
+// no instance to bind to yet: a plain `create` mints a card of that type in
+// that realm, and a `query` is rooted in the type it searches for.
+export type OperationTarget =
+  | { kind: 'instance'; url: string }
+  | { kind: 'type'; codeRef: CodeRef; realm: string };
+
+export interface OperationRequest {
+  target: OperationTarget;
+  // The name the operation is invoked under — a declared name, or one of the
+  // six base names for the built-in behavior. Never `base`: a `delete` built
+  // on `transform` is invoked as `delete`.
+  name: string;
+  // The payload, keyed the way the definition's `params` schema declares it.
+  params?: Record<string, unknown>;
+  // The invoking user, as the identity `actor()` resolves to.
+  actor: string;
+  // The caller's own id for this request. Echoed on the realm's index event so
+  // a client can tell its own write's event from anyone else's, which is what
+  // lets it retire the matching optimistic entry rather than reloading.
+  clientRequestId: string;
+  // The version the caller believes it is writing on top of. Absent means an
+  // unconditional write; present makes the write conditional, and the result's
+  // `baseMatched` reports whether the target was still at that version.
+  baseVersion?: string;
+}
+
+// A read's answer: the assembled JSON:API document, exactly as the card+json
+// GET serves it.
+export interface OperationDocumentResult {
+  document: SingleCardDocument | SingleFileMetaDocument;
+}
+
+// A headers-only read's answer. These are the values the card+json response
+// headers are computed from — the validator, the modification time, and the
+// index-data generation and screenshot manifest that go into it. No body is
+// assembled to produce them.
+export interface OperationHeadResult {
+  indexedAt: number | null;
+  lastModified: number | null;
+  generation: number | null;
+  screenshots: ScreenshotManifest | null;
+}
+
+// A write's answer: the identity of what was written and the version it now
+// holds, without reprinting the document. A caller that wants the new state
+// reads it; a caller that wrote it already has it, and the common case is a
+// client reconciling its own optimistic entry, which needs the version and
+// nothing else.
+export interface OperationIdentityResult {
+  id: string;
+  meta: {
+    // The token a later request passes as `baseVersion`.
+    version: string;
+    generation: number | null;
+    lastModified: number | null;
+    // Present only on a conditional write: whether the target was still at
+    // the `baseVersion` the request named. A false here is not an error — the
+    // write happened, and the caller decides what a moved base means.
+    baseMatched?: boolean;
+  };
+}
+
+// A `delete` answers with `null`: there is no state left to describe.
+export type OperationResult =
+  | OperationDocumentResult
+  | OperationHeadResult
+  | OperationIdentityResult
+  | null;
+
+export function isDocumentResult(
+  result: OperationResult,
+): result is OperationDocumentResult {
+  return result != null && 'document' in result;
+}
+
+export function isHeadResult(
+  result: OperationResult,
+): result is OperationHeadResult {
+  return result != null && 'indexedAt' in result;
+}
+
+export function isIdentityResult(
+  result: OperationResult,
+): result is OperationIdentityResult {
+  return result != null && 'id' in result;
+}
+
+export type OperationErrorCode =
+  // No operation of that name, and the name is not a base operation the
+  // target's def type carries.
+  | 'unknown-operation'
+  // The name resolves to a behavior the target's def type does not carry — a
+  // `transform` on a file, anything at all on a field.
+  | 'operation-not-allowed'
+  // The stored definition is flagged `invalid`: lowering recorded findings
+  // against the declaration, so there is an operation by that name but no
+  // runnable form of it. Distinct from `unknown-operation` so an author sees
+  // what is wrong with the declaration rather than being told it does not
+  // exist.
+  | 'invalid-operation'
+  // The payload does not satisfy the definition's `params` schema, or a
+  // marker in the operation references something this invocation cannot
+  // supply.
+  | 'invalid-params'
+  // Nothing at the target's URL.
+  | 'target-not-found'
+  // The target's source file is on disk but the realm has not indexed it yet.
+  // Separate from `target-not-found` because waiting resolves it: the write
+  // landed and the index row is coming.
+  | 'target-not-indexed'
+  // The target exists but its index row is an error row, so there is no clean
+  // state to work from. The row's own HTTP status carries through, which is
+  // why this is distinct from `internal-error`: a recorded 403 is the caller's
+  // to act on, not the realm's.
+  | 'target-errored'
+  // A precondition the operation's program asserts did not hold.
+  | 'assertion-failed'
+  // The request named a `baseVersion` the target is no longer at, on an
+  // operation that requires the base to match.
+  | 'version-conflict'
+  // The operation could not be carried out for a reason that is not the
+  // caller's — an unreadable definition, an errored index row, a failure
+  // inside the executor.
+  | 'internal-error';
+
+// A refusal, shaped like a JSON:API error object so an HTTP surface can put it
+// straight into an `errors` array. `status` is the number the realm's own
+// error bodies carry rather than JSON:API's string, so the two agree.
+export interface OperationError {
+  // The target the operation ran against, where there was one.
+  id?: string;
+  status: number;
+  code: OperationErrorCode;
+  title: string;
+  detail: string;
+  meta?: Record<string, unknown>;
+}
+
+// How a refusal travels. Thrown rather than returned: a batch of operations is
+// all-or-nothing, so the first refusal has to abandon the rest, and an
+// exception is what unwinds the work already staged.
+export class OperationFailure extends Error {
+  readonly error: OperationError;
+
+  constructor(error: OperationError) {
+    super(`${error.code}: ${error.detail}`);
+    this.name = 'OperationFailure';
+    this.error = error;
+  }
+}
+
+export function isOperationFailure(err: unknown): err is OperationFailure {
+  return err instanceof OperationFailure;
 }

--- a/packages/runtime-common/card-operations/types.ts
+++ b/packages/runtime-common/card-operations/types.ts
@@ -251,6 +251,13 @@ export interface OperationHeadResult {
   lastModified: number | null;
   generation: number | null;
   screenshots: ScreenshotManifest | null;
+  // The target's index-row dependencies. Carried because a validator is only
+  // safe when none of them live in another realm: cross-realm invalidation
+  // does not cascade `indexed_at`, so a stable local one does not mean the
+  // assembled `included[]` is current, and a caller that emitted an ETag
+  // anyway would serve a 304 against stale foreign content. Whoever computes
+  // the headers makes that call, so they need what it rests on.
+  deps: string[] | null;
 }
 
 // A write's answer: the identity of what was written and the version it now
@@ -330,6 +337,10 @@ export type OperationErrorCode =
   // The request named a `baseVersion` the target is no longer at, on an
   // operation that requires the base to match.
   | 'version-conflict'
+  // The operation is sound but is not carried out here. A `query` is the case:
+  // it is planned and run on the search engine, so reaching the operation core
+  // with one means the caller used the wrong entry point.
+  | 'wrong-entry-point'
   // The operation could not be carried out for a reason that is not the
   // caller's — an unreadable definition, an errored index row, a failure
   // inside the executor.

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -160,9 +160,9 @@ type Options = {
   signal?: AbortSignal;
 } & QueryOptions;
 
-type SearchResult = SearchResultDoc | SearchResultError;
+export type SearchResult = SearchResultDoc | SearchResultError;
 
-interface SearchResultDoc {
+export interface SearchResultDoc {
   type: 'doc';
   doc: SingleCardDocument;
   // The primary card's index-data generation (`boxel_index.generation`). The

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3186,6 +3186,8 @@ export class Realm {
           );
           return isResolvedCodeRef(absolute) ? absolute : undefined;
         },
+        fileDefCodeRef: (url) =>
+          resolveFileDefCodeRef(url, this.#virtualNetwork),
         unresolveInstanceIds: (doc) => this.#serveInstanceIdsAsRRI(doc),
       };
     }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -130,6 +130,7 @@ import {
   type LintResult,
   codeRefFromInternalKey,
   codeRefWithAbsoluteIdentifier,
+  isResolvedCodeRef,
   userInitiatedPriority,
   systemInitiatedPriority,
   userIdFromUsername,
@@ -142,6 +143,7 @@ import {
   type LooseCardResource,
   type FileMetaResource,
 } from './index.ts';
+import type { OperationCore } from './card-operations/dispatch.ts';
 import type { FromScratchResult } from './tasks/indexer.ts';
 import { isCodeRef, visitModuleDeps } from './code-ref.ts';
 import { merge } from 'lodash-es';
@@ -957,6 +959,11 @@ export class Realm {
   #realmServerURL: string;
   #realmIndexUpdater: RealmIndexUpdater;
   #realmIndexQueryEngine: RealmIndexQueryEngine;
+  #operationCore: OperationCore | undefined;
+  // The realm's own fetch, kept for the operation core. Held separately from
+  // `__fetchForTesting` so an operational dependency does not read as a test
+  // hook.
+  #operationFetch: typeof globalThis.fetch;
   #adapter: RealmAdapter;
   #router: Router;
   #log = logger('realm');
@@ -1235,6 +1242,7 @@ export class Realm {
     this.#definitionLookup = definitionLookup.forRealm(this);
 
     this.__fetchForTesting = _fetch;
+    this.#operationFetch = _fetch;
 
     this.#realmIndexUpdater = new RealmIndexUpdater({
       realm: this,
@@ -3152,6 +3160,41 @@ export class Realm {
 
   get realmIndexQueryEngine() {
     return this.#realmIndexQueryEngine;
+  }
+
+  // The operation core, built from the realm's own collaborators. What it is
+  // handed is deliberately narrow: the definition cache and the index query
+  // engine, plus plain functions for the few resolutions that belong to the
+  // realm's fetch layer. No `VirtualNetwork` crosses this boundary — it
+  // resolves author-controlled identifiers, and an operation runs in a trusted
+  // context where nothing author-written should be able to steer a lookup. So
+  // the realm absolutizes a code ref and canonicalizes a document's ids on the
+  // core's behalf rather than letting it reach for the network itself.
+  get operationCore(): OperationCore {
+    if (!this.#operationCore) {
+      this.#operationCore = {
+        realmURL: this.url,
+        definitionLookup: this.#definitionLookup,
+        indexQueryEngine: this.#realmIndexQueryEngine,
+        readSource: async (localPath) =>
+          (await this.readFileAsText(localPath))?.content,
+        isIgnored: (url) => this.isIgnored(url),
+        fileMetaDocument: (localPath) =>
+          this.#operationFileMetaDocument(localPath),
+        resolveCodeRef: (codeRef, relativeTo) => {
+          let absolute = codeRefWithAbsoluteIdentifier(
+            codeRef,
+            relativeTo,
+            undefined,
+            this.#virtualNetwork,
+          );
+          return isResolvedCodeRef(absolute) ? absolute : undefined;
+        },
+        unresolveInstanceIds: (doc) => this.#serveInstanceIdsAsRRI(doc),
+        fetch: this.#operationFetch,
+      };
+    }
+    return this.#operationCore;
   }
 
   async reindex() {
@@ -5539,6 +5582,28 @@ export class Realm {
     localPath: LocalPath,
     contentType: SupportedMimeType = SupportedMimeType.CardJson,
   ): Promise<Response | undefined> {
+    let doc = await this.#fileMetaDocumentFromDisk(localPath);
+    if (!doc) {
+      return undefined;
+    }
+    return createResponse({
+      body: JSON.stringify(doc, null, 2),
+      init: {
+        headers: {
+          'content-type': contentType,
+        },
+      },
+      requestContext,
+    });
+  }
+
+  // A file's metadata document read from the bytes on disk — the answer for a
+  // file the index has no row for. Content-derived values come from the
+  // write-time record where there is one and are computed from the bytes
+  // otherwise.
+  async #fileMetaDocumentFromDisk(
+    localPath: LocalPath,
+  ): Promise<SingleFileMetaDocument | undefined> {
     let fileRef = await this.openFileForMetadata(localPath);
     if (!fileRef) {
       return undefined;
@@ -5588,15 +5653,7 @@ export class Realm {
       },
     };
     this.#serveInstanceIdsAsRRI(doc);
-    return createResponse({
-      body: JSON.stringify(doc, null, 2),
-      init: {
-        headers: {
-          'content-type': contentType,
-        },
-      },
-      requestContext,
-    });
+    return doc;
   }
 
   private async fileMetaDocumentFromIndex(
@@ -5604,6 +5661,25 @@ export class Realm {
     localPath: LocalPath,
     fileEntry: IndexedFile,
   ): Promise<Response> {
+    let doc = await this.#fileMetaDocumentFromRow(localPath, fileEntry);
+    return createResponse({
+      body: JSON.stringify(doc, null, 2),
+      init: {
+        headers: {
+          'content-type': SupportedMimeType.FileMeta,
+        },
+      },
+      requestContext,
+    });
+  }
+
+  // A file's metadata document assembled from its index row, which is the
+  // preferred source: it carries the extract-computed attributes and the
+  // per-field subclass overrides that reading the bytes alone cannot recover.
+  async #fileMetaDocumentFromRow(
+    localPath: LocalPath,
+    fileEntry: IndexedFile,
+  ): Promise<SingleFileMetaDocument> {
     let fileURL = this.paths.fileURL(localPath).href;
     let name = localPath.split('/').pop() ?? localPath;
     let inferredContentType = inferContentType(name);
@@ -5710,15 +5786,31 @@ export class Realm {
       },
     };
     this.#serveInstanceIdsAsRRI(doc);
-    return createResponse({
-      body: JSON.stringify(doc, null, 2),
-      init: {
-        headers: {
-          'content-type': SupportedMimeType.FileMeta,
-        },
-      },
-      requestContext,
-    });
+    return doc;
+  }
+
+  // The file-meta document for a path that holds bytes rather than a card, as
+  // the operation core reads it: the indexed row where there is one, the bytes
+  // on disk otherwise, and no response around either. That is the file-meta
+  // endpoint's own preference rather than the card+json handler's, which reads
+  // the bytes alone — a `read` of a file is the file-meta surface, so it
+  // answers with the row's extract-computed attributes and subclass field
+  // overrides where the row exists. A path whose sibling `.json` makes it a
+  // card's source is not a file and answers undefined, which is what sends a
+  // card+json read back to its own not-found handling.
+  async #operationFileMetaDocument(
+    localPath: LocalPath,
+  ): Promise<SingleFileMetaDocument | undefined> {
+    let fileEntry = await this.#realmIndexQueryEngine.file(
+      this.paths.fileURL(localPath),
+    );
+    if (fileEntry) {
+      return await this.#fileMetaDocumentFromRow(localPath, fileEntry);
+    }
+    if (!(await this.nonJsonFileExists(localPath))) {
+      return undefined;
+    }
+    return await this.#fileMetaDocumentFromDisk(localPath);
   }
 
   private async getFileMeta(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -960,10 +960,6 @@ export class Realm {
   #realmIndexUpdater: RealmIndexUpdater;
   #realmIndexQueryEngine: RealmIndexQueryEngine;
   #operationCore: OperationCore | undefined;
-  // The realm's own fetch, kept for the operation core. Held separately from
-  // `__fetchForTesting` so an operational dependency does not read as a test
-  // hook.
-  #operationFetch: typeof globalThis.fetch;
   #adapter: RealmAdapter;
   #router: Router;
   #log = logger('realm');
@@ -1242,7 +1238,6 @@ export class Realm {
     this.#definitionLookup = definitionLookup.forRealm(this);
 
     this.__fetchForTesting = _fetch;
-    this.#operationFetch = _fetch;
 
     this.#realmIndexUpdater = new RealmIndexUpdater({
       realm: this,
@@ -3165,11 +3160,12 @@ export class Realm {
   // The operation core, built from the realm's own collaborators. What it is
   // handed is deliberately narrow: the definition cache and the index query
   // engine, plus plain functions for the few resolutions that belong to the
-  // realm's fetch layer. No `VirtualNetwork` crosses this boundary — it
-  // resolves author-controlled identifiers, and an operation runs in a trusted
-  // context where nothing author-written should be able to steer a lookup. So
-  // the realm absolutizes a code ref and canonicalizes a document's ids on the
-  // core's behalf rather than letting it reach for the network itself.
+  // realm's fetch layer. It gets no network capability and no
+  // `VirtualNetwork` — that resolves author-controlled identifiers, and an
+  // operation runs in a trusted context where nothing author-written should be
+  // able to steer a lookup. So the realm absolutizes a code ref and
+  // canonicalizes a document's ids on the core's behalf, and an operation
+  // never resolves either itself.
   get operationCore(): OperationCore {
     if (!this.#operationCore) {
       this.#operationCore = {
@@ -3191,7 +3187,6 @@ export class Realm {
           return isResolvedCodeRef(absolute) ? absolute : undefined;
         },
         unresolveInstanceIds: (doc) => this.#serveInstanceIdsAsRRI(doc),
-        fetch: this.#operationFetch,
       };
     }
     return this.#operationCore;
@@ -5661,25 +5656,6 @@ export class Realm {
     localPath: LocalPath,
     fileEntry: IndexedFile,
   ): Promise<Response> {
-    let doc = await this.#fileMetaDocumentFromRow(localPath, fileEntry);
-    return createResponse({
-      body: JSON.stringify(doc, null, 2),
-      init: {
-        headers: {
-          'content-type': SupportedMimeType.FileMeta,
-        },
-      },
-      requestContext,
-    });
-  }
-
-  // A file's metadata document assembled from its index row, which is the
-  // preferred source: it carries the extract-computed attributes and the
-  // per-field subclass overrides that reading the bytes alone cannot recover.
-  async #fileMetaDocumentFromRow(
-    localPath: LocalPath,
-    fileEntry: IndexedFile,
-  ): Promise<SingleFileMetaDocument> {
     let fileURL = this.paths.fileURL(localPath).href;
     let name = localPath.split('/').pop() ?? localPath;
     let inferredContentType = inferContentType(name);
@@ -5786,27 +5762,26 @@ export class Realm {
       },
     };
     this.#serveInstanceIdsAsRRI(doc);
-    return doc;
+    return createResponse({
+      body: JSON.stringify(doc, null, 2),
+      init: {
+        headers: {
+          'content-type': SupportedMimeType.FileMeta,
+        },
+      },
+      requestContext,
+    });
   }
 
   // The file-meta document for a path that holds bytes rather than a card, as
-  // the operation core reads it: the indexed row where there is one, the bytes
-  // on disk otherwise, and no response around either. That is the file-meta
-  // endpoint's own preference rather than the card+json handler's, which reads
-  // the bytes alone — a `read` of a file is the file-meta surface, so it
-  // answers with the row's extract-computed attributes and subclass field
-  // overrides where the row exists. A path whose sibling `.json` makes it a
-  // card's source is not a file and answers undefined, which is what sends a
-  // card+json read back to its own not-found handling.
+  // the operation core reads it — the card+json read's own answer for such a
+  // path, derived from the bytes, with no response around it. The guard is the
+  // one that read applies: a path whose sibling `.json` makes it a card's
+  // source is not a file, and answers undefined so the read falls back to its
+  // own not-found handling.
   async #operationFileMetaDocument(
     localPath: LocalPath,
   ): Promise<SingleFileMetaDocument | undefined> {
-    let fileEntry = await this.#realmIndexQueryEngine.file(
-      this.paths.fileURL(localPath),
-    );
-    if (fileEntry) {
-      return await this.#fileMetaDocumentFromRow(localPath, fileEntry);
-    }
     if (!(await this.nonJsonFileExists(localPath))) {
       return undefined;
     }

--- a/packages/runtime-common/tests/card-operations-dispatch-test.ts
+++ b/packages/runtime-common/tests/card-operations-dispatch-test.ts
@@ -188,12 +188,20 @@ function stub(opts: StubOptions = {}): Stub {
         : undefined;
     },
     resolveCodeRef: (codeRef) => codeRef as any,
+    // The realm derives a file's type from its extension; the stub answers the
+    // one file def the cases need.
+    fileDefCodeRef: () => MARKDOWN,
     unresolveInstanceIds: () => {
       calls.push('unresolveInstanceIds');
     },
   };
   return { core, calls };
 }
+
+const MARKDOWN: CodeRef = {
+  module: 'https://cardstack.com/base/markdown-file-def',
+  name: 'MarkdownDef',
+} as CodeRef;
 
 const CARD: OperationTarget = { kind: 'instance', url: `${REALM}person-1` };
 const FILE: OperationTarget = { kind: 'instance', url: `${REALM}sample.md` };
@@ -447,27 +455,6 @@ const tests = Object.freeze({
     assert.strictEqual(notACard.code, 'target-not-found');
   },
 
-  'a target outside the realm is refused before anything is read': async (
-    assert,
-  ) => {
-    let { core, calls } = stub();
-    let error = await refusalFrom(() =>
-      runOperation(
-        core,
-        invoke(
-          { kind: 'instance', url: 'http://example.com/other/person-1' },
-          'read',
-        ),
-      ),
-    );
-    assert.strictEqual(error.code, 'target-not-found');
-    assert.strictEqual(
-      calls.filter((call) => call === 'cardDocument').length,
-      0,
-      'the document is never assembled for a target this core cannot serve',
-    );
-  },
-
   'a type nobody can resolve is refused as a missing target': async (
     assert,
   ) => {
@@ -491,14 +478,15 @@ const tests = Object.freeze({
   },
 
   'a target is canonicalized before anything is read': async (assert) => {
-    // The realm root names the realm's index card, and a query string, a
-    // fragment or a `.json` spelling all name the card they hang off. None of
-    // them may reach the index lookup or `links.self` as written.
+    // The realm root names the realm's index card; a query string, a fragment
+    // and a trailing slash all name the card they hang off. None of them may
+    // reach the index lookup or `links.self` as written. A `.json` spelling is
+    // not in this set — it names the card's source, which is a different read.
     for (let [spelling, expected] of [
       [`${REALM}`, `${REALM}index`],
       [`${REALM}person-1?vary=1`, `${REALM}person-1`],
       [`${REALM}person-1#section`, `${REALM}person-1`],
-      [`${REALM}person-1.json`, `${REALM}person-1`],
+      [`${REALM}person-1/`, `${REALM}person-1`],
     ] as [string, string][]) {
       let { core } = stub();
       let result = await runOperation(
@@ -661,7 +649,6 @@ const tests = Object.freeze({
       };
       for (let spelling of [
         `${REALM}person-1`,
-        `${REALM}person-1.json`,
         `${REALM}person-1?vary=1`,
         `${REALM}person-1#section`,
         `${REALM}person-1/`,
@@ -686,25 +673,73 @@ const tests = Object.freeze({
       }
     },
 
-  'a card named by its source spelling is a card, not a file': async (
-    assert,
-  ) => {
-    // `.json` is a registered file extension, so an uncanonicalized target
-    // classifies a card's own source spelling as a file — and then refuses
-    // every operation a card carries beyond `read`.
-    let { core } = stub();
+  'a card source spelling names the source, not the card': async (assert) => {
+    // `<card>.json` names the card's stored bytes. That is a different read
+    // from the card, so the target routes as a file rather than resolving to
+    // the instance — and a file carries only `read`.
+    let { core, calls } = stub();
     let error = await refusalFrom(() =>
       runOperation(
         core,
         invoke({ kind: 'instance', url: `${REALM}person-1.json` }, 'update'),
       ),
     );
+    assert.strictEqual(error.code, 'operation-not-allowed');
     assert.strictEqual(
-      error.status,
-      501,
-      'update is a card operation with no executor yet, not one a file lacks',
+      calls.filter((call) => call === 'instance').length,
+      0,
+      'a source target is never resolved through the instance index',
     );
-    assert.strictEqual(error.code, 'internal-error');
+  },
+
+  'a file def declaration is resolved the same as a card def one': async (
+    assert,
+  ) => {
+    // A file names its type by its extension rather than in stored JSON, but
+    // the type's entry carries declarations either way, so a `read` declared
+    // on a file def subclass has to be found.
+    let { core, calls } = stub({
+      operations: {
+        readRedacted: { base: 'read' as const, deterministic: true },
+      },
+    });
+    let result = await runOperation(core, invoke(FILE, 'readRedacted'));
+    assert.true(isDocumentResult(result), 'the declared file read resolves');
+    assert.true(
+      calls.includes('lookupDefinition'),
+      'the file def type entry is consulted',
+    );
+
+    // The allowance still holds: a file carries `read` and nothing else,
+    // whatever it declares.
+    let mutating = stub({
+      operations: {
+        touch: { base: 'transform' as const, deterministic: true },
+      },
+    });
+    let error = await refusalFrom(() =>
+      runOperation(mutating.core, invoke(FILE, 'touch')),
+    );
+    assert.strictEqual(error.code, 'operation-not-allowed');
+  },
+
+  'a foreign target is refused without reading the index': async (assert) => {
+    let { core, calls } = stub();
+    let error = await refusalFrom(() =>
+      runOperation(
+        core,
+        invoke(
+          { kind: 'instance', url: 'http://example.com/other/person-1' },
+          'read',
+        ),
+      ),
+    );
+    assert.strictEqual(error.code, 'target-not-found');
+    assert.deepEqual(
+      calls,
+      [],
+      'a URL this realm does not contain settles before any read',
+    );
   },
 
   'the row peek is memoized for one invocation and no longer': async (

--- a/packages/runtime-common/tests/card-operations-dispatch-test.ts
+++ b/packages/runtime-common/tests/card-operations-dispatch-test.ts
@@ -55,6 +55,20 @@ interface Stub {
   calls: string[];
 }
 
+// `getInstance` matches `i.url` / `i.file_alias`, so a row answers to the
+// card's canonical URL and to nothing else — not to a query string, a
+// fragment, a trailing slash, or the `.json` source spelling. The stub holds
+// itself to the same rule so a target that reaches the index uncanonicalized
+// misses, the way it would against Postgres.
+function isCanonicalKey(url: URL): boolean {
+  return (
+    url.search === '' &&
+    url.hash === '' &&
+    !url.pathname.endsWith('.json') &&
+    !url.pathname.endsWith('/')
+  );
+}
+
 function stub(opts: StubOptions = {}): Stub {
   let calls: string[] = [];
   let {
@@ -88,7 +102,7 @@ function stub(opts: StubOptions = {}): Stub {
     indexQueryEngine: {
       async cardDocument(url) {
         calls.push('cardDocument');
-        if (document === 'missing') {
+        if (document === 'missing' || !isCanonicalKey(url)) {
           return undefined;
         }
         if (typeof document === 'object') {
@@ -124,7 +138,7 @@ function stub(opts: StubOptions = {}): Stub {
       },
       async instance(url) {
         calls.push('instance');
-        if (row === 'missing') {
+        if (row === 'missing' || !isCanonicalKey(url)) {
           return undefined;
         }
         return {
@@ -629,6 +643,68 @@ const tests = Object.freeze({
       ),
     );
     assert.strictEqual(notAURL.code, 'invalid-params');
+  },
+
+  'a declared operation resolves the same however the target is spelled':
+    async (assert) => {
+      // Dispatch resolves the type from the target and the executor reads from
+      // it, so both have to be looking at the same card. Canonicalizing in only
+      // one of them is worse than canonicalizing in neither: the type is
+      // resolved for one card and the document assembled for another, and a
+      // declared operation silently degrades to the built-in.
+      let declared = {
+        read: {
+          base: 'read' as const,
+          deterministic: true,
+          output: { source: 'PROJECT(.title)', syntax: 'solidified' as const },
+        },
+      };
+      for (let spelling of [
+        `${REALM}person-1`,
+        `${REALM}person-1.json`,
+        `${REALM}person-1?vary=1`,
+        `${REALM}person-1#section`,
+        `${REALM}person-1/`,
+      ]) {
+        let { core, calls } = stub({ operations: declared });
+        let error = await refusalFrom(() =>
+          runOperation(
+            core,
+            invoke({ kind: 'instance', url: spelling }, 'read'),
+          ),
+        );
+        assert.strictEqual(
+          error.status,
+          501,
+          `${spelling} resolves the declared read, not the built-in`,
+        );
+        assert.strictEqual(
+          calls.filter((call) => call === 'instance').length,
+          1,
+          `${spelling} costs one row read, shared by dispatch and the executor`,
+        );
+      }
+    },
+
+  'a card named by its source spelling is a card, not a file': async (
+    assert,
+  ) => {
+    // `.json` is a registered file extension, so an uncanonicalized target
+    // classifies a card's own source spelling as a file — and then refuses
+    // every operation a card carries beyond `read`.
+    let { core } = stub();
+    let error = await refusalFrom(() =>
+      runOperation(
+        core,
+        invoke({ kind: 'instance', url: `${REALM}person-1.json` }, 'update'),
+      ),
+    );
+    assert.strictEqual(
+      error.status,
+      501,
+      'update is a card operation with no executor yet, not one a file lacks',
+    );
+    assert.strictEqual(error.code, 'internal-error');
   },
 
   'the row peek is memoized for one invocation and no longer': async (

--- a/packages/runtime-common/tests/card-operations-dispatch-test.ts
+++ b/packages/runtime-common/tests/card-operations-dispatch-test.ts
@@ -1,0 +1,490 @@
+import {
+  isDocumentResult,
+  isHeadResult,
+  isOperationFailure,
+  newOperationScope,
+  resolveOperation,
+  runOperation,
+  type OperationCore,
+  type OperationError,
+  type OperationTarget,
+} from '../card-operations/index.ts';
+import type { CodeRef } from '../code-ref.ts';
+import type { Definition } from '../definitions.ts';
+import type { SharedTests } from '../helpers/index.ts';
+
+// ============================================================================
+// Which behavior a name resolves to, and what a refusal says.
+//
+// Dispatch reads a target's type out of the index, its operations out of the
+// definition cache, and decides from those two alone. Both are stubbed here,
+// which is the point: what is under test is the decision, not the realm's
+// ability to produce the inputs, and a stub makes the cases a real realm
+// cannot easily be put into — an errored index row, a card whose source has
+// landed but whose row has not — as cheap as the ordinary ones.
+//
+// The `read` executor rides along, since its refusals come from the same
+// taxonomy and its status mapping is the one thing a caller can observe about
+// a card that will not read cleanly.
+// ============================================================================
+
+const REALM = 'http://example.com/test/';
+const PERSON: CodeRef = {
+  module: `${REALM}person`,
+  name: 'Person',
+} as CodeRef;
+
+interface StubOptions {
+  // What `cardDocument` answers. `undefined` is a missing row.
+  document?: 'ok' | 'missing' | { errorStatus: number };
+  // What the row peek answers. `undefined` is a missing row.
+  row?: 'ok' | 'missing';
+  // The operations the target's type declares.
+  operations?: Definition['operations'];
+  // The type entry itself. `undefined` is an unreadable one.
+  definitionType?: Definition['type'] | 'unresolvable';
+  // The source file behind the target, when there is one on disk.
+  source?: string;
+  fileMeta?: boolean;
+}
+
+interface Stub {
+  core: OperationCore;
+  calls: string[];
+}
+
+function stub(opts: StubOptions = {}): Stub {
+  let calls: string[] = [];
+  let {
+    document = 'ok',
+    row = 'ok',
+    operations,
+    definitionType = 'card-def',
+    source,
+    fileMeta = true,
+  } = opts;
+
+  let core: OperationCore = {
+    realmURL: REALM,
+    definitionLookup: {
+      async lookupDefinition(codeRef) {
+        calls.push('lookupDefinition');
+        if (definitionType === 'unresolvable') {
+          return undefined;
+        }
+        return {
+          type: definitionType,
+          codeRef,
+          displayName: 'Person',
+          fields: {},
+          fieldDefs: {},
+          ...(operations ? { operations } : {}),
+        };
+      },
+    },
+    indexQueryEngine: {
+      async cardDocument(url) {
+        calls.push('cardDocument');
+        if (document === 'missing') {
+          return undefined;
+        }
+        if (typeof document === 'object') {
+          return {
+            type: 'error',
+            error: {
+              errorDetail: {
+                status: document.errorStatus,
+                title: 'Boom',
+                message: 'the card could not be built',
+              },
+              scopedCssUrls: [],
+              lastKnownGoodHtml: null,
+              cardTitle: null,
+            },
+          } as any;
+        }
+        return {
+          type: 'doc',
+          doc: {
+            data: {
+              id: url.href,
+              type: 'card',
+              attributes: { title: 'Hi' },
+              meta: { adoptsFrom: PERSON },
+            },
+          },
+          generation: 7,
+          indexedAt: 1700,
+          deps: [],
+          screenshots: null,
+        } as any;
+      },
+      async instance(url) {
+        calls.push('instance');
+        if (row === 'missing') {
+          return undefined;
+        }
+        return {
+          type: 'instance',
+          instance: {
+            id: url.href,
+            type: 'card',
+            meta: { adoptsFrom: PERSON },
+          },
+          generation: 7,
+          indexedAt: 1700,
+          lastModified: 1699,
+          screenshots: null,
+        } as any;
+      },
+      async file() {
+        calls.push('file');
+        return undefined;
+      },
+    },
+    async readSource() {
+      calls.push('readSource');
+      return source;
+    },
+    async isIgnored() {
+      return false;
+    },
+    async fileMetaDocument(localPath) {
+      calls.push('fileMetaDocument');
+      return fileMeta
+        ? ({
+            data: {
+              type: 'file-meta',
+              id: `${REALM}${localPath}`,
+              attributes: { name: localPath, lastModified: 42 },
+            },
+          } as any)
+        : undefined;
+    },
+    resolveCodeRef: (codeRef) => codeRef as any,
+    unresolveInstanceIds: () => {
+      calls.push('unresolveInstanceIds');
+    },
+    fetch: globalThis.fetch,
+  };
+  return { core, calls };
+}
+
+const CARD: OperationTarget = { kind: 'instance', url: `${REALM}person-1` };
+const FILE: OperationTarget = { kind: 'instance', url: `${REALM}sample.md` };
+
+function invoke(target: OperationTarget, name: string) {
+  return {
+    target,
+    name,
+    actor: '@test-actor:localhost',
+    clientRequestId: 'dispatch-test',
+  };
+}
+
+// Rethrows anything that is not an operation failure, so a genuine bug reports
+// itself rather than being read as the refusal under test.
+async function refusalFrom(
+  run: () => Promise<unknown>,
+): Promise<OperationError> {
+  try {
+    await run();
+  } catch (err) {
+    if (isOperationFailure(err)) {
+      return err.error;
+    }
+    throw err;
+  }
+  throw new Error('expected the operation to be refused, but it succeeded');
+}
+
+const tests = Object.freeze({
+  'a base operation with no declaration resolves to its built-in behavior':
+    async (assert) => {
+      let { core } = stub();
+      let definition = await resolveOperation(core, CARD, 'read');
+      assert.strictEqual(definition.base, 'read');
+      assert.true(
+        definition.deterministic,
+        'a built-in has no program, so it is deterministic by construction',
+      );
+      assert.strictEqual(
+        definition.program,
+        undefined,
+        'and it carries no program',
+      );
+    },
+
+  'a declaration wins over the built-in of the same name': async (assert) => {
+    let { core } = stub({
+      operations: {
+        // The rebinding the design exists for: asking this card to delete
+        // itself runs a transform, which is how a soft delete is spelled.
+        delete: {
+          base: 'transform',
+          deterministic: true,
+          program: { source: 'del(.x);', syntax: 'solidified' },
+        },
+      },
+    });
+    let definition = await resolveOperation(core, CARD, 'delete');
+    assert.strictEqual(
+      definition.base,
+      'transform',
+      'the name is what a caller invokes; the base is what carries it out',
+    );
+  },
+
+  'a name that is neither declared nor a base operation is refused': async (
+    assert,
+  ) => {
+    let { core } = stub();
+    let error = await refusalFrom(() =>
+      runOperation(core, invoke(CARD, 'addComment')),
+    );
+    assert.strictEqual(error.code, 'unknown-operation');
+    assert.strictEqual(error.status, 404);
+  },
+
+  'a def type that does not carry the behavior refuses it': async (assert) => {
+    let file = stub();
+    let onFile = await refusalFrom(() =>
+      runOperation(file.core, invoke(FILE, 'transform')),
+    );
+    assert.strictEqual(onFile.code, 'operation-not-allowed');
+    assert.strictEqual(onFile.status, 405);
+    assert.true(
+      onFile.detail.includes('read'),
+      `the refusal names what a file does carry: ${onFile.detail}`,
+    );
+
+    // A field's instances have no URL, so nothing is invocable on one — which
+    // only a type target can even express.
+    let field = stub({ definitionType: 'field-def' });
+    let onField = await refusalFrom(() =>
+      resolveOperation(
+        field.core,
+        { kind: 'type', codeRef: PERSON, realm: REALM },
+        'create',
+      ),
+    );
+    assert.strictEqual(onField.code, 'operation-not-allowed');
+  },
+
+  'a declaration lowering flagged invalid reports its findings': async (
+    assert,
+  ) => {
+    let { core } = stub({
+      operations: {
+        addComment: {
+          base: 'transform',
+          deterministic: true,
+          invalid: true,
+          issues: [
+            {
+              code: 'unknown-field',
+              operation: 'addComment',
+              path: 'append.to',
+              message: '"comments" is not a field on Person',
+            },
+          ],
+        },
+      },
+    });
+    let error = await refusalFrom(() =>
+      runOperation(core, invoke(CARD, 'addComment')),
+    );
+    assert.strictEqual(
+      error.code,
+      'invalid-operation',
+      'a declaration with findings is not the same as no declaration',
+    );
+    assert.true(
+      error.detail.includes('"comments" is not a field on Person'),
+      `the refusal carries the finding: ${error.detail}`,
+    );
+  },
+
+  'a read serves the indexed document with its generation joined on': async (
+    assert,
+  ) => {
+    let { core } = stub();
+    let result = await runOperation(core, invoke(CARD, 'read'));
+    assert.true(isDocumentResult(result), 'a read answers with a document');
+    if (!isDocumentResult(result)) {
+      return;
+    }
+    assert.strictEqual(result.document.data.links?.self, `${REALM}person-1`);
+    assert.strictEqual(
+      (result.document.data.meta as { generation?: number }).generation,
+      7,
+      'the index-data generation is joined at serve time',
+    );
+  },
+
+  'a headers-only read shares dispatch read of the index row': async (
+    assert,
+  ) => {
+    let { core, calls } = stub();
+    let result = await runOperation(core, invoke(CARD, 'read'), {
+      headersOnly: true,
+    });
+    assert.true(isHeadResult(result), 'it answers with the header values');
+    assert.strictEqual(
+      calls.filter((call) => call === 'cardDocument').length,
+      0,
+      'no document is assembled',
+    );
+    assert.strictEqual(
+      calls.filter((call) => call === 'instance').length,
+      1,
+      'dispatch and the executor read the row once between them',
+    );
+  },
+
+  'an errored index row carries its own status through': async (assert) => {
+    let forbidden = await refusalFrom(() =>
+      runOperation(
+        stub({ document: { errorStatus: 403 } }).core,
+        invoke(CARD, 'read'),
+      ),
+    );
+    assert.strictEqual(forbidden.status, 403, 'a real HTTP status is mirrored');
+    assert.strictEqual(forbidden.code, 'target-errored');
+
+    // 404 is the one status never mirrored: an existing-but-errored card is
+    // not "not found", and that code is reserved for a missing row so a 404
+    // from a read is an unambiguous "this card no longer exists".
+    let recorded404 = await refusalFrom(() =>
+      runOperation(
+        stub({ document: { errorStatus: 404 } }).core,
+        invoke(CARD, 'read'),
+      ),
+    );
+    assert.strictEqual(recorded404.status, 500);
+
+    let nonHttp = await refusalFrom(() =>
+      runOperation(
+        stub({ document: { errorStatus: 0 } }).core,
+        invoke(CARD, 'read'),
+      ),
+    );
+    assert.strictEqual(nonHttp.status, 500);
+  },
+
+  'a read tells a missing card from one still being indexed': async (
+    assert,
+  ) => {
+    let gone = await refusalFrom(() =>
+      runOperation(
+        stub({ document: 'missing', row: 'missing', fileMeta: false }).core,
+        invoke(CARD, 'read'),
+      ),
+    );
+    assert.strictEqual(gone.code, 'target-not-found');
+
+    let pending = await refusalFrom(() =>
+      runOperation(
+        stub({
+          document: 'missing',
+          row: 'missing',
+          fileMeta: false,
+          source: JSON.stringify({
+            data: {
+              type: 'card',
+              attributes: {},
+              meta: { adoptsFrom: PERSON },
+            },
+          }),
+        }).core,
+        invoke(CARD, 'read'),
+      ),
+    );
+    assert.strictEqual(
+      pending.code,
+      'target-not-indexed',
+      'a `.json` on disk with no row is a write this realm has not caught up with',
+    );
+
+    // A source file that will never become an instance row is not a card in
+    // waiting, whatever else it is.
+    let notACard = await refusalFrom(() =>
+      runOperation(
+        stub({
+          document: 'missing',
+          row: 'missing',
+          fileMeta: false,
+          source: JSON.stringify({ data: [] }),
+        }).core,
+        invoke(CARD, 'read'),
+      ),
+    );
+    assert.strictEqual(notACard.code, 'target-not-found');
+  },
+
+  'a target outside the realm is refused before anything is read': async (
+    assert,
+  ) => {
+    let { core, calls } = stub();
+    let error = await refusalFrom(() =>
+      runOperation(
+        core,
+        invoke(
+          { kind: 'instance', url: 'http://example.com/other/person-1' },
+          'read',
+        ),
+      ),
+    );
+    assert.strictEqual(error.code, 'target-not-found');
+    assert.strictEqual(
+      calls.filter((call) => call === 'cardDocument').length,
+      0,
+      'the document is never assembled for a target this core cannot serve',
+    );
+  },
+
+  'a type nobody can resolve is refused as a missing target': async (
+    assert,
+  ) => {
+    let { core } = stub({ definitionType: 'unresolvable' });
+    let error = await refusalFrom(() =>
+      resolveOperation(
+        core,
+        { kind: 'type', codeRef: PERSON, realm: REALM },
+        'create',
+      ),
+    );
+    assert.strictEqual(error.code, 'target-not-found');
+  },
+
+  'a card whose type entry is unreadable still reads': async (assert) => {
+    // The built-in `read` consults no definition, so refusing here would make
+    // every card of a broken module unreadable.
+    let { core } = stub({ definitionType: 'unresolvable' });
+    let result = await runOperation(core, invoke(CARD, 'read'));
+    assert.true(isDocumentResult(result), 'the card still reads');
+  },
+
+  'the row peek is memoized for one invocation and no longer': async (
+    assert,
+  ) => {
+    let { core, calls } = stub();
+    let url = new URL(`${REALM}person-1`);
+    let scope = newOperationScope(core);
+    await scope.peekInstance(url);
+    await scope.peekInstance(url);
+    assert.strictEqual(
+      calls.filter((call) => call === 'instance').length,
+      1,
+      'a scope reads a row once',
+    );
+    await newOperationScope(core).peekInstance(url);
+    assert.strictEqual(
+      calls.filter((call) => call === 'instance').length,
+      2,
+      'and a fresh scope reads it again, so no row outlives its request',
+    );
+  },
+}) as SharedTests<Record<string, never>>;
+
+export default tests;

--- a/packages/runtime-common/tests/card-operations-dispatch-test.ts
+++ b/packages/runtime-common/tests/card-operations-dispatch-test.ts
@@ -46,6 +46,8 @@ interface StubOptions {
   // The source file behind the target, when there is one on disk.
   source?: string;
   fileMeta?: boolean;
+  // Whether the file target has an index row.
+  fileRow?: boolean;
 }
 
 interface Stub {
@@ -62,6 +64,7 @@ function stub(opts: StubOptions = {}): Stub {
     definitionType = 'card-def',
     source,
     fileMeta = true,
+    fileRow = false,
   } = opts;
 
   let core: OperationCore = {
@@ -139,7 +142,16 @@ function stub(opts: StubOptions = {}): Stub {
       },
       async file() {
         calls.push('file');
-        return undefined;
+        return fileRow
+          ? ({
+              type: 'file',
+              lastModified: 1699,
+              generation: 4,
+              screenshots: null,
+              deps: null,
+              indexedAt: 1700,
+            } as any)
+          : undefined;
       },
     },
     async readSource() {
@@ -165,7 +177,6 @@ function stub(opts: StubOptions = {}): Stub {
     unresolveInstanceIds: () => {
       calls.push('unresolveInstanceIds');
     },
-    fetch: globalThis.fetch,
   };
   return { core, calls };
 }
@@ -463,6 +474,161 @@ const tests = Object.freeze({
     let { core } = stub({ definitionType: 'unresolvable' });
     let result = await runOperation(core, invoke(CARD, 'read'));
     assert.true(isDocumentResult(result), 'the card still reads');
+  },
+
+  'a target is canonicalized before anything is read': async (assert) => {
+    // The realm root names the realm's index card, and a query string, a
+    // fragment or a `.json` spelling all name the card they hang off. None of
+    // them may reach the index lookup or `links.self` as written.
+    for (let [spelling, expected] of [
+      [`${REALM}`, `${REALM}index`],
+      [`${REALM}person-1?vary=1`, `${REALM}person-1`],
+      [`${REALM}person-1#section`, `${REALM}person-1`],
+      [`${REALM}person-1.json`, `${REALM}person-1`],
+    ] as [string, string][]) {
+      let { core } = stub();
+      let result = await runOperation(
+        core,
+        invoke({ kind: 'instance', url: spelling }, 'read'),
+      );
+      assert.true(isDocumentResult(result), `${spelling} reads`);
+      if (isDocumentResult(result)) {
+        assert.strictEqual(
+          result.document.data.links?.self,
+          expected,
+          `${spelling} resolves to ${expected}`,
+        );
+      }
+    }
+  },
+
+  'a declared read the executor cannot carry out is refused': async (
+    assert,
+  ) => {
+    // Serving the plain document would be a well-formed answer to a different
+    // question than the declaration asked.
+    let { core } = stub({
+      operations: {
+        summary: {
+          base: 'read',
+          deterministic: true,
+          output: { source: 'PROJECT(.title)', syntax: 'solidified' },
+        },
+      },
+    });
+    let error = await refusalFrom(() =>
+      runOperation(core, invoke(CARD, 'summary')),
+    );
+    assert.strictEqual(error.status, 501);
+    assert.true(
+      error.detail.includes('output'),
+      `the refusal names the stage: ${error.detail}`,
+    );
+  },
+
+  'a payload missing a declared param is refused before any behavior runs':
+    async (assert) => {
+      let { core, calls } = stub({
+        operations: {
+          summary: {
+            base: 'read',
+            deterministic: true,
+            params: {
+              locale: { kind: 'field', codeRef: PERSON },
+            },
+          },
+        },
+      });
+      let error = await refusalFrom(() =>
+        runOperation(core, invoke(CARD, 'summary')),
+      );
+      assert.strictEqual(error.code, 'invalid-params');
+      assert.true(
+        error.detail.includes('locale'),
+        `the refusal names the param: ${error.detail}`,
+      );
+      assert.strictEqual(
+        calls.filter((call) => call === 'cardDocument').length,
+        0,
+        'nothing is read for a payload that cannot satisfy the operation',
+      );
+    },
+
+  'a name every object answers to is unknown, not a dispatchable operation':
+    async (assert) => {
+      // A lowered `operations` record has been through JSON, so it carries
+      // `Object.prototype` and answers these names with something that is not
+      // an operation. Reading one as a declaration reaches a `base` of
+      // `undefined`.
+      for (let name of [
+        'toString',
+        'constructor',
+        '__proto__',
+        'valueOf',
+        'hasOwnProperty',
+      ]) {
+        let { core } = stub();
+        let error = await refusalFrom(() =>
+          runOperation(core, invoke(CARD, name)),
+        );
+        assert.strictEqual(
+          error.code,
+          'unknown-operation',
+          `"${name}" is not an operation`,
+        );
+      }
+    },
+
+  'a headers-only read of a file answers from the file row': async (assert) => {
+    let indexed = stub({ fileRow: true });
+    let fromRow = await runOperation(indexed.core, invoke(FILE, 'read'), {
+      headersOnly: true,
+    });
+    assert.deepEqual(fromRow, {
+      indexedAt: 1700,
+      lastModified: 1699,
+      generation: 4,
+      screenshots: null,
+      deps: null,
+    });
+    assert.strictEqual(
+      indexed.calls.filter((call) => call === 'fileMetaDocument').length,
+      0,
+      'an indexed file needs no document assembled',
+    );
+
+    // A file the realm serves but has not indexed still has a modification
+    // time to report.
+    let unindexed = stub({ fileRow: false });
+    let fromDisk = await runOperation(unindexed.core, invoke(FILE, 'read'), {
+      headersOnly: true,
+    });
+    assert.deepEqual(fromDisk, {
+      indexedAt: null,
+      lastModified: 42,
+      generation: null,
+      screenshots: null,
+      deps: null,
+    });
+  },
+
+  'a read needs an instance to read': async (assert) => {
+    let { core } = stub();
+    let onType = await refusalFrom(() =>
+      runOperation(
+        core,
+        invoke({ kind: 'type', codeRef: PERSON, realm: REALM }, 'read'),
+      ),
+    );
+    assert.strictEqual(onType.code, 'invalid-params');
+
+    let notAURL = await refusalFrom(() =>
+      runOperation(
+        core,
+        invoke({ kind: 'instance', url: 'not a url' }, 'read'),
+      ),
+    );
+    assert.strictEqual(notAURL.code, 'invalid-params');
   },
 
   'the row peek is memoized for one invocation and no longer': async (

--- a/packages/runtime-common/tests/card-operations-dispatch-test.ts
+++ b/packages/runtime-common/tests/card-operations-dispatch-test.ts
@@ -742,6 +742,82 @@ const tests = Object.freeze({
     );
   },
 
+  'both read modes answer for a file whose extension is not registered': async (
+    assert,
+  ) => {
+    // `urlNamesFile` only knows the extensions the platform maps to a file def,
+    // so a `.css`, a `.yaml` or an extensionless name reaches the card branch
+    // and misses the index. Both modes have to make the same fallback, or one
+    // path answers with a body and refuses its own headers.
+    let unregistered: OperationTarget = {
+      kind: 'instance',
+      url: `${REALM}styles.css`,
+    };
+
+    let doc = await runOperation(
+      stub({ document: 'missing', row: 'missing' }).core,
+      invoke(unregistered, 'read'),
+    );
+    assert.true(isDocumentResult(doc), 'the document mode serves the file');
+
+    let headers = await runOperation(
+      stub({ document: 'missing', row: 'missing' }).core,
+      invoke(unregistered, 'read'),
+      { headersOnly: true },
+    );
+    assert.true(isHeadResult(headers), 'and the headers mode answers too');
+    if (isHeadResult(headers)) {
+      assert.strictEqual(
+        headers.lastModified,
+        42,
+        'reporting what the file itself can say',
+      );
+      assert.strictEqual(
+        headers.indexedAt,
+        null,
+        'and nothing an index row would have carried',
+      );
+    }
+  },
+
+  'a malformed type realm is a refusal, not a raw throw': async (assert) => {
+    let { core } = stub();
+    let error = await refusalFrom(() =>
+      resolveOperation(
+        core,
+        { kind: 'type', codeRef: PERSON, realm: 'not-a-url' },
+        'create',
+      ),
+    );
+    assert.strictEqual(error.code, 'invalid-params');
+    assert.strictEqual(error.status, 400);
+  },
+
+  'a read refuses any clause it does not carry out': async (assert) => {
+    // Not only the program stages: a declaration rebound onto `read` may carry
+    // a clause belonging to the base it came from, and ignoring it is the same
+    // failure as ignoring a projection.
+    for (let clause of ['program', 'input', 'output', 'fill', 'of', 'query']) {
+      let { core } = stub({
+        operations: {
+          look: {
+            base: 'read' as const,
+            deterministic: true,
+            [clause]: clause === 'fill' ? {} : ({ x: 1 } as any),
+          } as any,
+        },
+      });
+      let error = await refusalFrom(() =>
+        runOperation(core, invoke(CARD, 'look')),
+      );
+      assert.strictEqual(
+        error.status,
+        501,
+        `a read carrying \`${clause}\` is refused rather than flattened`,
+      );
+    }
+  },
+
   'the row peek is memoized for one invocation and no longer': async (
     assert,
   ) => {


### PR DESCRIPTION
Stacked on cardstack/boxel#6050 — review that one first; this branch's base is its head, so the diff here is only this change.

## Background and Goal

The lowering PR made an operation resolvable from a card's `adoptsFrom` alone: the card's JSON names its type, and the type's definition-cache entry carries the whole lowered operation. This adds the piece that reads it — "given a target and an operation name, work out which built-in behavior it is, check the target's kind carries it, and run it."

Read side only, and nothing is routed to it. That keeps it fully additive and testable: every existing handler and suite is untouched. The write executors come next, the HTTP surfaces after that.

No card JavaScript is loaded anywhere on this path. The core gets no network capability and no `VirtualNetwork` — the realm absolutizes code refs, resolves a file's type from its extension, and canonicalizes document ids on its behalf, handing the core plain functions, because those resolutions are author-influenced and an operation runs in a trusted context.

## Where to start

- `packages/runtime-common/card-operations/dispatch.ts` — the `OperationCore` collaborators, `canonicalizeTarget`, the def-kind allowance table, then `resolveOperation` / `runOperation`.
- `packages/runtime-common/card-operations/read.ts` — the two modes, and a module header stating which parity the GET facade can rely on and which three things stay the handler's.
- `packages/runtime-common/card-operations/query.ts` — invocation-time marker substitution and the validation lowering deferred to it.
- `packages/runtime-common/card-operations/types.ts` — the invocation-time half, below the stored-shape half the previous PR added.
- `packages/runtime-common/tests/card-operations-dispatch-test.ts` — the dispatch table and the refusal taxonomy against a stubbed core.
- `packages/realm-server/tests/card-operations-core-test.ts` — the same core obtained from a real test realm, held against what the HTTP handlers serve.

## Key decisions and non-obvious mechanics

- **Cards and files both participate; what separates them is scope.** Type-scoped operations are a card's, since a file cannot be created through the core, while a file participates fully through its instance-scoped `read` — the one operation its content-derived, read-only metadata can support. A file def subclass that declares a `read` has that declaration resolved the same as a card's: a file names its type by its extension rather than in stored JSON, but the type's entry is what carries declarations either way. The extension-to-type mapping arrives from the realm as a bound function and performs no read of its own, though the definition lookup it feeds does cost one.

- **The file/card line is drawn from the target, not from the index.** `Definition.type` cannot express it (a `FileDef` descends from `BaseDef`, not `CardDef`, so its entry says `field-def`), and asking the index would make indexing a gate on dispatch rather than only on the read. The card+json GET does ask the index first, so the two orderings differ; they agree in practice because a card's id is minted from a UUID `localId` and never carries an extension.

- **A target is canonicalized before dispatch and the executor see it.** The realm root names the realm's index card, and a query string, fragment or trailing slash all name the card they hang off. The local path is derived from the target and the URL derived back from it. `runOperation` does this once and passes the result down; the executor repeats it, idempotently, so a direct caller of it addresses the same card dispatch would have. Canonicalizing in only one of them would be worse than in neither: dispatch resolves the type from the target and the executor reads from it, so the two would address different cards.

- **`<card>.json` is left alone deliberately.** It names the card's stored source, and the stored bytes of an instance are a different read from the instance — one this core does not serve yet — so the target routes as a file, where that read will live. This is the one place the read diverges from the GET handler by intent: the handler redirects that spelling to the card. It answers 404 until the stored-bytes read exists.

- **A foreign target is refused before anything reads it,** and a type target's `realm` is validated rather than handed to a URL constructor deeper in.

- **A card whose type entry is unreadable still reads.** The built-in `read` consults no definition — today's GET does zero definition lookups — so a broken module must not make its cards unreadable. A `type` target is the opposite case: a plain `create` is a question about a definition, so an unresolvable ref there is refused as a missing target, and an entry carrying neither known `type` value refuses rather than being trusted.

- **A declaration wins over the built-in of the same name.** That is how an author specializes `read` or rebinds `delete` onto `transform` for a soft delete, so the type's entry is consulted whichever name arrived — which is why dispatch costs one index-row peek the GET does not pay. What is avoidable is paying it twice, so a per-invocation memo means dispatch and the executor share one read of a row and see the same snapshot. It lives for the invocation and no longer.

- **Every wire-supplied name is looked up as an own property.** A lowered `operations` record has been through JSON, so it carries `Object.prototype` and answers `toString` / `constructor` / `__proto__` with something that is not an operation. The authoring API builds its declaration records with a null prototype for exactly this reason, and that protection does not survive the round trip. The same applies to a `params` marker keyed `__proto__`. `runOperation`'s switch carries a `default` so no path can return a non-`OperationResult`.

- **A `read` refuses every clause it does not carry out** — `program`, `input`, `output`, and the `fill` / `of` / `query` a declaration rebound onto `read` may carry from the base it came from. Serving the plain document would be a well-formed answer to a different question. The payload is validated against the definition's `params` before dispatch.

- **The document mode's *body* is byte-for-byte what the card+json GET serves** — the same canonical URL, `links.self`, prefix-form ids, freshly-joined `meta.generation` and `meta.screenshots`, the same disk-read file-meta document for a path that holds bytes, and the same status mapping for an errored index row (a real HTTP status carries through; 404 never does, since an existing-but-errored card is not "not found"; a non-HTTP failure recorded as status 0 falls back to 500). The body, not the response around it: three things stay the handler's and are named in the module header — the incremental-indexing drain, the redirects, and the 200's validator, which is computed from the assembled document's own `deps` / `indexedAt` / `screenshots` that the document result does not carry. Errored rows get their own code, `target-errored`: a recorded 403 is the caller's to act on.

- **Headers-only mode never reaches `cardDocument`.** It answers from the row peek alone, and reports `deps` alongside the validator base and the manifest, which is what the 304 decision rests on — including the foreign-realm-dependency check, since cross-realm invalidation does not cascade `indexed_at`. It does not reproduce the whole conditional-GET branch: a validator that misses still falls through to a body, and assembling that is the document mode's job. Both modes make the same fallback for a path that holds bytes, including one whose extension is not a registered file extension, so a path can never serve a body and refuse its own headers. The suite pins the no-`cardDocument` claim with a spy.

- **`skipQueryBackedExpansion` is a read option,** because a render inside a prerender request must not recurse back into the search that would resolve a query-backed field.

- **A missing row is not always a missing card.** A `.json` already on disk with no row is `target-not-indexed`, letting a caller hold a placeholder until the index event arrives. The source is parsed and required to be a single card resource, since that is what the indexer will make a row for. An ignored path is never visited, so it is plainly not found.

- **A refusal is thrown, not returned.** A batch is all-or-nothing, so the first refusal has to abandon the rest. `OperationError` is shaped like a JSON:API error object; `status` is the number the realm's own error bodies carry rather than JSON:API's string.

- **Query lowering resolves markers, then validates.** Lowering checks a declared query against the realm's grammar only where it can — a template still holding a marker stands in for a value the realm types concretely — so the rest of that check lands here, where the value is known, and runs the same parser the `_search` handler runs on the same payload. A number substituted into `matches`, or a scalar where `in` wants a list, is a refusal carrying the grammar's own reason rather than a failure in the search parser. `actor()` resolves only to the identity, `instance()` is refused since a query has no target, and a `card(…)` wrapper adds nothing around a value already being compared as an identity. An authored `realms` stands, empty included.

- **A declared `query` reaching `runOperation` is a wrong entry point, not a fault** — 400 `wrong-entry-point`. A query is resolved with `lowerQueryOperation` and run on the search engine. The four unbuilt write executors answer 501.

- **The realm's disk file-meta builder is split from its response wrapper** so the core can read that document without a `Response` around it. Pure extraction.

## Test plan

Ran locally:

- `packages/runtime-common/tests/card-operations-dispatch-test.ts` (25 cases, all passing) — driven directly through the shared-tests module rather than through the realm-server runner, which this sandbox cannot boot. The stub answers only a canonical index key, the way `getInstance` matches `i.url` / `i.file_alias`, so a target reaching the index uncanonicalized misses as it would against Postgres. Covers base-name resolution, a declaration overriding a base name, a file def declaration resolving like a card's, a declared operation resolving identically across every card spelling at one row read each, a card's source spelling routing as a file, a foreign target settling with no read at all, a malformed type realm refusing rather than throwing, both read modes answering for a file whose extension is not registered, a `read` refusing each clause it cannot carry out, the refusal taxonomy (`unknown-operation`, `operation-not-allowed`, `invalid-operation` with its findings, `invalid-params`, `target-not-found`, `target-not-indexed`), the errored-row status mapping across 403 / recorded-404 / non-HTTP, prototype-member names resolving as unknown, both headers-only branches, that an unreadable type entry still reads, and that the row memo is per invocation.
- Query lowering exercised directly: marker substitution, the `card(…)` wrapper, the authored-`realms` precedence, post-substitution grammar validation, and each refusal — missing param, `instance()`, a keyed `actor()`, an unknown marker, and a `__proto__` param key.
- The shard-assignment conventions checked for both new realm-server files, and that the shim declares exactly the shared module's test names — a shim that misses one runs it nowhere and reports nothing.
- `lint:types` clean for `runtime-common`, `realm-server` and `host`; `eslint` and `prettier` clean for every changed file.

Left to CI: `packages/realm-server/tests/card-operations-core-test.ts`. It obtains the core from a real test realm and holds `read` against what the handlers serve — the card document equals the card+json GET body, the realm root reads as the index card, the file read equals the card+json GET body for that file, the headers-only mode reaches neither `cardDocument` nor a second row read, and the refusals resolve as above. This sandbox has no Docker daemon, so Postgres and Synapse do not come up and no realm-server suite runs here at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcFB1HdBLCFQbfTMmW6MLW