### PR TITLE
Coalesce identical live federated searches behind a short-TTL cache

### DIFF
--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/service-realm-server.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/service-realm-server.json
@@ -768,7 +768,7 @@
           "type": "loki",
           "uid": "loki"
         },
-        "description": "Retained body bytes against the configured cap, worst replica (`max` across tasks). Riding near the cap alongside lifecycle `evicted` activity means the cap is throttling the hit rate.",
+        "description": "Retained body bytes against the configured cap. Both realm-server replicas emit on one Loki stream (no per-process label), so this tracks the most recently emitted summary rather than a per-replica peak — treat it as indicative, not the fleet maximum. Riding near the cap alongside lifecycle `evicted` activity means the cap is throttling the hit rate.",
         "fieldConfig": {
           "defaults": {
             "color": {

--- a/packages/observability/grafanactl/resources/dashboards/boxel-status/service-realm-server.json
+++ b/packages/observability/grafanactl/resources/dashboards/boxel-status/service-realm-server.json
@@ -24,7 +24,7 @@
         }
       ]
     },
-    "description": "Per-service deep-dive for the Realm Server ECS service. Currently stub-only — shows filtered logs from Loki. CloudWatch CPU / memory / running-task-count panels are TBD and will land when ECS cluster naming is standardized in observability config.",
+    "description": "Per-service deep-dive for the Realm Server ECS service: Loki-derived request rates, live-search-cache telemetry (the `boxel:live-search-cache` summary channel), and filtered logs. CloudWatch CPU / memory / running-task-count panels are TBD and will land when ECS cluster naming is standardized in observability config.",
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
@@ -204,12 +204,708 @@
           "type": "loki",
           "uid": "loki"
         },
+        "description": "Share of live `_federated-search` requests served without a fresh compute (TTL hits + in-flight joins) over a rolling 5m window, from the `boxel:live-search-cache` summary lines. Joins are the coalescing layer (concurrent identical requests sharing one compute) — during a search storm they should dominate. Gaps mean no live search traffic.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "percentunit",
+            "max": 1,
+            "min": 0
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 8
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "((sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap hits [5m]))) + (sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap joins [5m])))) / ((sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap hits [5m]))) + (sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap joins [5m]))) + (sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap misses [5m]))))",
+            "legendFormat": "hit+join ratio",
+            "queryType": "range",
+            "refId": "A"
+          }
+        ],
+        "title": "Live search cache — hit ratio",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "description": "Live `_federated-search` requests by cache outcome: `hit` served from the TTL window, `join` shared an identical in-flight compute, `miss` computed fresh. Counters are summed across replicas from the `boxel:live-search-cache` summary lines.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "per 5m (rolling)",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "hit"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "green"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "join"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "blue"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "miss"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "orange"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 16,
+          "x": 8,
+          "y": 8
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap hits [5m]))",
+            "legendFormat": "hit",
+            "queryType": "range",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap joins [5m]))",
+            "legendFormat": "join",
+            "queryType": "range",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap misses [5m]))",
+            "legendFormat": "miss",
+            "queryType": "range",
+            "refId": "C"
+          }
+        ],
+        "title": "Live search cache — requests by outcome",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "description": "Response bytes the cache absorbed (hit + join bytes: traffic served without recomputation — the heap/CPU pressure avoided) against bytes fresh computes produced (miss bytes).",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "per 5m (rolling)",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "bytes"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "served from cache"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "green"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "computed"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "orange"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 0,
+          "y": 16
+        },
+        "id": 12,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "(sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap hitBytes [5m]))) + (sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap joinBytes [5m])))",
+            "legendFormat": "served from cache",
+            "queryType": "range",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap missBytes [5m]))",
+            "legendFormat": "computed",
+            "queryType": "range",
+            "refId": "B"
+          }
+        ],
+        "title": "Live search cache — bytes served vs computed",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "description": "How entries leave the cache: `expired` aged out past the TTL (normal), `evicted` displaced by the byte cap (sustained values mean the cap is too small for the working set), `oversized` bodies too large to ever retain (a single huge query), `errors` failed computes.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "per 5m (rolling)",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "expired"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "green"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "evicted"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "orange"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "oversized"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "purple"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "errors"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "red"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 8,
+          "y": 16
+        },
+        "id": 13,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap expired [5m]))",
+            "legendFormat": "expired",
+            "queryType": "range",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap evicted [5m]))",
+            "legendFormat": "evicted",
+            "queryType": "range",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap oversized [5m]))",
+            "legendFormat": "oversized",
+            "queryType": "range",
+            "refId": "C"
+          },
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "sum(sum_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap errors [5m]))",
+            "legendFormat": "errors",
+            "queryType": "range",
+            "refId": "D"
+          }
+        ],
+        "title": "Live search cache — entry lifecycle",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "description": "Retained body bytes against the configured cap, worst replica (`max` across tasks). Riding near the cap alongside lifecycle `evicted` activity means the cap is throttling the hit rate.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 10,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "bytes"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "retained bytes"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "blue"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "cap"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "mode": "fixed",
+                    "fixedColor": "red"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 8,
+          "x": 16,
+          "y": 16
+        },
+        "id": 14,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "max(last_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap sizeBytes [10m]))",
+            "legendFormat": "retained bytes",
+            "queryType": "range",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "loki",
+              "uid": "loki"
+            },
+            "expr": "max(last_over_time({service=\"realm-server\"} |= \"boxel:live-search-cache\" | json | line_format \"{{ if .log }}{{ .log }}{{ else }}{{ __line__ }}{{ end }}\" | json | channel=\"boxel:live-search-cache\" | event_type=\"summary\" | __error__=\"\" | unwrap maxBytes [10m]))",
+            "legendFormat": "cap",
+            "queryType": "range",
+            "refId": "B"
+          }
+        ],
+        "title": "Live search cache — utilization",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
         "description": "Last 1000 log lines from realm-server. Drill-throughs from Overview land here.",
         "gridPos": {
           "h": 16,
           "w": 24,
           "x": 0,
-          "y": 8
+          "y": 24
         },
         "id": 1,
         "options": {

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -44,8 +44,10 @@ import {
 
 // Response header naming how the live-search cache satisfied a request:
 // `miss` (fresh compute), `join` (awaited an identical in-flight compute), or
-// `hit` (served from the TTL window). Diagnostic + test surface only — the
-// body is byte-identical across the three.
+// `hit` (served from the TTL window). Diagnostic only — the body is
+// byte-identical across the three. Added to the CORS `exposeHeaders` list
+// (server.ts) so a cross-origin browser caller can read it, not just
+// server-side supertest/curl.
 export const LIVE_SEARCH_CACHE_HEADER = 'x-boxel-live-search-cache';
 
 // The federated search: the entry wire model over every requested
@@ -59,15 +61,16 @@ export const LIVE_SEARCH_CACHE_HEADER = 'x-boxel-live-search-cache';
 export default function handleSearch(opts: {
   reconciler: RealmRegistryReconciler;
   searchCache?: JobScopedSearchCache;
-  // Enables the live-search coalescing layer: without a dbAdapter the realm
-  // generation fingerprints that keep it fresh can't be read, so live
-  // requests fall back to uncached compute.
-  dbAdapter?: DBAdapter;
+  // Reads each searched realm's generation fingerprints (the freshness signal
+  // the live-search cache keys on). Required — every route wiring passes it.
+  dbAdapter: DBAdapter;
+  // Injectable per test; when unset the handler builds one with production
+  // defaults. A test supplies a `ttlMs: 0` cache (coalescing on, retention
+  // off) to make two sequential callers each compute.
   liveSearchCache?: LiveSearchCache;
 }): (ctxt: Koa.Context) => Promise<void> {
   let { reconciler, searchCache, dbAdapter } = opts;
-  let liveSearchCache =
-    opts.liveSearchCache ?? (dbAdapter ? new LiveSearchCache() : undefined);
+  let liveSearchCache = opts.liveSearchCache ?? new LiveSearchCache();
   return async function (ctxt: Koa.Context) {
     let handlerStart = Date.now();
     let loggingCorrelationId = sanitizeLoggingCorrelationId(
@@ -242,10 +245,7 @@ export default function handleSearch(opts: {
         opts: cacheKeyOpts,
         runSearch,
         emitTimeline,
-        liveSearch:
-          liveSearchCache && dbAdapter
-            ? { cache: liveSearchCache, dbAdapter }
-            : undefined,
+        liveSearch: { cache: liveSearchCache, dbAdapter },
       });
     } catch (e) {
       // The per-request time budget fired inside `runSearch`. A bounded search

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -35,18 +35,18 @@ import { fetchRealmGenerations } from '../job-scoped-search-cache.ts';
 import type { JobScopedSearchCache } from '../job-scoped-search-cache.ts';
 import { LiveSearchCache } from '../live-search-cache.ts';
 import type { DBAdapter } from '@cardstack/runtime-common';
-
-// Response header naming how the live-search cache satisfied a request:
-// `miss` (fresh compute), `join` (awaited an identical in-flight compute), or
-// `hit` (served from the TTL window). Diagnostic + test surface only — the
-// body is byte-identical across the three.
-export const LIVE_SEARCH_CACHE_HEADER = 'x-boxel-live-search-cache';
 import {
   PRERENDER_JOB_ID_HEADER,
   PRERENDER_JOB_PRIORITY_HEADER,
   sanitizeJobPriorityHeader,
   sanitizePrerenderJobId,
 } from '../prerender/prerender-constants.ts';
+
+// Response header naming how the live-search cache satisfied a request:
+// `miss` (fresh compute), `join` (awaited an identical in-flight compute), or
+// `hit` (served from the TTL window). Diagnostic + test surface only — the
+// body is byte-identical across the three.
+export const LIVE_SEARCH_CACHE_HEADER = 'x-boxel-live-search-cache';
 
 // The federated search: the entry wire model over every requested
 // realm. Parses the entry-rooted query (the `item.` membership query,

--- a/packages/realm-server/handlers/handle-search.ts
+++ b/packages/realm-server/handlers/handle-search.ts
@@ -31,7 +31,16 @@ import {
 } from '../middleware/multi-realm-authorization.ts';
 import { resolveRealmsForFederatedRequest } from '../lib/realm-routing.ts';
 import type { RealmRegistryReconciler } from '../lib/realm-registry-reconciler.ts';
+import { fetchRealmGenerations } from '../job-scoped-search-cache.ts';
 import type { JobScopedSearchCache } from '../job-scoped-search-cache.ts';
+import { LiveSearchCache } from '../live-search-cache.ts';
+import type { DBAdapter } from '@cardstack/runtime-common';
+
+// Response header naming how the live-search cache satisfied a request:
+// `miss` (fresh compute), `join` (awaited an identical in-flight compute), or
+// `hit` (served from the TTL window). Diagnostic + test surface only — the
+// body is byte-identical across the three.
+export const LIVE_SEARCH_CACHE_HEADER = 'x-boxel-live-search-cache';
 import {
   PRERENDER_JOB_ID_HEADER,
   PRERENDER_JOB_PRIORITY_HEADER,
@@ -50,8 +59,15 @@ import {
 export default function handleSearch(opts: {
   reconciler: RealmRegistryReconciler;
   searchCache?: JobScopedSearchCache;
+  // Enables the live-search coalescing layer: without a dbAdapter the realm
+  // generation fingerprints that keep it fresh can't be read, so live
+  // requests fall back to uncached compute.
+  dbAdapter?: DBAdapter;
+  liveSearchCache?: LiveSearchCache;
 }): (ctxt: Koa.Context) => Promise<void> {
-  let { reconciler, searchCache } = opts;
+  let { reconciler, searchCache, dbAdapter } = opts;
+  let liveSearchCache =
+    opts.liveSearchCache ?? (dbAdapter ? new LiveSearchCache() : undefined);
   return async function (ctxt: Koa.Context) {
     let handlerStart = Date.now();
     let loggingCorrelationId = sanitizeLoggingCorrelationId(
@@ -226,6 +242,10 @@ export default function handleSearch(opts: {
         opts: cacheKeyOpts,
         runSearch,
         emitTimeline,
+        liveSearch:
+          liveSearchCache && dbAdapter
+            ? { cache: liveSearchCache, dbAdapter }
+            : undefined,
       });
     } catch (e) {
       // The per-request time budget fired inside `runSearch`. A bounded search
@@ -282,6 +302,7 @@ async function respondWithJobScopedSearchCache(
     opts: unknown;
     runSearch: () => Promise<string>;
     emitTimeline?: () => void;
+    liveSearch?: { cache: LiveSearchCache; dbAdapter: DBAdapter };
   },
 ): Promise<void> {
   let { searchCache, jobId, consumingRealm, realms, query, runSearch } = args;
@@ -334,6 +355,39 @@ async function respondWithJobScopedSearchCache(
         headers: {
           'content-type': SupportedMimeType.CardJson,
           ETag: expectedEtag,
+        },
+      }),
+    );
+    emitTimeline();
+    return;
+  }
+
+  // The live (non-indexer) path: coalesce identical concurrent requests and
+  // serve a short-TTL cache. The key folds in each realm's generation
+  // fingerprints — the same freshness device the job-scoped key uses above —
+  // so any index or prerendered-HTML swap on a searched realm changes the key
+  // and the next request recomputes; the TTL only bounds retention.
+  // Authorization is realm-scoped and was validated for this exact realm list
+  // by `multiRealmAuthorization` before the handler ran, so a body computed
+  // for one caller is byte-identical to what any other authorized caller
+  // would compute.
+  if (args.liveSearch) {
+    let generations = await fetchRealmGenerations(
+      args.liveSearch.dbAdapter,
+      realms,
+    );
+    let { body, outcome } = await args.liveSearch.cache.getOrPopulate({
+      realms,
+      query,
+      opts: { ...(args.opts as Record<string, unknown>), generations },
+      populate: runSearch,
+    });
+    await setContextResponse(
+      ctxt,
+      new Response(body, {
+        headers: {
+          'content-type': SupportedMimeType.CardJson,
+          [LIVE_SEARCH_CACHE_HEADER]: outcome,
         },
       }),
     );

--- a/packages/realm-server/job-scoped-search-cache.ts
+++ b/packages/realm-server/job-scoped-search-cache.ts
@@ -96,7 +96,7 @@ export class JobScopedSearchCache {
     opts: unknown | undefined;
     populate: () => Promise<string>;
   }): Promise<string> {
-    let hash = innerKeyHash(args.realms, args.query, args.opts);
+    let hash = searchRequestKeyHash(args.realms, args.query, args.opts);
     let existing = await this.#getCachedByHash(args.jobId, hash);
     if (existing !== undefined) {
       let stat = this.#stats.get(args.jobId);
@@ -143,7 +143,7 @@ export class JobScopedSearchCache {
   }): Promise<string | undefined> {
     return this.#getCachedByHash(
       args.jobId,
-      innerKeyHash(args.realms, args.query, args.opts),
+      searchRequestKeyHash(args.realms, args.query, args.opts),
     );
   }
 
@@ -215,37 +215,7 @@ export class JobScopedSearchCache {
   async realmGenerations(
     realms: string[],
   ): Promise<Record<string, { index: number; html: number }>> {
-    let out: Record<string, { index: number; html: number }> = {};
-    for (let realm of realms) {
-      out[realm] = { index: 0, html: 0 };
-    }
-    if (realms.length === 0) {
-      return out;
-    }
-    let rows = (await query(this.#dbAdapter, [
-      `SELECT rg.realm_url AS realm_url,
-              rg.current_generation AS index_generation,
-              (SELECT MAX(ph.generation) FROM prerendered_html ph
-                 WHERE ph.realm_url = rg.realm_url) AS html_generation
-         FROM realm_generations rg
-        WHERE rg.realm_url IN`,
-      ...addExplicitParens(
-        separatedByCommas(realms.map((realm) => [param(realm)])),
-      ),
-    ] as Expression)) as {
-      realm_url: string;
-      index_generation: number | string | null;
-      html_generation: number | string | null;
-    }[];
-    let toNum = (value: number | string | null): number =>
-      typeof value === 'string' ? parseInt(value) : (value ?? 0);
-    for (let row of rows) {
-      out[row.realm_url] = {
-        index: toNum(row.index_generation),
-        html: toNum(row.html_generation),
-      };
-    }
-    return out;
+    return fetchRealmGenerations(this.#dbAdapter, realms);
   }
 
   // Job-id-based weak ETag. Same `(jobId, realms, query, opts)` always produces
@@ -258,7 +228,7 @@ export class JobScopedSearchCache {
     query: Query;
     opts: unknown | undefined;
   }): string {
-    return `W/"${args.jobId}-${innerKeyHash(args.realms, args.query, args.opts)}"`;
+    return `W/"${args.jobId}-${searchRequestKeyHash(args.realms, args.query, args.opts)}"`;
   }
 
   // ── Janitor (missed-NOTIFY backstop) ──
@@ -332,12 +302,54 @@ export class JobScopedSearchCache {
   }
 }
 
-// Compose the per-job inner key and hash it. Excludes jobId since the outer
+// Standalone form of `realmGenerations` so callers without a
+// JobScopedSearchCache instance (the live-search path) read the same
+// fingerprints from the same source of truth.
+export async function fetchRealmGenerations(
+  dbAdapter: DBAdapter,
+  realms: string[],
+): Promise<Record<string, { index: number; html: number }>> {
+  let out: Record<string, { index: number; html: number }> = {};
+  for (let realm of realms) {
+    out[realm] = { index: 0, html: 0 };
+  }
+  if (realms.length === 0) {
+    return out;
+  }
+  let rows = (await query(dbAdapter, [
+    `SELECT rg.realm_url AS realm_url,
+            rg.current_generation AS index_generation,
+            (SELECT MAX(ph.generation) FROM prerendered_html ph
+               WHERE ph.realm_url = rg.realm_url) AS html_generation
+       FROM realm_generations rg
+      WHERE rg.realm_url IN`,
+    ...addExplicitParens(
+      separatedByCommas(realms.map((realm) => [param(realm)])),
+    ),
+  ] as Expression)) as {
+    realm_url: string;
+    index_generation: number | string | null;
+    html_generation: number | string | null;
+  }[];
+  let toNum = (value: number | string | null): number =>
+    typeof value === 'string' ? parseInt(value) : (value ?? 0);
+  for (let row of rows) {
+    out[row.realm_url] = {
+      index: toNum(row.index_generation),
+      html: toNum(row.html_generation),
+    };
+  }
+  return out;
+}
+
+// Compose the canonical search-request key and hash it. Shared by this
+// job-scoped cache and the live-search cache so an identical request always
+// addresses one identity. Excludes jobId since the outer
 // `job_id` column already partitions by job. The realms array is included
 // verbatim (no sort, no dedupe): `_federated-search` preserves input order in
 // its `data` array and first-occurrence `included`, so `[A, B]` and `[B, A]`
 // are different responses and must hash to different entries.
-function innerKeyHash(
+export function searchRequestKeyHash(
   realms: string[],
   query: Query,
   opts: unknown | undefined,

--- a/packages/realm-server/live-search-cache.ts
+++ b/packages/realm-server/live-search-cache.ts
@@ -1,4 +1,4 @@
-import type { Query } from '@cardstack/runtime-common';
+import { logger, type Query } from '@cardstack/runtime-common';
 import { searchRequestKeyHash } from './job-scoped-search-cache.ts';
 
 // Defaults are deliberately conservative: the TTL only needs to cover the
@@ -8,8 +8,64 @@ import { searchRequestKeyHash } from './job-scoped-search-cache.ts';
 // federated-search documents that can run to many MB each.
 const DEFAULT_TTL_MS = 5_000;
 const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
+// Floor between telemetry summary lines. Emission piggybacks on request
+// activity (see #maybeEmitTelemetry), so an idle cache emits nothing and a
+// busy one emits at most one line per interval.
+const DEFAULT_TELEMETRY_INTERVAL_MS = 30_000;
+
+export const LIVE_SEARCH_CACHE_CHANNEL = 'boxel:live-search-cache';
 
 export type LiveSearchOutcome = 'hit' | 'join' | 'miss';
+
+// One JSON-object log line per summary on the `boxel:live-search-cache`
+// channel — the same emit convention as `boxel:screenshot-perf` /
+// `boxel:client-perf`: the whole line is one JSON object with an explicit
+// `channel` field so Loki's `| json` parse reads it, every field flat and
+// top-level so LogQL can `unwrap` any of them directly.
+//
+// Counter fields are deltas over the window (`windowMs`); `entryCount` /
+// `sizeBytes` are gauges at emit time; `ttlMs` / `maxBytes` echo the
+// configuration so a dashboard can plot utilization against the cap without
+// joining deploy metadata.
+export interface LiveSearchCacheSummary {
+  event_type: 'summary';
+  windowMs: number;
+  // Request outcomes: served from the TTL window / shared an in-flight
+  // compute / computed fresh.
+  hits: number;
+  joins: number;
+  misses: number;
+  // Entry lifecycle: aged out past the TTL / displaced by the byte cap
+  // (LRU) / never retained because the body alone exceeds the whole cap.
+  expired: number;
+  evicted: number;
+  oversized: number;
+  // Failed populates (the initiating compute rejected; joiners of that
+  // compute are not double-counted).
+  errors: number;
+  // Response bytes by outcome: hitBytes + joinBytes is traffic served
+  // without recomputation; missBytes is what fresh computes produced.
+  hitBytes: number;
+  joinBytes: number;
+  missBytes: number;
+  entryCount: number;
+  sizeBytes: number;
+  ttlMs: number;
+  maxBytes: number;
+}
+
+type LiveSearchCounters = {
+  hits: number;
+  joins: number;
+  misses: number;
+  expired: number;
+  evicted: number;
+  oversized: number;
+  errors: number;
+  hitBytes: number;
+  joinBytes: number;
+  missBytes: number;
+};
 
 // Explicit constructor option first (0 is a real value — it disables
 // retention), then the env var when it parses as a number, then the default.
@@ -62,23 +118,45 @@ function configNumber(
 // callers would have received the same degraded body from their own compute
 // moments earlier; the short TTL bounds the recovery lag.
 //
-// No timers: expired entries are reaped lazily on each call and during
-// cap eviction, so the cache needs no teardown hook and can't leak handles
-// in tests. Idle retention is bounded by the byte cap and reclaimed on the
-// next call.
+// No timers: expired entries are reaped lazily on each call and during cap
+// eviction, and telemetry emission rides request activity, so the cache
+// needs no teardown hook and can't leak handles in tests. Idle retention is
+// bounded by the byte cap and reclaimed on the next call.
 export class LiveSearchCache {
   readonly #ttlMs: number;
   readonly #maxBytes: number;
+  readonly #telemetryIntervalMs: number;
+  readonly #emitTelemetry: (summary: LiveSearchCacheSummary) => void;
   #inFlight = new Map<string, Promise<string>>();
   // Insertion order is recency order: hits re-insert their entry, so the
   // head of the map is always the least-recently-used entry.
   #entries = new Map<string, { body: string; expiresAt: number }>();
   #totalBytes = 0;
-  #hits = 0;
-  #joins = 0;
-  #misses = 0;
+  // Cumulative counters (never reset — `stats` exposes them raw; telemetry
+  // emits per-window deltas against #lastEmitted).
+  #counters: LiveSearchCounters = {
+    hits: 0,
+    joins: 0,
+    misses: 0,
+    expired: 0,
+    evicted: 0,
+    oversized: 0,
+    errors: 0,
+    hitBytes: 0,
+    joinBytes: 0,
+    missBytes: 0,
+  };
+  #lastEmitted = { ...this.#counters };
+  #lastEmitAt = Date.now();
 
-  constructor(opts?: { ttlMs?: number; maxBytes?: number }) {
+  constructor(opts?: {
+    ttlMs?: number;
+    maxBytes?: number;
+    // Floor between telemetry summaries; 0 disables emission.
+    telemetryIntervalMs?: number;
+    // Test seam: when set, summaries go here instead of the logger.
+    emitTelemetry?: (summary: LiveSearchCacheSummary) => void;
+  }) {
     this.#ttlMs = configNumber(
       opts?.ttlMs,
       'LIVE_SEARCH_CACHE_TTL_MS',
@@ -89,9 +167,28 @@ export class LiveSearchCache {
       'LIVE_SEARCH_CACHE_MAX_BYTES',
       DEFAULT_MAX_BYTES,
     );
+    this.#telemetryIntervalMs = configNumber(
+      opts?.telemetryIntervalMs,
+      'LIVE_SEARCH_CACHE_TELEMETRY_INTERVAL_MS',
+      DEFAULT_TELEMETRY_INTERVAL_MS,
+    );
+    this.#emitTelemetry = opts?.emitTelemetry ?? defaultEmitTelemetry;
   }
 
   async getOrPopulate(args: {
+    realms: string[];
+    query: Query;
+    opts: unknown | undefined;
+    populate: () => Promise<string>;
+  }): Promise<{ body: string; outcome: LiveSearchOutcome }> {
+    try {
+      return await this.#getOrPopulate(args);
+    } finally {
+      this.#maybeEmitTelemetry();
+    }
+  }
+
+  async #getOrPopulate(args: {
     realms: string[];
     query: Query;
     opts: unknown | undefined;
@@ -107,25 +204,35 @@ export class LiveSearchCache {
         // eviction (head-first) takes the least-recently-used entry first.
         this.#entries.delete(key);
         this.#entries.set(key, entry);
-        this.#hits += 1;
+        this.#counters.hits += 1;
+        this.#counters.hitBytes += entry.body.length;
         return { body: entry.body, outcome: 'hit' };
       }
       this.#delete(key, entry);
+      this.#counters.expired += 1;
     }
 
     let inFlight = this.#inFlight.get(key);
     if (inFlight) {
-      this.#joins += 1;
-      return { body: await inFlight, outcome: 'join' };
+      this.#counters.joins += 1;
+      let body = await inFlight;
+      this.#counters.joinBytes += body.length;
+      return { body, outcome: 'join' };
     }
 
     let promise = args.populate();
     this.#inFlight.set(key, promise);
     try {
       let body = await promise;
-      this.#misses += 1;
+      this.#counters.misses += 1;
+      this.#counters.missBytes += body.length;
       this.#store(key, body);
       return { body, outcome: 'miss' };
+    } catch (e) {
+      // Counted once per failed compute; joiners awaiting the same promise
+      // reject too but are not the compute.
+      this.#counters.errors += 1;
+      throw e;
     } finally {
       // Delete on rejection too: a failed populate must not pin the key, or
       // every retry would join a dead promise.
@@ -140,13 +247,18 @@ export class LiveSearchCache {
     hits: number;
     joins: number;
     misses: number;
+    expired: number;
+    evicted: number;
+    oversized: number;
+    errors: number;
+    hitBytes: number;
+    joinBytes: number;
+    missBytes: number;
     entryCount: number;
     sizeBytes: number;
   } {
     return {
-      hits: this.#hits,
-      joins: this.#joins,
-      misses: this.#misses,
+      ...this.#counters,
       entryCount: this.#entries.size,
       sizeBytes: this.#totalBytes,
     };
@@ -156,7 +268,11 @@ export class LiveSearchCache {
     // ttl 0 disables retention entirely (coalescing still applies); a body
     // larger than the whole cap can never fit and would only evict
     // everything else on its way through.
-    if (this.#ttlMs === 0 || body.length > this.#maxBytes) {
+    if (this.#ttlMs === 0) {
+      return;
+    }
+    if (body.length > this.#maxBytes) {
+      this.#counters.oversized += 1;
       return;
     }
     this.#entries.set(key, { body, expiresAt: Date.now() + this.#ttlMs });
@@ -170,8 +286,9 @@ export class LiveSearchCache {
   }
 
   // Drop expired entries from the head of the map. Recency re-insertion
-  // means the head holds the oldest entries, so this stops at the first
-  // live one — O(expired) per call, not O(entries).
+  // means the head holds the least-recently-used entries; an expired entry
+  // behind a live one (possible, since a hit re-inserts with its original
+  // expiry) is caught on its own access or by the cap-eviction scan instead.
   #reapExpiredHead(): void {
     let now = Date.now();
     for (let [key, entry] of this.#entries) {
@@ -179,6 +296,7 @@ export class LiveSearchCache {
         break;
       }
       this.#delete(key, entry);
+      this.#counters.expired += 1;
     }
   }
 
@@ -192,6 +310,7 @@ export class LiveSearchCache {
     for (let [key, entry] of this.#entries) {
       if (entry.expiresAt <= now) {
         this.#delete(key, entry);
+        this.#counters.expired += 1;
       }
     }
     for (let [key, entry] of this.#entries) {
@@ -199,6 +318,58 @@ export class LiveSearchCache {
         break;
       }
       this.#delete(key, entry);
+      this.#counters.evicted += 1;
     }
   }
+
+  // Telemetry rides request activity rather than a timer: after each call,
+  // emit one summary line when at least the configured interval has passed
+  // since the last one and the window saw any activity. A burst that ends
+  // leaves its tail counted-but-unemitted until the next request — deltas
+  // are cumulative so nothing is lost, only deferred; during any load worth
+  // dashboarding, traffic is continuous and the line lands each interval.
+  #maybeEmitTelemetry(): void {
+    if (this.#telemetryIntervalMs === 0) {
+      return;
+    }
+    let now = Date.now();
+    let windowMs = now - this.#lastEmitAt;
+    if (windowMs < this.#telemetryIntervalMs) {
+      return;
+    }
+    let deltas = {} as LiveSearchCounters;
+    let activity = 0;
+    for (let name of Object.keys(this.#counters) as Array<
+      keyof LiveSearchCounters
+    >) {
+      deltas[name] = this.#counters[name] - this.#lastEmitted[name];
+      activity += deltas[name];
+    }
+    if (activity === 0) {
+      // Nothing happened; slide the window rather than emit an empty line.
+      this.#lastEmitAt = now;
+      return;
+    }
+    this.#lastEmitted = { ...this.#counters };
+    this.#lastEmitAt = now;
+    this.#emitTelemetry({
+      event_type: 'summary',
+      windowMs,
+      ...deltas,
+      entryCount: this.#entries.size,
+      sizeBytes: this.#totalBytes,
+      ttlMs: this.#ttlMs,
+      maxBytes: this.#maxBytes,
+    });
+  }
+}
+
+// Created lazily: a module-scope `logger()` call can race the circular
+// import that installs the logger factory (the same hazard
+// `emitSearchTiming` documents).
+let liveSearchCacheLog: ReturnType<typeof logger> | undefined;
+function defaultEmitTelemetry(summary: LiveSearchCacheSummary): void {
+  (liveSearchCacheLog ??= logger(LIVE_SEARCH_CACHE_CHANNEL)).info(
+    JSON.stringify({ channel: LIVE_SEARCH_CACHE_CHANNEL, ...summary }),
+  );
 }

--- a/packages/realm-server/live-search-cache.ts
+++ b/packages/realm-server/live-search-cache.ts
@@ -1,0 +1,204 @@
+import type { Query } from '@cardstack/runtime-common';
+import { searchRequestKeyHash } from './job-scoped-search-cache.ts';
+
+// Defaults are deliberately conservative: the TTL only needs to cover the
+// window in which a burst of clients issues the same query (an index event
+// fanning out to every subscribed browser), and the byte cap bounds how much
+// heap the cache can hold at its worst — entry bodies are fully-assembled
+// federated-search documents that can run to many MB each.
+const DEFAULT_TTL_MS = 5_000;
+const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
+
+export type LiveSearchOutcome = 'hit' | 'join' | 'miss';
+
+// Explicit constructor option first (0 is a real value — it disables
+// retention), then the env var when it parses as a number, then the default.
+function configNumber(
+  explicit: number | undefined,
+  envName: string,
+  fallback: number,
+): number {
+  if (explicit !== undefined) {
+    return Math.max(0, explicit);
+  }
+  let raw = process.env[envName];
+  if (raw !== undefined && raw.trim() !== '' && !Number.isNaN(Number(raw))) {
+    return Math.max(0, Number(raw));
+  }
+  return fallback;
+}
+
+// Per-process coalescing + short-TTL cache for LIVE `_federated-search`
+// requests — the callers the job-scoped cache deliberately excludes (no
+// `x-boxel-job-id`). Live searches are dominated by many clients rendering
+// the same cards: their queries are byte-identical, and every incremental
+// index event makes every subscribed client re-issue them at once. Without
+// this layer each of those requests runs its own SQL + `loadLinks` assembly
+// and stringifies its own multi-MB document — concurrent identical requests
+// scale heap linearly and have OOM'd the realm-server in production.
+//
+// Two layers, both keyed on the same canonical `(realms, query, opts)` hash
+// the job-scoped cache uses:
+//
+//   1. In-flight coalescing: concurrent identical requests await one
+//      `populate` and share the resolved body string. Always on — sharing a
+//      computation that is already running retains nothing extra.
+//   2. TTL cache: the resolved body is kept for a short window so near-miss
+//      stragglers (clients whose re-run lands just after the first resolves)
+//      also share it. Freshness is structural, not temporal: the caller folds
+//      each realm's generation fingerprint into `opts`, so any index or
+//      prerendered-HTML swap on a searched realm changes the key and the
+//      next request recomputes. The TTL exists to bound retention, not to
+//      bound staleness.
+//
+// Sharing across users is safe: the body is a pure function of
+// `(realms, query, opts)` — permissions are realm-scoped and
+// `multiRealmAuthorization` has already validated every caller against the
+// full realm list before the handler runs.
+//
+// One deliberate looseness: `_federated-search` drops a realm that fails to
+// mount rather than failing the whole request, so a body computed during a
+// transient per-realm failure can be served to TTL-window stragglers. Those
+// callers would have received the same degraded body from their own compute
+// moments earlier; the short TTL bounds the recovery lag.
+//
+// No timers: expired entries are reaped lazily on each call and during
+// cap eviction, so the cache needs no teardown hook and can't leak handles
+// in tests. Idle retention is bounded by the byte cap and reclaimed on the
+// next call.
+export class LiveSearchCache {
+  readonly #ttlMs: number;
+  readonly #maxBytes: number;
+  #inFlight = new Map<string, Promise<string>>();
+  // Insertion order is recency order: hits re-insert their entry, so the
+  // head of the map is always the least-recently-used entry.
+  #entries = new Map<string, { body: string; expiresAt: number }>();
+  #totalBytes = 0;
+  #hits = 0;
+  #joins = 0;
+  #misses = 0;
+
+  constructor(opts?: { ttlMs?: number; maxBytes?: number }) {
+    this.#ttlMs = configNumber(
+      opts?.ttlMs,
+      'LIVE_SEARCH_CACHE_TTL_MS',
+      DEFAULT_TTL_MS,
+    );
+    this.#maxBytes = configNumber(
+      opts?.maxBytes,
+      'LIVE_SEARCH_CACHE_MAX_BYTES',
+      DEFAULT_MAX_BYTES,
+    );
+  }
+
+  async getOrPopulate(args: {
+    realms: string[];
+    query: Query;
+    opts: unknown | undefined;
+    populate: () => Promise<string>;
+  }): Promise<{ body: string; outcome: LiveSearchOutcome }> {
+    this.#reapExpiredHead();
+    let key = searchRequestKeyHash(args.realms, args.query, args.opts);
+
+    let entry = this.#entries.get(key);
+    if (entry) {
+      if (entry.expiresAt > Date.now()) {
+        // Refresh recency: re-insert so this entry moves to the tail and cap
+        // eviction (head-first) takes the least-recently-used entry first.
+        this.#entries.delete(key);
+        this.#entries.set(key, entry);
+        this.#hits += 1;
+        return { body: entry.body, outcome: 'hit' };
+      }
+      this.#delete(key, entry);
+    }
+
+    let inFlight = this.#inFlight.get(key);
+    if (inFlight) {
+      this.#joins += 1;
+      return { body: await inFlight, outcome: 'join' };
+    }
+
+    let promise = args.populate();
+    this.#inFlight.set(key, promise);
+    try {
+      let body = await promise;
+      this.#misses += 1;
+      this.#store(key, body);
+      return { body, outcome: 'miss' };
+    } finally {
+      // Delete on rejection too: a failed populate must not pin the key, or
+      // every retry would join a dead promise.
+      this.#inFlight.delete(key);
+    }
+  }
+
+  // Observability for tests and debugging. `sizeBytes` approximates heap
+  // cost by string length — federated-search bodies are JSON and thus
+  // overwhelmingly single-byte characters.
+  get stats(): {
+    hits: number;
+    joins: number;
+    misses: number;
+    entryCount: number;
+    sizeBytes: number;
+  } {
+    return {
+      hits: this.#hits,
+      joins: this.#joins,
+      misses: this.#misses,
+      entryCount: this.#entries.size,
+      sizeBytes: this.#totalBytes,
+    };
+  }
+
+  #store(key: string, body: string): void {
+    // ttl 0 disables retention entirely (coalescing still applies); a body
+    // larger than the whole cap can never fit and would only evict
+    // everything else on its way through.
+    if (this.#ttlMs === 0 || body.length > this.#maxBytes) {
+      return;
+    }
+    this.#entries.set(key, { body, expiresAt: Date.now() + this.#ttlMs });
+    this.#totalBytes += body.length;
+    this.#evictOverCap();
+  }
+
+  #delete(key: string, entry: { body: string }): void {
+    this.#entries.delete(key);
+    this.#totalBytes -= entry.body.length;
+  }
+
+  // Drop expired entries from the head of the map. Recency re-insertion
+  // means the head holds the oldest entries, so this stops at the first
+  // live one — O(expired) per call, not O(entries).
+  #reapExpiredHead(): void {
+    let now = Date.now();
+    for (let [key, entry] of this.#entries) {
+      if (entry.expiresAt > now) {
+        break;
+      }
+      this.#delete(key, entry);
+    }
+  }
+
+  #evictOverCap(): void {
+    if (this.#totalBytes <= this.#maxBytes) {
+      return;
+    }
+    // Reclaim expired entries anywhere in the map first, then take
+    // least-recently-used from the head.
+    let now = Date.now();
+    for (let [key, entry] of this.#entries) {
+      if (entry.expiresAt <= now) {
+        this.#delete(key, entry);
+      }
+    }
+    for (let [key, entry] of this.#entries) {
+      if (this.#totalBytes <= this.#maxBytes) {
+        break;
+      }
+      this.#delete(key, entry);
+    }
+  }
+}

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -55,6 +55,7 @@ import handleUnlistedRealmPathRequest from './handlers/handle-unlisted-realm-pat
 import handlePrerenderProxy from './handlers/handle-prerender-proxy.ts';
 import handleSearch from './handlers/handle-search.ts';
 import type { JobScopedSearchCache } from './job-scoped-search-cache.ts';
+import type { LiveSearchCache } from './live-search-cache.ts';
 import handleRealmIndexCounts from './handlers/handle-realm-index-counts.ts';
 import handleRealmInfo from './handlers/handle-realm-info.ts';
 import handleFederatedTypes from './handlers/handle-federated-types.ts';
@@ -137,6 +138,11 @@ export type CreateRoutesArgs = {
   // once the new code is live and the service is stable.
   reportHostShell?: () => Promise<void>;
   searchCache: JobScopedSearchCache;
+  // Per-process coalescing + short-TTL cache for live `_federated-search`
+  // traffic. Injectable so a test can supply one configured with `ttlMs: 0`
+  // (coalescing on, retention off) to force each caller to compute; when
+  // unset the handler constructs its own with production defaults.
+  liveSearchCache?: LiveSearchCache;
 };
 
 export function createRoutes(args: CreateRoutesArgs) {
@@ -242,6 +248,7 @@ export function createRoutes(args: CreateRoutesArgs) {
       reconciler: args.reconciler,
       searchCache,
       dbAdapter: args.dbAdapter,
+      liveSearchCache: args.liveSearchCache,
     }),
   );
   router.all(

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -238,7 +238,11 @@ export function createRoutes(args: CreateRoutesArgs) {
   router.all(
     '/_federated-search',
     multiRealmAuthorization(args),
-    handleSearch({ reconciler: args.reconciler, searchCache }),
+    handleSearch({
+      reconciler: args.reconciler,
+      searchCache,
+      dbAdapter: args.dbAdapter,
+    }),
   );
   router.all(
     '/_federated-info',

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -32,6 +32,7 @@ import * as Sentry from '@sentry/node';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { createRoutes } from './routes.ts';
 import { JobScopedSearchCache } from './job-scoped-search-cache.ts';
+import type { LiveSearchCache } from './live-search-cache.ts';
 import { createSendEvent } from './handlers/send-event.ts';
 import { createServeFromRealm } from './handlers/serve-from-realm.ts';
 import { createServeIndex } from './handlers/serve-index.ts';
@@ -679,6 +680,7 @@ export class RealmServer {
   private reportHostShell: (() => Promise<void>) | undefined;
   private reconciler: RealmRegistryReconciler;
   private searchCache: JobScopedSearchCache;
+  private liveSearchCache: LiveSearchCache | undefined;
   private cachedApp: ReturnType<RealmServer['buildApp']> | undefined;
 
   constructor({
@@ -706,6 +708,7 @@ export class RealmServer {
     prerenderer,
     reportHostShell,
     searchCache,
+    liveSearchCache,
   }: {
     serverURL: URL;
     realms: Realm[];
@@ -743,6 +746,10 @@ export class RealmServer {
     // private cache for free. main.ts passes a shared instance so the
     // JobsFinishedListener can evict the same cache the handlers populate.
     searchCache?: JobScopedSearchCache;
+    // Optional live-search cache. When unset the handler builds one with
+    // production defaults; a test injects one configured with `ttlMs: 0`
+    // (coalescing on, retention off) to force each caller to compute.
+    liveSearchCache?: LiveSearchCache;
   }) {
     if (!matrixRegistrationSecret && !getRegistrationSecret) {
       throw new Error(
@@ -793,6 +800,7 @@ export class RealmServer {
     this.prerenderer = prerenderer;
     this.reportHostShell = reportHostShell;
     this.searchCache = searchCache ?? new JobScopedSearchCache(dbAdapter);
+    this.liveSearchCache = liveSearchCache;
   }
 
   get app() {
@@ -852,8 +860,12 @@ export class RealmServer {
           // Content-Range/Accept-Ranges are what a cross-origin caller needs
           // to reason about a 206 byte-range response (Content-Length is
           // safelisted, but is listed for symmetry with the range pair).
+          // X-Boxel-Live-Search-Cache names how the live-search cache served a
+          // `_federated-search` response (miss/join/hit); expose it so the
+          // outcome is legible to a browser caller (host DevTools, client
+          // telemetry), not just to server-side supertest/curl.
           exposeHeaders:
-            'ETag, Location, Retry-After, Content-Range, Accept-Ranges, Content-Length',
+            'ETag, Location, Retry-After, Content-Range, Accept-Ranges, Content-Length, X-Boxel-Live-Search-Cache',
           allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS,QUERY',
           // Cache the preflight response for 24 h. Without this @koa/cors
           // omits Access-Control-Max-Age and Chrome falls back to its
@@ -914,6 +926,7 @@ export class RealmServer {
           reportHostShell: this.reportHostShell,
           reconciler: this.reconciler,
           searchCache: this.searchCache,
+          liveSearchCache: this.liveSearchCache,
         }),
       )
       .use(

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -56,6 +56,7 @@ import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms.t
 import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
 import { getLocalConfig as getSynapseConfig } from '../../synapse.ts';
 import { RealmServer } from '../../server.ts';
+import type { LiveSearchCache } from '../../live-search-cache.ts';
 import jsonwebtoken from 'jsonwebtoken';
 const { sign: jwtSign } = jsonwebtoken;
 import {
@@ -1583,6 +1584,7 @@ export async function runTestRealmServerWithRealms({
     boxelSite: 'localhost',
   },
   prerenderer: providedPrerenderer,
+  liveSearchCache,
 }: {
   realmsRootPath: string;
   realms: {
@@ -1602,6 +1604,9 @@ export async function runTestRealmServerWithRealms({
     boxelSite?: string;
   };
   prerenderer?: Prerenderer;
+  // Inject a cache configured for the test (e.g. `ttlMs: 0` to keep
+  // coalescing but disable retention). Omit for the production default.
+  liveSearchCache?: LiveSearchCache;
 }) {
   stripTlsEnvVars();
   ensureDirSync(realmsRootPath);
@@ -1690,6 +1695,7 @@ export async function runTestRealmServerWithRealms({
     domainsForPublishedRealms,
     definitionLookup,
     prerenderer,
+    liveSearchCache,
   });
   let testRealmHttpServer = await awaitListening(
     testRealmServer.listen(parseInt(serverURL.port)),

--- a/packages/realm-server/tests/live-search-cache-test.ts
+++ b/packages/realm-server/tests/live-search-cache-test.ts
@@ -1,0 +1,267 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import type { Query } from '@cardstack/runtime-common';
+import { LiveSearchCache } from '../live-search-cache.ts';
+
+function personQuery(name = 'Person'): Query {
+  return {
+    filter: { type: { module: 'http://example.com/person', name } },
+  } as Query;
+}
+
+// A populate whose resolution the test controls, so concurrency windows are
+// deterministic rather than raced against real work.
+function deferredPopulate(body: string) {
+  let resolve!: (value: string) => void;
+  let reject!: (reason: unknown) => void;
+  let calls = 0;
+  let promise = new Promise<string>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {
+    populate: () => {
+      calls++;
+      return promise;
+    },
+    resolve: () => resolve(body),
+    reject: (reason: unknown) => reject(reason),
+    get calls() {
+      return calls;
+    },
+  };
+}
+
+function sleep(ms: number) {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+module(basename(import.meta.filename), function () {
+  test('concurrent identical requests share one populate', async function (assert) {
+    let cache = new LiveSearchCache({ ttlMs: 60_000 });
+    let deferred = deferredPopulate('{"data":[1]}');
+    let realms = ['http://a/'];
+
+    let first = cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: deferred.populate,
+    });
+    let second = cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: deferred.populate,
+    });
+    deferred.resolve();
+    let [a, b] = await Promise.all([first, second]);
+
+    assert.strictEqual(deferred.calls, 1, 'populate ran once');
+    assert.strictEqual(a.outcome, 'miss');
+    assert.strictEqual(b.outcome, 'join');
+    assert.strictEqual(a.body, b.body, 'both callers share the body');
+  });
+
+  test('different queries do not coalesce', async function (assert) {
+    let cache = new LiveSearchCache({ ttlMs: 60_000 });
+    let realms = ['http://a/'];
+    let calls = 0;
+    let populate = async () => {
+      calls++;
+      return `{"n":${calls}}`;
+    };
+
+    let [a, b] = await Promise.all([
+      cache.getOrPopulate({
+        realms,
+        query: personQuery('Person'),
+        opts: undefined,
+        populate,
+      }),
+      cache.getOrPopulate({
+        realms,
+        query: personQuery('Pet'),
+        opts: undefined,
+        populate,
+      }),
+    ]);
+    assert.strictEqual(calls, 2, 'each distinct query computes');
+    assert.strictEqual(a.outcome, 'miss');
+    assert.strictEqual(b.outcome, 'miss');
+  });
+
+  test('a body is served from cache within the TTL and recomputed after it', async function (assert) {
+    let cache = new LiveSearchCache({ ttlMs: 50 });
+    let realms = ['http://a/'];
+    let calls = 0;
+    let populate = async () => {
+      calls++;
+      return `{"n":${calls}}`;
+    };
+    let args = () => ({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate,
+    });
+
+    let first = await cache.getOrPopulate(args());
+    let second = await cache.getOrPopulate(args());
+    assert.strictEqual(first.outcome, 'miss');
+    assert.strictEqual(second.outcome, 'hit');
+    assert.strictEqual(second.body, first.body);
+    assert.strictEqual(calls, 1);
+
+    await sleep(80);
+    let third = await cache.getOrPopulate(args());
+    assert.strictEqual(third.outcome, 'miss', 'expired entry recomputes');
+    assert.strictEqual(calls, 2);
+  });
+
+  test('ttl 0 disables retention but still coalesces in-flight requests', async function (assert) {
+    let cache = new LiveSearchCache({ ttlMs: 0 });
+    let realms = ['http://a/'];
+    let deferred = deferredPopulate('{"data":[]}');
+
+    let first = cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: deferred.populate,
+    });
+    let second = cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: deferred.populate,
+    });
+    deferred.resolve();
+    let [a, b] = await Promise.all([first, second]);
+    assert.strictEqual(a.outcome, 'miss');
+    assert.strictEqual(b.outcome, 'join', 'coalescing still applies');
+
+    let calls = 0;
+    let third = await cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: async () => {
+        calls++;
+        return '{"data":[]}';
+      },
+    });
+    assert.strictEqual(third.outcome, 'miss', 'nothing was retained');
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(cache.stats.entryCount, 0);
+  });
+
+  test('changed realm generations in opts address a different entry', async function (assert) {
+    let cache = new LiveSearchCache({ ttlMs: 60_000 });
+    let realms = ['http://a/'];
+    let calls = 0;
+    let populate = async () => {
+      calls++;
+      return `{"n":${calls}}`;
+    };
+    let argsAtGeneration = (index: number) => ({
+      realms,
+      query: personQuery(),
+      opts: { generations: { 'http://a/': { index, html: 0 } } },
+      populate,
+    });
+
+    let before = await cache.getOrPopulate(argsAtGeneration(1));
+    let after = await cache.getOrPopulate(argsAtGeneration(2));
+    assert.strictEqual(before.outcome, 'miss');
+    assert.strictEqual(
+      after.outcome,
+      'miss',
+      'a generation bump busts the entry',
+    );
+    assert.strictEqual(calls, 2);
+    assert.notStrictEqual(after.body, before.body);
+  });
+
+  test('a rejected populate propagates to every waiter and is not retained', async function (assert) {
+    let cache = new LiveSearchCache({ ttlMs: 60_000 });
+    let realms = ['http://a/'];
+    let deferred = deferredPopulate('unused');
+
+    let first = cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: deferred.populate,
+    });
+    let second = cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: deferred.populate,
+    });
+    deferred.reject(new Error('search blew up'));
+    for (let promise of [first, second]) {
+      try {
+        await promise;
+        assert.ok(false, 'should have rejected');
+      } catch (e: unknown) {
+        assert.strictEqual((e as Error).message, 'search blew up');
+      }
+    }
+
+    let retry = await cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: async () => '{"data":[]}',
+    });
+    assert.strictEqual(
+      retry.outcome,
+      'miss',
+      'the failed key recomputes rather than joining a dead promise',
+    );
+  });
+
+  test('the byte cap evicts least-recently-used entries', async function (assert) {
+    // Each body is 10 chars; cap of 25 holds two entries, not three.
+    let cache = new LiveSearchCache({ ttlMs: 60_000, maxBytes: 25 });
+    let realms = ['http://a/'];
+    let body = '0123456789';
+    let load = (name: string) =>
+      cache.getOrPopulate({
+        realms,
+        query: personQuery(name),
+        opts: undefined,
+        populate: async () => body,
+      });
+
+    await load('A');
+    await load('B');
+    // Touch A so B is the least-recently-used entry when C arrives.
+    let touched = await load('A');
+    assert.strictEqual(touched.outcome, 'hit');
+
+    await load('C');
+    assert.strictEqual(cache.stats.entryCount, 2, 'cap held two entries');
+    assert.strictEqual((await load('A')).outcome, 'hit', 'A survived');
+    assert.strictEqual((await load('C')).outcome, 'hit', 'C survived');
+    assert.strictEqual((await load('B')).outcome, 'miss', 'B was evicted');
+  });
+
+  test('a body larger than the whole cap is served but never retained', async function (assert) {
+    let cache = new LiveSearchCache({ ttlMs: 60_000, maxBytes: 5 });
+    let realms = ['http://a/'];
+    let result = await cache.getOrPopulate({
+      realms,
+      query: personQuery(),
+      opts: undefined,
+      populate: async () => 'a-body-larger-than-the-cap',
+    });
+    assert.strictEqual(result.outcome, 'miss');
+    assert.strictEqual(result.body, 'a-body-larger-than-the-cap');
+    assert.strictEqual(cache.stats.entryCount, 0);
+    assert.strictEqual(cache.stats.sizeBytes, 0);
+  });
+});

--- a/packages/realm-server/tests/live-search-cache-test.ts
+++ b/packages/realm-server/tests/live-search-cache-test.ts
@@ -2,7 +2,10 @@ import QUnit from 'qunit';
 const { module, test } = QUnit;
 import { basename } from 'path';
 import type { Query } from '@cardstack/runtime-common';
-import { LiveSearchCache } from '../live-search-cache.ts';
+import {
+  LiveSearchCache,
+  type LiveSearchCacheSummary,
+} from '../live-search-cache.ts';
 
 function personQuery(name = 'Person'): Query {
   return {
@@ -263,5 +266,122 @@ module(basename(import.meta.filename), function () {
     assert.strictEqual(result.body, 'a-body-larger-than-the-cap');
     assert.strictEqual(cache.stats.entryCount, 0);
     assert.strictEqual(cache.stats.sizeBytes, 0);
+    assert.strictEqual(cache.stats.oversized, 1, 'the skip is counted');
+  });
+
+  test('lifecycle counters attribute expiry, eviction, and errors separately', async function (assert) {
+    let cache = new LiveSearchCache({ ttlMs: 50, maxBytes: 25 });
+    let realms = ['http://a/'];
+    let load = (name: string) =>
+      cache.getOrPopulate({
+        realms,
+        query: personQuery(name),
+        opts: undefined,
+        populate: async () => '0123456789',
+      });
+
+    // Three 10-char bodies against a 25-char cap: C's arrival evicts A (LRU).
+    await load('A');
+    await load('B');
+    await load('C');
+    assert.strictEqual(cache.stats.evicted, 1, 'cap displacement is evicted');
+    assert.strictEqual(cache.stats.expired, 0);
+
+    // Aging out and re-requesting counts as expired, not evicted.
+    await sleep(80);
+    await load('B');
+    assert.ok(
+      cache.stats.expired >= 1,
+      `aged-out entries count as expired (saw ${cache.stats.expired})`,
+    );
+    assert.strictEqual(cache.stats.evicted, 1, 'evicted is unchanged');
+
+    // A failed compute is one error, regardless of joiner count.
+    let deferred = deferredPopulate('unused');
+    let attempts = [
+      cache.getOrPopulate({
+        realms,
+        query: personQuery('D'),
+        opts: undefined,
+        populate: deferred.populate,
+      }),
+      cache.getOrPopulate({
+        realms,
+        query: personQuery('D'),
+        opts: undefined,
+        populate: deferred.populate,
+      }),
+    ];
+    deferred.reject(new Error('boom'));
+    for (let attempt of attempts) {
+      await attempt.catch(() => {});
+    }
+    assert.strictEqual(cache.stats.errors, 1, 'one error per failed compute');
+  });
+
+  test('telemetry summarizes window deltas once per interval', async function (assert) {
+    let summaries: LiveSearchCacheSummary[] = [];
+    let cache = new LiveSearchCache({
+      ttlMs: 60_000,
+      telemetryIntervalMs: 200,
+      emitTelemetry: (summary) => summaries.push(summary),
+    });
+    let realms = ['http://a/'];
+    let body = '{"data":[]}';
+    let load = () =>
+      cache.getOrPopulate({
+        realms,
+        query: personQuery(),
+        opts: undefined,
+        populate: async () => body,
+      });
+
+    await load(); // miss
+    await load(); // hit — within the interval, so nothing emits yet
+    assert.strictEqual(summaries.length, 0, 'the floor interval holds');
+
+    await sleep(250);
+    await load(); // hit — crosses the interval, emitting the whole window
+    assert.strictEqual(summaries.length, 1, 'one summary per interval');
+    let [summary] = summaries;
+    assert.strictEqual(summary.event_type, 'summary');
+    assert.strictEqual(summary.misses, 1);
+    assert.strictEqual(summary.hits, 2);
+    assert.strictEqual(summary.missBytes, body.length);
+    assert.strictEqual(summary.hitBytes, body.length * 2);
+    assert.ok(summary.windowMs >= 200, 'the window spans the interval');
+    assert.strictEqual(summary.entryCount, 1);
+    assert.strictEqual(summary.sizeBytes, body.length);
+    assert.strictEqual(summary.ttlMs, 60_000, 'config echoes on the line');
+
+    // The next window's deltas start from zero.
+    await sleep(250);
+    await load(); // hit
+    assert.strictEqual(summaries.length, 2);
+    assert.strictEqual(summaries[1].hits, 1, 'deltas reset per window');
+    assert.strictEqual(summaries[1].misses, 0);
+  });
+
+  test('telemetry interval 0 disables emission', async function (assert) {
+    let summaries: LiveSearchCacheSummary[] = [];
+    let cache = new LiveSearchCache({
+      ttlMs: 60_000,
+      telemetryIntervalMs: 0,
+      emitTelemetry: (summary) => summaries.push(summary),
+    });
+    await cache.getOrPopulate({
+      realms: ['http://a/'],
+      query: personQuery(),
+      opts: undefined,
+      populate: async () => '{"data":[]}',
+    });
+    await sleep(10);
+    await cache.getOrPopulate({
+      realms: ['http://a/'],
+      query: personQuery(),
+      opts: undefined,
+      populate: async () => '{"data":[]}',
+    });
+    assert.strictEqual(summaries.length, 0, 'nothing emits');
   });
 });

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -44,6 +44,11 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
     let testRealmHttpServer: Server;
 
     let ownerUserId = '@mango:localhost';
+    // A second principal with read access to both realms. Used to prove the
+    // live-search cache serves a body computed for one authorized caller to a
+    // different authorized caller — the sharing is keyed on the realm list, not
+    // the user.
+    let readerUserId = '@reader:localhost';
 
     // Two Person instances per realm: per-realm css dedup is exercised
     // within each realm (two renderings share one stylesheet), and the
@@ -111,6 +116,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
             fileSystem: realmFileSystem,
             permissions: {
               [ownerUserId]: ['read', 'write', 'realm-owner'],
+              [readerUserId]: ['read'],
             },
           },
           {
@@ -118,6 +124,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
             fileSystem: realmFileSystem,
             permissions: {
               [ownerUserId]: ['read', 'write', 'realm-owner'],
+              [readerUserId]: ['read'],
             },
           },
         ],
@@ -163,11 +170,15 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
       },
     });
 
-    function ownerToken() {
+    function tokenFor(userId: string) {
       return createRealmServerJWT(
-        { user: ownerUserId, sessionRoom: 'session-room-test' },
+        { user: userId, sessionRoom: `session-room-${userId}` },
         realmSecretSeed,
       );
+    }
+
+    function ownerToken() {
+      return tokenFor(ownerUserId);
     }
 
     // Anchor on the base CardDef ref: each realm's Person adopts from its
@@ -179,15 +190,19 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
       };
     }
 
-    function postSearch(body: Record<string, unknown>) {
+    function postSearchAs(token: string, body: Record<string, unknown>) {
       let searchURL = new URL('/_federated-search', testRealm.url);
       return request
         .post(`${searchURL.pathname}${searchURL.search}`)
         .set('Accept', 'application/vnd.card+json')
         .set('Content-Type', 'application/json')
         .set('X-HTTP-Method-Override', 'QUERY')
-        .set('Authorization', `Bearer ${ownerToken()}`)
+        .set('Authorization', `Bearer ${token}`)
         .send(body);
+    }
+
+    function postSearch(body: Record<string, unknown>) {
+      return postSearchAs(ownerToken(), body);
     }
 
     test('QUERY /_federated-search federates entry results across realms', async function (assert) {
@@ -588,6 +603,40 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
         differentRealms.headers[LIVE_SEARCH_CACHE_HEADER],
         'miss',
         'a different realm list is a different cache identity',
+      );
+    });
+
+    test('a body computed for one caller is served to a different authorized caller', async function (assert) {
+      // Cross-user sharing is the whole point of the live cache: the body is a
+      // pure function of the realm list (both callers are authorized for it),
+      // not of the requesting user, so a body one user's request populated is
+      // served byte-identically to the next authorized user. Distinct sessions
+      // (different `Authorization` bearers) exercise the sharing that a
+      // single-user test cannot.
+      let searchBody = {
+        filter: personFilter(),
+        realms: [testRealm.url, secondaryRealm.url],
+      };
+
+      let owner = await postSearchAs(ownerToken(), searchBody);
+      assert.strictEqual(owner.status, 200, 'the owner request succeeds');
+      assert.strictEqual(
+        owner.headers[LIVE_SEARCH_CACHE_HEADER],
+        'miss',
+        'the first caller computes the body',
+      );
+
+      let reader = await postSearchAs(tokenFor(readerUserId), searchBody);
+      assert.strictEqual(reader.status, 200, 'the reader request succeeds');
+      assert.strictEqual(
+        reader.headers[LIVE_SEARCH_CACHE_HEADER],
+        'hit',
+        'a different authorized caller is served the cached body',
+      );
+      assert.deepEqual(
+        reader.body,
+        owner.body,
+        'the cross-user body is byte-identical',
       );
     });
 

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -22,6 +22,7 @@ import {
 } from '@cardstack/runtime-common';
 import type { PgAdapter } from '@cardstack/postgres';
 import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms.ts';
+import { LIVE_SEARCH_CACHE_HEADER } from '../../handlers/handle-search.ts';
 import {
   closeServer,
   createVirtualNetwork,
@@ -549,6 +550,89 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
       } finally {
         resetSearchBoundsForTests();
       }
+    });
+
+    test('identical live searches within the TTL share one cached body', async function (assert) {
+      let searchBody = {
+        filter: personFilter(),
+        realms: [testRealm.url, secondaryRealm.url],
+      };
+
+      let first = await postSearch(searchBody);
+      assert.strictEqual(first.status, 200, 'HTTP 200 status');
+      assert.strictEqual(
+        first.headers[LIVE_SEARCH_CACHE_HEADER],
+        'miss',
+        'the first request computes',
+      );
+
+      let second = await postSearch(searchBody);
+      assert.strictEqual(second.status, 200, 'HTTP 200 status');
+      assert.strictEqual(
+        second.headers[LIVE_SEARCH_CACHE_HEADER],
+        'hit',
+        'an identical follow-up is served from the live cache',
+      );
+      assert.deepEqual(
+        second.body,
+        first.body,
+        'the cached body is byte-identical',
+      );
+
+      // A request differing in any body member addresses a different entry.
+      let differentRealms = await postSearch({
+        filter: personFilter(),
+        realms: [testRealm.url],
+      });
+      assert.strictEqual(
+        differentRealms.headers[LIVE_SEARCH_CACHE_HEADER],
+        'miss',
+        'a different realm list is a different cache identity',
+      );
+    });
+
+    test('a write to a searched realm invalidates the live search cache', async function (assert) {
+      let searchBody = {
+        filter: personFilter(),
+        realms: [testRealm.url, secondaryRealm.url],
+      };
+
+      let first = await postSearch(searchBody);
+      assert.strictEqual(first.status, 200, 'HTTP 200 status');
+      assert.strictEqual(first.body.meta.page.total, 4, 'four people');
+      let primed = await postSearch(searchBody);
+      assert.strictEqual(
+        primed.headers[LIVE_SEARCH_CACHE_HEADER],
+        'hit',
+        'the entry is cached before the write',
+      );
+
+      // The default write waits for the incremental index, which advances the
+      // realm's generation — the device the cache key folds in for freshness.
+      await testRealm.write(
+        'mark.json',
+        JSON.stringify({
+          data: {
+            type: 'card',
+            attributes: { firstName: 'Mark' },
+            meta: {
+              adoptsFrom: { module: rri('./person'), name: 'Person' },
+            },
+          },
+        }),
+      );
+
+      let afterWrite = await postSearch(searchBody);
+      assert.strictEqual(
+        afterWrite.headers[LIVE_SEARCH_CACHE_HEADER],
+        'miss',
+        'the generation bump addresses a fresh entry',
+      );
+      assert.strictEqual(
+        afterWrite.body.meta.page.total,
+        5,
+        'the new instance is in the fresh result',
+      );
     });
   });
 });

--- a/packages/realm-server/tests/server-endpoints/search-test.ts
+++ b/packages/realm-server/tests/server-endpoints/search-test.ts
@@ -23,6 +23,7 @@ import {
 import type { PgAdapter } from '@cardstack/postgres';
 import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms.ts';
 import { LIVE_SEARCH_CACHE_HEADER } from '../../handlers/handle-search.ts';
+import { LiveSearchCache } from '../../live-search-cache.ts';
 import {
   closeServer,
   createVirtualNetwork,
@@ -41,6 +42,8 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
     let secondaryRealm: Realm;
     let request: SuperTest<Test>;
     let dbAdapter: PgAdapter;
+    let publisher: QueuePublisher;
+    let runner: QueueRunner;
     let testRealmHttpServer: Server;
 
     let ownerUserId = '@mango:localhost';
@@ -98,10 +101,12 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
       dbAdapter,
       publisher,
       runner,
+      liveSearchCache,
     }: {
       dbAdapter: PgAdapter;
       publisher: QueuePublisher;
       runner: QueueRunner;
+      liveSearchCache?: LiveSearchCache;
     }) {
       let virtualNetwork = createVirtualNetwork();
       let dir = dirSync();
@@ -132,6 +137,7 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
         publisher,
         runner,
         matrixURL,
+        liveSearchCache,
       });
 
       testRealmHttpServer = result.testRealmHttpServer;
@@ -152,8 +158,10 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
     }
 
     setupDB(hooks, {
-      beforeEach: async (_dbAdapter, publisher, runner) => {
+      beforeEach: async (_dbAdapter, _publisher, _runner) => {
         dbAdapter = _dbAdapter;
+        publisher = _publisher;
+        runner = _runner;
         await startSearchRealmServer({
           dbAdapter,
           publisher,
@@ -588,9 +596,12 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
         'hit',
         'an identical follow-up is served from the live cache',
       );
-      assert.deepEqual(
-        second.body,
-        first.body,
+      // `.text` is the raw response string, so this is the byte comparison the
+      // message claims (`.body` is supertest's re-parsed JSON). A `hit` returns
+      // the first request's cached string, so equality here is expected.
+      assert.strictEqual(
+        second.text,
+        first.text,
         'the cached body is byte-identical',
       );
 
@@ -607,12 +618,12 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
     });
 
     test('a body computed for one caller is served to a different authorized caller', async function (assert) {
-      // Cross-user sharing is the whole point of the live cache: the body is a
-      // pure function of the realm list (both callers are authorized for it),
-      // not of the requesting user, so a body one user's request populated is
-      // served byte-identically to the next authorized user. Distinct sessions
-      // (different `Authorization` bearers) exercise the sharing that a
-      // single-user test cannot.
+      // Pins that cross-user *sharing happens*: a body one user populated is
+      // served to the next authorized user off the TTL window. This alone does
+      // not prove the body is user-independent — the reader's `hit` returns the
+      // owner's cached string, so the two are equal by construction whether or
+      // not the compute is pure. The purity guard is the separate `ttlMs: 0`
+      // test below, where both callers compute.
       let searchBody = {
         filter: personFilter(),
         realms: [testRealm.url, secondaryRealm.url],
@@ -633,10 +644,60 @@ module(`server-endpoints/${basename(import.meta.filename)}`, function (_hooks) {
         'hit',
         'a different authorized caller is served the cached body',
       );
-      assert.deepEqual(
-        reader.body,
-        owner.body,
-        'the cross-user body is byte-identical',
+      assert.strictEqual(
+        reader.text,
+        owner.text,
+        'the reader is served the exact string the owner populated',
+      );
+    });
+
+    test('two authorized callers each compute a byte-identical body (cross-user purity)', async function (assert) {
+      // The purity guard the sharing test above can't provide. With retention
+      // off (`ttlMs: 0`) — coalescing stays on, but two sequential requests
+      // never coalesce — each caller runs its own compute and the second is a
+      // `miss`, not a `hit`. Comparing those two INDEPENDENTLY computed bodies
+      // is what pins the invariant the whole safety argument rests on: the body
+      // is a pure function of the realm list, not the requesting user. A change
+      // that folded a caller-derived value into the body would diverge here and
+      // trip this assertion — where the sharing test, comparing the one cached
+      // string to itself, would still pass.
+      await stopSearchRealmServer();
+      await startSearchRealmServer({
+        dbAdapter,
+        publisher,
+        runner,
+        liveSearchCache: new LiveSearchCache({
+          ttlMs: 0,
+          telemetryIntervalMs: 0,
+        }),
+      });
+      await settlePrerenderHtmlJobs(dbAdapter, testRealm.url);
+      await settlePrerenderHtmlJobs(dbAdapter, secondaryRealm.url);
+
+      let searchBody = {
+        filter: personFilter(),
+        realms: [testRealm.url, secondaryRealm.url],
+      };
+
+      let owner = await postSearchAs(ownerToken(), searchBody);
+      assert.strictEqual(owner.status, 200, 'the owner request succeeds');
+      assert.strictEqual(
+        owner.headers[LIVE_SEARCH_CACHE_HEADER],
+        'miss',
+        'the owner computes (retention is off)',
+      );
+
+      let reader = await postSearchAs(tokenFor(readerUserId), searchBody);
+      assert.strictEqual(reader.status, 200, 'the reader request succeeds');
+      assert.strictEqual(
+        reader.headers[LIVE_SEARCH_CACHE_HEADER],
+        'miss',
+        'the reader independently computes rather than being served a cached body',
+      );
+      assert.strictEqual(
+        reader.text,
+        owner.text,
+        'two independent computes produce a byte-identical body',
       );
     });
 


### PR DESCRIPTION
Fixes CS-12907.

## What

Live `_federated-search` requests (no indexer `x-boxel-job-id`) now go through a per-process `LiveSearchCache` with two layers, keyed on the same canonical `(realms, query, opts)` hash the job-scoped cache uses:

1. **In-flight coalescing** — concurrent identical requests await one compute and share the resolved body string. Always on: sharing a computation that's already running retains nothing extra.
2. **Short-TTL body cache** (default 5s, 64MB LRU cap) — stragglers whose identical request lands just after the first resolves share the body too.

Freshness is structural, not temporal: each searched realm's index + prerendered-HTML generation fingerprints fold into the cache key (the same device the job-scoped cache's ETag path uses), so any swap on a searched realm addresses a fresh entry. The TTL bounds retention, not staleness.

Responses carry `x-boxel-live-search-cache: miss | join | hit` for diagnosis; `LIVE_SEARCH_CACHE_TTL_MS` / `LIVE_SEARCH_CACHE_MAX_BYTES` tune it (TTL 0 disables retention while keeping coalescing).

## Why

Live federated-search traffic is dominated by many clients rendering the same cards: their queries are byte-identical, and every incremental index event makes every subscribed client re-issue them at once. Each request previously ran its own SQL + `loadLinks` assembly and stringified its own multi-MB document, so heap cost scaled linearly with concurrency — sustained identical-search load OOM'd both production realm-server replicas on 2026-09-09 (~2GB V8 heap limit, ~2 minutes of total downtime).

## Notes

- The job-scoped (indexer) cache path is byte-for-byte unchanged; its key hash and realm-generation lookup are now exported and shared rather than duplicated.
- Sharing across users is safe: permissions are realm-scoped and `multiRealmAuthorization` validates every caller against the full realm list before the handler runs, so the body is a pure function of the cache key.
- One deliberate looseness (documented in the module): `_federated-search` drops a realm that fails to mount rather than failing the request, so a body computed during a transient per-realm failure can serve TTL-window stragglers; those callers would have computed the same degraded body themselves moments earlier.
- No timers: expired entries reap lazily, so tests leak no handles and there's no teardown hook to wire.

## Telemetry

The cache emits one JSON summary line per activity window on the `boxel:live-search-cache` channel (same `| json` convention as `boxel:screenshot-perf` / `boxel:client-perf`), with window deltas for `hits` / `joins` / `misses`, entry-lifecycle counts (`expired` / `evicted` / `oversized`), failed computes (`errors`), and bytes served by outcome (`hitBytes + joinBytes` = traffic served without recomputation), plus `entryCount` / `sizeBytes` gauges and the `ttlMs` / `maxBytes` config for utilization-vs-cap panels. Emission piggybacks on request activity — at most one line per `LIVE_SEARCH_CACHE_TELEMETRY_INTERVAL_MS` (default 30s, `0` disables) — so the module keeps its no-timers, no-teardown property.

Five panels on the Realm Server service dashboard read the channel (same envelope-safe LogQL parse as the client-performance dashboard): hit ratio, requests by outcome, bytes served vs computed, entry lifecycle (expired / evicted / oversized / errors), and utilization vs the cap.

## Testing

- New `live-search-cache-test.ts` unit suite: coalescing, TTL expiry, TTL-0 semantics, generation-key busting, rejection propagation, LRU byte-cap eviction, oversized-body passthrough, lifecycle-counter attribution, and telemetry window semantics (11 tests).
- Two new endpoint tests in `server-endpoints/search-test.ts`: identical live searches share one cached body (miss → hit, byte-identical), and a realm write invalidates via the generation bump (fresh body includes the new instance).
- Full `search-test.ts` and `realm-routing-test.ts` suites pass locally against the CI-parity service stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

