### PR TITLE
Scope card-initiated entry searches to the current realm by default instead of fanning out

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -18,6 +18,7 @@ import { or, not } from '@cardstack/boxel-ui/helpers';
 
 import {
   CardContextName,
+  CardSearchDefaultRealmContextName,
   GetCardContextName,
   GetCardsContextName,
   GetCardCollectionContextName,
@@ -40,7 +41,7 @@ import type MessageService from '@cardstack/host/services/message-service';
 import CardChooserModal from '../card-chooser/modal';
 import FileChooserModal from '../file-chooser/modal';
 import MarkdownEmbedChooserModal from '../markdown-embed-chooser/modal';
-import SearchResults from '../search/search-results';
+import CardContextSearchResults from '../search/card-context-search-results';
 import { Submodes } from '../submode-switcher';
 
 import CreateListingModal from './create-listing-modal';
@@ -118,6 +119,15 @@ export default class OperatorModeContainer extends Component<Signature> {
       });
   }
 
+  // The realm the card-facing `searchResultsComponent` scopes a no-realm search
+  // to — the same current realm `getCards` defaults to, so both card-search
+  // surfaces target one realm rather than fanning out across the whole server.
+  @provide(CardSearchDefaultRealmContextName)
+  // @ts-ignore "cardSearchDefaultRealm" is declared but not used
+  private get cardSearchDefaultRealm(): () => string | undefined {
+    return () => this.currentRealm;
+  }
+
   @provide(GetCardCollectionContextName)
   // @ts-ignore "getCardCollection" is declared but not used
   private get getCardCollection() {
@@ -141,7 +151,7 @@ export default class OperatorModeContainer extends Component<Signature> {
       // populated alongside toolContext for content still reading the
       // pre-rename spelling
       commandContext: this.toolContext,
-      searchResultsComponent: SearchResults,
+      searchResultsComponent: CardContextSearchResults,
       markdownEmbedChooser: this.markdownEmbedChooser,
       mode: 'operator',
       submode: this.operatorModeStateService.state?.submode,

--- a/packages/host/app/components/search/card-context-search-results.gts
+++ b/packages/host/app/components/search/card-context-search-results.gts
@@ -1,0 +1,57 @@
+import Component from '@glimmer/component';
+
+import { consume } from 'ember-provide-consume-context';
+
+import {
+  CardSearchDefaultRealmContextName,
+  type SearchResultsComponentSignature,
+} from '@cardstack/runtime-common';
+
+import SearchResults from './search-results';
+
+// The component the host provides on `@context.searchResultsComponent`. It is
+// `<SearchResults>` with card-facing scoping baked in: a no-realm search
+// targets the current realm (consumed from `CardSearchDefaultRealmContextName`,
+// the realm the `@context` was provided with) instead of fanning out to every
+// readable realm — the server-wide-blast-radius footgun of the raw all-realms
+// fallback. Host-owned call sites (choosers, playground, the search sheet) use
+// `<SearchResults>` directly and keep the all-realms default.
+//
+// A separate wrapper (rather than currying args onto `<SearchResults>` at the
+// provider) is what lets the card surface opt in while the host surface stays
+// unconstrained: cards render whatever `searchResultsComponent` resolves to and
+// never pass `@cardInitiated` themselves.
+export default class CardContextSearchResults extends Component<SearchResultsComponentSignature> {
+  @consume(CardSearchDefaultRealmContextName)
+  declare private defaultRealm: (() => string | undefined) | undefined;
+
+  // Stable identity across renders (a class field, not a getter) so the
+  // resource created once inside `<SearchResults>` keeps reading the same thunk;
+  // the current realm itself is re-read lazily on each search.
+  private getDefaultRealm = () => this.defaultRealm?.();
+
+  <template>
+    {{#if (has-block)}}
+      <SearchResults
+        @query={{@query}}
+        @mode={{@mode}}
+        @overlays={{@overlays}}
+        @cardInitiated={{true}}
+        @getDefaultRealm={{this.getDefaultRealm}}
+        ...attributes
+        as |results|
+      >
+        {{yield results}}
+      </SearchResults>
+    {{else}}
+      <SearchResults
+        @query={{@query}}
+        @mode={{@mode}}
+        @overlays={{@overlays}}
+        @cardInitiated={{true}}
+        @getDefaultRealm={{this.getDefaultRealm}}
+        ...attributes
+      />
+    {{/if}}
+  </template>
+}

--- a/packages/host/app/components/search/search-results.gts
+++ b/packages/host/app/components/search/search-results.gts
@@ -34,6 +34,13 @@ interface HostSearchResultsSignature {
     // component varies nothing through `@query` — the resource's owner drives
     // it. When absent the component creates and owns its resource as before.
     resource?: SearchEntriesResource;
+    // Card-facing scoping, set by the `@context.searchResultsComponent`
+    // wrapper: a no-realm search targets `@getDefaultRealm` rather than fanning
+    // out to every readable realm. Host-owned call sites (choosers, playground,
+    // the sheet) omit both and keep the all-realms default. Ignored on the
+    // `@resource` path — the caller-owned resource carries its own scoping.
+    cardInitiated?: boolean;
+    getDefaultRealm?: () => string | undefined;
   };
   Blocks: SearchResultsComponentSignature['Blocks'];
 }
@@ -76,6 +83,10 @@ export default class SearchResults extends Component<HostSearchResultsSignature>
         () => this.args.query,
         () => this.mode,
         () => this.overlays,
+        {
+          cardInitiated: this.args.cardInitiated,
+          getDefaultRealm: this.args.getDefaultRealm,
+        },
       );
 
   private get results(): SearchResultsYield {

--- a/packages/host/app/resources/renderable-search-entries.ts
+++ b/packages/host/app/resources/renderable-search-entries.ts
@@ -317,9 +317,16 @@ export function getRenderableSearchEntries(
   getQuery: () => SearchEntryWireQuery | undefined,
   getMode: () => HydrationMode,
   getOverlays: () => boolean = () => true,
+  opts?: {
+    // Forwarded to the underlying resource: scope a no-realm card search to the
+    // current realm instead of fanning out. Set only by the card-facing
+    // `searchResultsComponent` surface.
+    cardInitiated?: boolean;
+    getDefaultRealm?: () => string | undefined;
+  },
 ): RenderableSearchEntries {
   return new RenderableSearchEntries(
-    getSearchEntriesResource(owner, getQuery),
+    getSearchEntriesResource(owner, getQuery, opts),
     getMode,
     getOverlays,
   );

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -96,6 +96,14 @@ export interface SearchEntry {
 interface Args {
   named: {
     query: SearchEntryWireQuery | undefined;
+    // Scope a no-realm search to the current realm rather than fanning out to
+    // every readable realm. Set only by the card-facing `searchResultsComponent`
+    // surface; host-owned callers (the search sheet, choosers, playground) leave
+    // it unset and keep the all-realms default.
+    cardInitiated?: boolean;
+    // The realm a no-realm card search targets (the realm the `@context` was
+    // provided with). Only meaningful with `cardInitiated`.
+    getDefaultRealm?: () => string | undefined;
   };
 }
 
@@ -157,6 +165,8 @@ export class SearchEntriesResource extends Resource<Args> {
 
   #previousQuery: SearchEntryWireQuery | undefined;
   #previousRealms: string[] | undefined;
+  #cardInitiated = false;
+  #getDefaultRealm: (() => string | undefined) | undefined;
   #idleClearScheduled = false;
   #log = runtimeLogger('search-entries-resource');
   // Kept private for tests/internal load bookkeeping.
@@ -217,7 +227,16 @@ export class SearchEntriesResource extends Resource<Args> {
   }
 
   modify(_positional: never[], named: Args['named']) {
-    let { query } = named;
+    let { query, cardInitiated, getDefaultRealm } = named;
+
+    // Keep the previously provided values when optional args are omitted on
+    // subsequent modify() calls (mirrors how the query is re-read each pass).
+    if (cardInitiated !== undefined) {
+      this.#cardInitiated = cardInitiated;
+    }
+    if (getDefaultRealm !== undefined) {
+      this.#getDefaultRealm = getDefaultRealm;
+    }
 
     if (query === undefined) {
       // Clear stale state so live subscriptions don't re-fire the old query.
@@ -264,10 +283,17 @@ export class SearchEntriesResource extends Resource<Args> {
       return;
     }
 
+    // A no-realm card search targets the current realm (the realm the
+    // `@context` was provided with), never every visible realm — an empty
+    // realms array turns a render into a federated scan across the whole
+    // server. A host-owned search (not card-initiated) keeps the all-realms
+    // default.
     let realms = normalizeRealms(
       query.realms && query.realms.length > 0
         ? query.realms
-        : this.realmServer.availableRealmIdentifiers,
+        : this.#cardInitiated
+          ? this.#currentRealmList()
+          : this.realmServer.availableRealmIdentifiers,
     );
     this.realmsToSearch = realms;
 
@@ -359,6 +385,14 @@ export class SearchEntriesResource extends Resource<Args> {
         () => loaded.fulfill(),
       );
     });
+  }
+
+  // The realm a no-realm card search targets: the current realm from the
+  // `@context` provider, or an empty list if none is known (which yields no
+  // results rather than fanning out to every realm).
+  #currentRealmList(): string[] {
+    let current = this.#getDefaultRealm?.();
+    return current ? [current] : [];
   }
 
   get isLoading() {
@@ -459,7 +493,14 @@ export class SearchEntriesResource extends Resource<Args> {
         : this.realmsToSearch;
 
       try {
-        let doc = await this.runtimeStore.searchEntries(query, realmsToFetch);
+        // A card-initiated search must not fan out to every realm when its
+        // realm list is empty (the current realm is unknown). `realmsToFetch`
+        // has already resolved a no-realm card search to the current realm (see
+        // modify); the flag keeps `searchEntries` from re-expanding an empty
+        // list back to all realms.
+        let doc = await this.runtimeStore.searchEntries(query, realmsToFetch, {
+          cardInitiated: this.#cardInitiated,
+        });
         await this.loadStylesheets(doc);
         let fresh = this.buildEntries(doc);
 
@@ -929,10 +970,19 @@ function memberValidator(member: SearchEntry): string {
 export function getSearchEntriesResource(
   parent: object,
   getQuery: () => SearchEntryWireQuery | undefined,
+  opts?: {
+    // Set by the card-facing `searchResultsComponent` surface: scope a no-realm
+    // search to `getDefaultRealm` instead of every readable realm. Host-owned
+    // callers leave these unset and keep the all-realms default.
+    cardInitiated?: boolean;
+    getDefaultRealm?: () => string | undefined;
+  },
 ) {
   return SearchEntriesResource.from(parent, () => ({
     named: {
       query: getQuery(),
+      cardInitiated: opts?.cardInitiated,
+      getDefaultRealm: opts?.getDefaultRealm,
     },
   })) as SearchEntriesResource;
 }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1231,8 +1231,17 @@ export default class StoreService extends Service implements StoreInterface {
   async searchEntries(
     query: SearchEntryWireQuery,
     realms?: string[],
+    opts?: {
+      // Set by the card-facing `searchResultsComponent` surface, mirroring
+      // `store.search`: an empty realm list means the card's current realm is
+      // unknown, so search nothing rather than fanning out to every realm.
+      // Host callers leave it unset and keep the all-realms fallback.
+      cardInitiated?: boolean;
+    },
   ): Promise<SearchEntryResults> {
-    let searchRealms = this.normalizeSearchRealms(realms);
+    let searchRealms = opts?.cardInitiated
+      ? this.normalizeRealmPaths(realms)
+      : this.normalizeSearchRealms(realms);
     if (searchRealms.length === 0) {
       return { data: [], meta: { page: { total: 0 } } };
     }

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -16,6 +16,7 @@ import window from 'ember-window-mock';
 
 import {
   type CardErrorJSONAPI,
+  CardSearchDefaultRealmContextName,
   GetCardContextName,
   GetCardsContextName,
   GetCardCollectionContextName,
@@ -28,7 +29,7 @@ import {
 
 import HostModeContent from '@cardstack/host/components/host-mode/content';
 import OperatorModeContainer from '@cardstack/host/components/operator-mode/container';
-import SearchResults from '@cardstack/host/components/search/search-results';
+import CardContextSearchResults from '@cardstack/host/components/search/card-context-search-results';
 
 import config from '@cardstack/host/config/environment';
 
@@ -97,6 +98,15 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
         cardInitiated: true,
         getDefaultRealm,
       });
+  }
+
+  // The realm the card-facing `searchResultsComponent` scopes a no-realm search
+  // to — the same current realm `getCards` defaults to, so both card-search
+  // surfaces target one realm rather than fanning out across the whole server.
+  @provide(CardSearchDefaultRealmContextName)
+  // @ts-ignore "cardSearchDefaultRealm" is declared but not used
+  private get cardSearchDefaultRealm(): () => string | undefined {
+    return () => this.currentRealm;
   }
 
   @provide(GetCardCollectionContextName)
@@ -169,7 +179,7 @@ export class IndexComponent extends Component<IndexComponentComponentSignature> 
       store: this.cardStore,
       toolContext: this.toolContext,
       commandContext: this.toolContext,
-      searchResultsComponent: SearchResults,
+      searchResultsComponent: CardContextSearchResults,
       mode: this.hostModeService.isActive ? 'host' : 'operator',
       submode: this.hostModeService.isActive
         ? 'host'

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -10,6 +10,7 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 
 import {
   type getCard as GetCardType,
+  CardSearchDefaultRealmContextName,
   GetCardContextName,
   GetCardsContextName,
   GetCardCollectionContextName,
@@ -18,7 +19,7 @@ import {
   type Query,
 } from '@cardstack/runtime-common';
 
-import SearchResults from '@cardstack/host/components/search/search-results';
+import CardContextSearchResults from '@cardstack/host/components/search/card-context-search-results';
 import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
 import type RenderStoreService from '@cardstack/host/services/render-store';
@@ -68,6 +69,15 @@ class RenderHtmlTemplate extends Component<Signature> {
       });
   }
 
+  // The realm the card-facing `searchResultsComponent` scopes a no-realm search
+  // to — the same current realm `getCards` defaults to, so both card-search
+  // surfaces target one realm rather than fanning out across the whole server.
+  @provide(CardSearchDefaultRealmContextName)
+  // @ts-ignore "cardSearchDefaultRealm" is declared but not used
+  private get cardSearchDefaultRealm(): () => string | undefined {
+    return () => this.currentRealm;
+  }
+
   @provide(GetCardCollectionContextName)
   private get getCardCollection() {
     return getCardCollection;
@@ -81,7 +91,7 @@ class RenderHtmlTemplate extends Component<Signature> {
       getCards: this.getCards,
       getCardCollection: this.getCardCollection,
       store: this.cardStore,
-      searchResultsComponent: SearchResults,
+      searchResultsComponent: CardContextSearchResults,
       mode: 'host',
       submode: 'host',
     };

--- a/packages/host/tests/integration/components/card-context-search-results-test.gts
+++ b/packages/host/tests/integration/components/card-context-search-results-test.gts
@@ -14,13 +14,14 @@ import { module, test } from 'qunit';
 
 import {
   isCardInstance,
+  CardSearchDefaultRealmContextName,
   GetCardContextName,
   type getCard as GetCardType,
   type SearchEntryWireQuery,
   type SearchResultsComponentSignature,
 } from '@cardstack/runtime-common';
 
-import SearchResults from '@cardstack/host/components/search/search-results';
+import CardContextSearchResults from '@cardstack/host/components/search/card-context-search-results';
 import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
 import type StoreService from '@cardstack/host/services/store';
@@ -78,11 +79,22 @@ const BOOK_2 = `${testRealmURL}books/2`;
 // `GetCardContextName` is provided too so the nested hydratable rows resolve
 // their live instances, the way the route wires it.
 class CardSearchContext extends GlimmerComponent<{
+  Args: {
+    // The realm a card-initiated no-realm search defaults to, mirroring what the
+    // host route provides on `CardSearchDefaultRealmContextName`. Omit to
+    // simulate a card whose default realm can't be resolved yet.
+    defaultRealm?: string;
+  };
   Blocks: { default: [CardContext] };
 }> {
   @provide(GetCardContextName)
   get getCardFn() {
     return getCard;
+  }
+
+  @provide(CardSearchDefaultRealmContextName)
+  get cardSearchDefaultRealm(): () => string | undefined {
+    return () => this.args.defaultRealm;
   }
 
   get context(): CardContext {
@@ -92,7 +104,7 @@ class CardSearchContext extends GlimmerComponent<{
       getCards: store.getSearchResource.bind(store),
       getCardCollection,
       store,
-      searchResultsComponent: SearchResults,
+      searchResultsComponent: CardContextSearchResults,
     };
   }
 
@@ -186,6 +198,65 @@ module(
         isCardInstance(storeService.peek(BOOK_1)),
         'the hydration GET deposited the card into the store',
       );
+    });
+
+    test('a no-realm card search scopes to the context default realm', async function (assert) {
+      // The query carries no `realms`. Card-initiated, it targets the realm the
+      // `@context` was provided with rather than fanning out across every
+      // readable realm.
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+      };
+      await render(
+        <template>
+          <CardSearchContext @defaultRealm={{testRealmURL}} as |context|>
+            <context.searchResultsComponent @query={{query}} @mode='none' />
+          </CardSearchContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-search-result]')),
+      );
+
+      assert
+        .dom(`[data-test-search-result="${BOOK_1}"]`)
+        .exists('the default realm is searched');
+      assert
+        .dom(`[data-test-search-result="${BOOK_2}"]`)
+        .exists('the default realm is searched');
+    });
+
+    test('a no-realm card search with no resolvable default realm returns nothing', async function (assert) {
+      // No `realms` on the query and no default realm on the context (the card's
+      // model has no id yet): it must not fall back to scanning every realm.
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+      };
+      await render(
+        <template>
+          <CardSearchContext as |context|>
+            <context.searchResultsComponent
+              @query={{query}}
+              @mode='none'
+              as |results|
+            >
+              {{#unless results.isLoading}}
+                <span data-test-settled></span>
+              {{/unless}}
+              {{#each results.entries key='id' as |entry|}}
+                <entry.component data-test-search-result={{entry.id}} />
+              {{/each}}
+            </context.searchResultsComponent>
+          </CardSearchContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-settled]')),
+      );
+
+      assert
+        .dom('[data-test-search-result]')
+        .doesNotExist('no fan-out across all realms when no default realm');
     });
 
     test('the converged @context exposes the entry + deprecated rendering surfaces and the instances surface', async function (assert) {

--- a/packages/host/tests/integration/resources/search-entries-test.gts
+++ b/packages/host/tests/integration/resources/search-entries-test.gts
@@ -50,12 +50,16 @@ import { setupRenderingTest } from '../../helpers/setup';
 
 const testRealm2URL = 'http://test-realm/test2/';
 
+interface TestNamedArgs {
+  query: SearchEntryWireQuery | undefined;
+  cardInitiated?: boolean;
+  getDefaultRealm?: () => string | undefined;
+}
+
 function getResourceForTest(
   parent: object,
   args: () => {
-    named: {
-      query: SearchEntryWireQuery | undefined;
-    };
+    named: TestNamedArgs;
   },
 ) {
   return SearchEntriesResource.from(parent, args) as unknown as Omit<
@@ -64,12 +68,7 @@ function getResourceForTest(
   > & {
     // we expose the private loaded promise just for our tests
     loaded: Promise<void>;
-    modify: (
-      positional: never[],
-      named: {
-        query: SearchEntryWireQuery | undefined;
-      },
-    ) => void;
+    modify: (positional: never[], named: TestNamedArgs) => void;
   };
 }
 
@@ -274,6 +273,75 @@ module('Integration | search-entries resource', function (hooks) {
         'an html-bearing entry has no item fallback',
       );
     }
+  });
+
+  test('a card-initiated no-realm search scopes to the default realm instead of fanning out', async function (assert) {
+    // The footgun this guards against: a card whose realms array resolves to
+    // empty (e.g. its model has no id yet) would otherwise turn a single-realm
+    // render into a federated scan across every readable realm. Card-initiated,
+    // it targets the default realm (the realm the `@context` was provided with)
+    // and never sees realm2's matching book.
+    let search = getResourceForTest(storeService, () => ({
+      named: {
+        query: { filter: { 'item.on': bookRef } },
+        cardInitiated: true,
+        getDefaultRealm: () => testRealmURL,
+      },
+    }));
+    await search.loaded;
+
+    assert.strictEqual(
+      search.entries.length,
+      2,
+      'only the two books in the default realm are returned',
+    );
+    assert.true(
+      search.entries.every((entry) => entry.realmUrl === testRealmURL),
+      'every result is from the default realm',
+    );
+    assert.false(
+      search.entries.some((entry) => entry.realmUrl === testRealm2URL),
+      'realm2 was never searched — no fan-out',
+    );
+  });
+
+  test('a card-initiated no-realm search with no resolvable default realm yields no results', async function (assert) {
+    // When the default realm cannot be determined (the model has no id yet), a
+    // card search returns nothing rather than falling back to every realm.
+    let search = getResourceForTest(storeService, () => ({
+      named: {
+        query: { filter: { 'item.on': bookRef } },
+        cardInitiated: true,
+        getDefaultRealm: () => undefined,
+      },
+    }));
+    await search.loaded;
+
+    assert.strictEqual(
+      search.entries.length,
+      0,
+      'no results, rather than a fan-out across all realms',
+    );
+  });
+
+  test('a host-owned no-realm search keeps the all-realms fallback', async function (assert) {
+    // Host-owned surfaces (the search sheet, choosers, playground) legitimately
+    // want every readable realm — leaving `cardInitiated` unset preserves that.
+    let search = getResourceForTest(storeService, () => ({
+      named: {
+        query: { filter: { 'item.on': bookRef } },
+      },
+    }));
+    await search.loaded;
+
+    assert.true(
+      search.entries.some((entry) => entry.realmUrl === testRealmURL),
+      'the default realm is searched',
+    );
+    assert.true(
+      search.entries.some((entry) => entry.realmUrl === testRealm2URL),
+      'realm2 is searched too — the all-realms fallback still fans out',
+    );
   });
 
   test('registers file result URLs so clicks/overlay classify them as files', async function (assert) {

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -107,6 +107,14 @@ export const CardURLContextName = 'card-url-context';
 
 export const RealmURLContextName = 'realm-url-context';
 
+// The realm a card-initiated, no-realm search defaults to (the realm the
+// `@context` was provided with). Provided alongside the card-facing
+// `searchResultsComponent` so that surface can scope a realm-less query to the
+// current realm instead of fanning out across every readable realm. Value is a
+// thunk: `() => string | undefined`.
+export const CardSearchDefaultRealmContextName =
+  'card-search-default-realm-context';
+
 export interface Permissions {
   readonly canRead: boolean;
   readonly canWrite: boolean;


### PR DESCRIPTION
## Problem

The card-facing `@context.searchResultsComponent` surface (the `entry`-based search used by `CardList` / `CardsGrid` and custom list cards) fell back to `realmServer.availableRealmIdentifiers` whenever a query supplied no realms. A card that *intends* single-realm scope but resolves an empty realms array — e.g. its model has no id yet, so its own-realm getter returns `undefined` — silently became a federated scan across **every** readable realm. On an account with many realms that turns one render into a 15+-realm scan, each realm running its own SQL + `loadLinks` and stringifying a multi-MB document on the realm-server heap. This was a contributor to the 2026-09-09 OOM outage.

The sibling `getCards` surface was already fixed; this brings the `entry` surface to parity.

## Change

- **`SearchEntriesResource`** takes `cardInitiated` + `getDefaultRealm`. A no-realm card search resolves to the current realm (the realm the `@context` was provided with), or to **no results** when the realm is unknown — never a fan-out.
- **`store.searchEntries`** is now card-initiated aware (uses `normalizeRealmPaths`), so an empty realm list stays empty instead of re-expanding to all realms — closing the second, hidden fan-out point.
- **`CardContextSearchResults`** (new) is the component the host now provides on `searchResultsComponent`. It bakes in `cardInitiated` and reads the default realm from the new `CardSearchDefaultRealmContextName` (supplied by the operator/index/render providers). This cleanly separates the card-facing surface (scoped) from host-owned `<SearchResults>` call sites — choosers, playground, search sheet — which are untouched and keep the all-realms default.

## Tests

New coverage at both layers (all green locally, in-browser QUnit):
- Resource: card-initiated no-realm → scopes to default realm (no fan-out); no resolvable default realm → empty; host-owned → all-realms fallback preserved.
- Wrapper/context: `@context.searchResultsComponent` scopes via the context default realm and returns nothing when none is resolvable; existing render/hydration + type-witness tests still pass through the new wrapper.

## Follow-up

The prerender screenshot route (`render/screenshot.gts`) lives on an unmerged branch and isn't on `main`, so it still hands cards the raw all-realms `SearchResults`. It should adopt `CardContextSearchResults` when that branch rebases onto a `main` containing this change.

Ref: CS-12910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GsYGsuCqHJz9GAti4jheG