### PR TITLE
refactor: classify FileDef types as file-def in the definition cache

### DIFF
--- a/packages/bxl/src/mutation/boxel-source-adapter.ts
+++ b/packages/bxl/src/mutation/boxel-source-adapter.ts
@@ -22,7 +22,11 @@ export interface BxlBoxelSourceFieldDefinition<CodeReference = unknown> {
 
 /** Loaderless subset of Boxel's runtime-common `Definition` shape. */
 export interface BxlBoxelSourceDefinition<CodeReference = unknown> {
-  type?: 'card-def' | 'field-def';
+  // The three families a Boxel definition can describe: a card, a field that
+  // only exists inside a card, and a file whose metadata comes from uploaded
+  // bytes. Mirrored so a caller can hand over any definition it holds; nothing
+  // here branches on the kind.
+  type?: 'card-def' | 'field-def' | 'file-def';
   codeRef?: CodeReference;
   displayName?: string | null;
   fields: Record<string, string>;

--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -12,6 +12,7 @@ import { isEqual } from 'lodash-es';
 
 import {
   baseCardRef,
+  baseFileRef,
   CardError,
   Deferred,
   definitionDisplayName,
@@ -22,6 +23,7 @@ import {
   isBaseDef,
   isCardDef,
   isCardError,
+  isFileDef,
   loadCardDef,
   parseRenderRouteOptions,
   rri,
@@ -64,7 +66,7 @@ import type NetworkService from '../services/network';
 import type RealmService from '../services/realm';
 import type RenderStoreService from '../services/render-store';
 import type * as CardAPI from '@cardstack/base/card-api';
-import type { CardDef, BaseDef } from '@cardstack/base/card-api';
+import type { BaseDef } from '@cardstack/base/card-api';
 import type * as OperationsAPI from '@cardstack/base/operations';
 
 export type Model = {
@@ -622,9 +624,12 @@ async function makeDefinition(
     if (operations) {
       definition.operations = operations;
     }
-    let typesMaybeError = isCardDef(def)
-      ? await getTypes(def, context)
-      : { type: 'types' as const, types: [] };
+    // A card and a file each have a URL and an ancestry a consumer can filter
+    // on, so both record theirs. A field def has neither and records none.
+    let typesMaybeError =
+      isCardDef(def) || isFileDef(def)
+        ? await getTypes(def, context)
+        : { type: 'types' as const, types: [] };
     if (typesMaybeError.type === 'error') {
       console.warn(
         `encountered error indexing definition  "${urlString}/${name}": ${typesMaybeError.error.message}`,
@@ -657,38 +662,45 @@ async function makeDefinition(
   }
 }
 
+// Walk a def's ancestry, from the def itself up to and including the root of
+// its own family — `CardDef` for a card, `FileDef` for a file. The two families
+// are disjoint, so the walk stays within the one it started in and the root it
+// stops at is what says which that was.
 async function getTypes(
-  card: typeof CardDef,
+  def: typeof BaseDef,
   context: ModuleModelContext,
 ): Promise<TypesWithErrors> {
   let cache = context.state.getTypesCache();
-  let cached = cache.get(card);
+  let cached = cache.get(def);
   if (cached) {
     return await cached;
   }
-  let ref = identifyCard(card);
+  let ref = identifyCard(def);
   if (!ref) {
-    throw new Error(`could not identify card ${card.name}`);
+    throw new Error(`could not identify type ${def.name}`);
   }
+  let isFile = isFileDef(def);
+  let familyRootRef = isFile ? baseFileRef : baseCardRef;
+  let inFamily = isFile ? isFileDef : isCardDef;
   let deferred = new Deferred<TypesWithErrors>();
-  cache.set(card, deferred.promise);
+  cache.set(def, deferred.promise);
   let types: CardType[] = [];
   let fullRef: CodeRef = ref;
   let result: TypesWithErrors | undefined;
   try {
     for (;;) {
-      let loadedCard: typeof CardAPI.CardDef,
+      let loadedCard: typeof CardAPI.BaseDef,
         loadedCardRef: CodeRef | undefined;
       try {
         let maybeCard = await loadCardDef(fullRef, {
           loader: context.loaderService.loader,
         });
-        if (!isCardDef(maybeCard)) {
+        if (!inFamily(maybeCard)) {
           result = {
             type: 'error' as const,
             error: toSerializedError(
               undefined,
-              `The definition at ${JSON.stringify(fullRef)} is not a CardDef`,
+              `The definition at ${JSON.stringify(fullRef)} is not a ${familyRootRef.name}`,
             ),
           };
           return result;
@@ -727,7 +739,7 @@ async function getTypes(
         codeRef: loadedCardRef,
         displayName: getDisplayName(loadedCard),
       });
-      if (!isEqual(loadedCardRef, baseCardRef)) {
+      if (!isEqual(loadedCardRef, familyRootRef)) {
         fullRef = {
           type: 'ancestorOf',
           card: loadedCardRef,
@@ -745,7 +757,7 @@ async function getTypes(
       deferred.fulfill({
         type: 'error',
         error: serializableError(
-          new Error(`unable to determine result for card type ${card.name}`),
+          new Error(`unable to determine result for type ${def.name}`),
         ),
       });
     }
@@ -891,10 +903,13 @@ function parseRfc7321Time(time: string) {
   );
 }
 
-function getDisplayName(card: typeof CardDef) {
-  if (card.displayName === 'Card') {
-    return card.name;
+// A def that declares no display name of its own inherits its family's
+// placeholder — 'Card' or 'File' — which names the family rather than the type.
+// The class name is the more useful answer in that case.
+function getDisplayName(def: typeof BaseDef) {
+  if (def.displayName === 'Card' || def.displayName === 'File') {
+    return def.name;
   } else {
-    return card.displayName;
+    return def.displayName;
   }
 }

--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -386,7 +386,7 @@ export async function buildModuleModel(
             {
               name,
               url: moduleURL,
-              cardOrFieldDef: maybeBaseDef,
+              def: maybeBaseDef,
             },
             context,
             found,
@@ -546,7 +546,7 @@ function makeDefinitionLookup(
 // the `searchable` pass is — a failure is logged and captures no operations
 // rather than failing the definition.
 async function captureOperations(
-  cardOrFieldDef: typeof BaseDef,
+  def: typeof BaseDef,
   definition: Definition,
   api: typeof CardAPI,
   context: ModuleModelContext,
@@ -560,14 +560,14 @@ async function captureOperations(
     // The authored view, not `getOperations`: a base operation reached with no
     // declaration has nothing to lower, and the clause a base requires is
     // only guaranteed present on an entry that went through the decorator.
-    let declared = operationsApi.getDeclaredOperations(cardOrFieldDef);
+    let declared = operationsApi.getDeclaredOperations(def);
     if (Object.keys(declared).length === 0) {
       return undefined;
     }
     let lowered = await lowerOperationDeclarations(declared, {
       definition,
       lookupDefinition: makeDefinitionLookup(api, loader, 'operation lowering'),
-      identifyCard: (def) => identifyCard(def),
+      identifyCard: (card) => identifyCard(card),
     });
     for (let issue of lowered.issues) {
       console.warn(
@@ -586,11 +586,11 @@ async function makeDefinition(
   {
     url,
     name,
-    cardOrFieldDef,
+    def,
   }: {
     url: RealmResourceIdentifier | URL;
     name: string;
-    cardOrFieldDef: typeof BaseDef;
+    def: typeof BaseDef;
   },
   context: ModuleModelContext,
   // Collects the operation-lowering findings for this def. The caller tags
@@ -603,17 +603,17 @@ async function makeDefinition(
     let api = await context.loaderService.loader.import<typeof CardAPI>(
       '@cardstack/base/card-api',
     );
-    let { fields, fieldDefs } = getFieldDefinitions(api, cardOrFieldDef);
-    let codeRef = identifyCard(cardOrFieldDef) as ResolvedCodeRef;
+    let { fields, fieldDefs } = getFieldDefinitions(api, def);
+    let codeRef = identifyCard(def) as ResolvedCodeRef;
     let definition: Definition = {
       codeRef,
       fields,
       fieldDefs,
-      type: definitionKind(cardOrFieldDef),
-      displayName: definitionDisplayName(cardOrFieldDef),
+      type: definitionKind(def),
+      displayName: definitionDisplayName(def),
     };
     let operations = await captureOperations(
-      cardOrFieldDef,
+      def,
       definition,
       api,
       context,
@@ -622,8 +622,8 @@ async function makeDefinition(
     if (operations) {
       definition.operations = operations;
     }
-    let typesMaybeError = isCardDef(cardOrFieldDef)
-      ? await getTypes(cardOrFieldDef, context)
+    let typesMaybeError = isCardDef(def)
+      ? await getTypes(def, context)
       : { type: 'types' as const, types: [] };
     if (typesMaybeError.type === 'error') {
       console.warn(

--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -14,6 +14,8 @@ import {
   baseCardRef,
   CardError,
   Deferred,
+  definitionDisplayName,
+  definitionKind,
   getFieldDefinitions,
   identifyCard,
   internalKeyFor,
@@ -515,8 +517,8 @@ function makeDefinitionLookup(
         codeRef,
         fields,
         fieldDefs,
-        type: isCardDef(card) ? 'card-def' : 'field-def',
-        displayName: isCardDef(card) ? card.displayName : null,
+        type: definitionKind(card),
+        displayName: definitionDisplayName(card),
       };
     } catch (err: any) {
       console.warn(
@@ -607,10 +609,8 @@ async function makeDefinition(
       codeRef,
       fields,
       fieldDefs,
-      type: isCardDef(cardOrFieldDef) ? 'card-def' : 'field-def',
-      displayName: isCardDef(cardOrFieldDef)
-        ? cardOrFieldDef.displayName
-        : null,
+      type: definitionKind(cardOrFieldDef),
+      displayName: definitionDisplayName(cardOrFieldDef),
     };
     let operations = await captureOperations(
       cardOrFieldDef,

--- a/packages/host/tests/acceptance/prerender-module-test.gts
+++ b/packages/host/tests/acceptance/prerender-module-test.gts
@@ -228,8 +228,8 @@ module('Acceptance | prerender | module', function (hooks) {
     );
     assert.strictEqual(photoFile?.type, 'file-def', 'a file def is a file def');
 
-    // `displayName` names the thing a user sees, which a card and a file both
-    // have and a field does not.
+    // Every family declares a display name on its class; the entry records one
+    // only for the families a consumer can address by URL.
     assert.strictEqual(photo?.displayName, 'Photo', "a card's display name");
     assert.strictEqual(
       photoFile?.displayName,
@@ -255,6 +255,34 @@ module('Acceptance | prerender | module', function (hooks) {
     assert.ok(
       'contentType' in (photoFile?.fields ?? {}),
       "a file def's fields are captured",
+    );
+
+    // Ancestry is recorded for both families that have one to filter on, each
+    // walked up to its own family's root. A field def has no URL, so none.
+    let typesFor = (name: string) => {
+      let entry = model.definitions[`${moduleAlias}/${name}`];
+      return entry?.type === 'definition' ? entry.types : [];
+    };
+    assert.ok(
+      typesFor('Photo').includes(`${baseRealmRRI}card-api/CardDef`),
+      "a card's ancestry reaches CardDef",
+    );
+    assert.ok(
+      typesFor('PhotoFile').includes(`${moduleAlias}/PhotoFile`),
+      "a file's ancestry includes itself",
+    );
+    assert.ok(
+      typesFor('PhotoFile').includes(`${baseRealmRRI}card-api/FileDef`),
+      "a file's ancestry reaches FileDef",
+    );
+    assert.notOk(
+      typesFor('PhotoFile').includes(`${baseRealmRRI}card-api/CardDef`),
+      "a file's ancestry stops at its own family root",
+    );
+    assert.deepEqual(
+      typesFor('Caption'),
+      [],
+      'a field def records no ancestry',
     );
   });
 

--- a/packages/host/tests/acceptance/prerender-module-test.gts
+++ b/packages/host/tests/acceptance/prerender-module-test.gts
@@ -94,6 +94,26 @@ module('Acceptance | prerender | module', function (hooks) {
       @field reviewer = linksTo(() => SearchAuthor, { searchable: 'bogus' });
     }
   `;
+  // The three `BaseDef` families in one module, so a single visit shows how
+  // definition build classifies each of them.
+  const FAMILIES_MODULE = `
+    import { CardDef, FieldDef, field, contains, StringField } from '@cardstack/base/card-api';
+    import { FileDef } from '@cardstack/base/file-api';
+
+    export class Caption extends FieldDef {
+      static displayName = 'Caption';
+      @field text = contains(StringField);
+    }
+
+    export class Photo extends CardDef {
+      static displayName = 'Photo';
+      @field caption = contains(Caption);
+    }
+
+    export class PhotoFile extends FileDef {
+      static displayName = 'PhotoFile';
+    }
+  `;
   // One declaration that lowers cleanly (Note.addTag) and one whose clause
   // names a field the type does not have (Note.addNote), so the same visit
   // covers both the captured `operations` and the recorded findings.
@@ -132,6 +152,7 @@ module('Acceptance | prerender | module', function (hooks) {
           'broken.gts': BROKEN_MODULE,
           'searchable-card.gts': SEARCHABLE_MODULE,
           'note.gts': OPERATIONS_MODULE,
+          'families.gts': FAMILIES_MODULE,
         },
       }),
     ));
@@ -175,6 +196,52 @@ module('Acceptance | prerender | module', function (hooks) {
     assert.ok(
       personEntry.types.includes(`${baseRealmRRI}card-api/CardDef`),
       'types include base card',
+    );
+  });
+
+  test('classifies each of the three BaseDef families', async function (assert) {
+    // A file is a sibling of a card under `BaseDef`, not a kind of field: it
+    // has a URL and content-derived metadata, so the entry a consumer reads to
+    // decide what a target supports has to tell it apart from a field.
+    let moduleURL = `${testRealmURL}families.gts`;
+
+    await visit(modulePath(moduleURL));
+    let { model } = captureModuleResult();
+
+    let moduleAlias = trimExecutableExtension(rri(moduleURL));
+    let definitionFor = (name: string) => {
+      let entry = model.definitions[`${moduleAlias}/${name}`];
+      assert.strictEqual(entry.type, 'definition', `${name} has a definition`);
+      return entry.type === 'definition' ? entry.definition : undefined;
+    };
+    let photo = definitionFor('Photo');
+    let caption = definitionFor('Caption');
+    let photoFile = definitionFor('PhotoFile');
+
+    assert.strictEqual(photo?.type, 'card-def', 'a card def is a card def');
+    assert.strictEqual(
+      caption?.type,
+      'field-def',
+      'a field def is a field def',
+    );
+    assert.strictEqual(photoFile?.type, 'file-def', 'a file def is a file def');
+
+    // `displayName` names the thing a user sees, which a card and a file both
+    // have and a field does not.
+    assert.strictEqual(photo?.displayName, 'Photo', "a card's display name");
+    assert.strictEqual(
+      photoFile?.displayName,
+      'PhotoFile',
+      "a file's display name",
+    );
+    assert.strictEqual(caption?.displayName, null, 'a field def carries none');
+
+    // A file def's own fields are captured the same way a card's are, so a
+    // consumer reads a file's metadata off its entry without loading the
+    // module.
+    assert.ok(
+      'contentType' in (photoFile?.fields ?? {}),
+      "a file def's fields are captured",
     );
   });
 

--- a/packages/host/tests/acceptance/prerender-module-test.gts
+++ b/packages/host/tests/acceptance/prerender-module-test.gts
@@ -113,6 +113,8 @@ module('Acceptance | prerender | module', function (hooks) {
     export class PhotoFile extends FileDef {
       static displayName = 'PhotoFile';
     }
+
+    export class PlainFile extends FileDef {}
   `;
   // One declaration that lowers cleanly (Note.addTag) and one whose clause
   // names a field the type does not have (Note.addNote), so the same visit
@@ -211,8 +213,8 @@ module('Acceptance | prerender | module', function (hooks) {
     let moduleAlias = trimExecutableExtension(rri(moduleURL));
     let definitionFor = (name: string) => {
       let entry = model.definitions[`${moduleAlias}/${name}`];
-      assert.strictEqual(entry.type, 'definition', `${name} has a definition`);
-      return entry.type === 'definition' ? entry.definition : undefined;
+      assert.strictEqual(entry?.type, 'definition', `${name} has a definition`);
+      return entry?.type === 'definition' ? entry.definition : undefined;
     };
     let photo = definitionFor('Photo');
     let caption = definitionFor('Caption');
@@ -234,7 +236,18 @@ module('Acceptance | prerender | module', function (hooks) {
       'PhotoFile',
       "a file's display name",
     );
-    assert.strictEqual(caption?.displayName, null, 'a field def carries none');
+    assert.strictEqual(
+      caption?.displayName,
+      null,
+      'the entry for a field def records none',
+    );
+    // A file def that declares no name of its own still records one: the entry
+    // carries whatever the class resolves to, inherited included.
+    assert.strictEqual(
+      definitionFor('PlainFile')?.displayName,
+      'File',
+      "an undeclared file def's inherited display name",
+    );
 
     // A file def's own fields are captured the same way a card's are, so a
     // consumer reads a file's metadata off its entry without loading the

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -223,6 +223,23 @@ module(basename(import.meta.filename), function () {
                 }
               }
             `,
+            // The three `BaseDef` families in one module, so the realm's own
+            // indexing writes an entry of each kind into the modules table.
+            'families.gts': `
+              import { CardDef, FieldDef, field, contains, StringField } from '@cardstack/base/card-api';
+              import { FileDef } from '@cardstack/base/file-api';
+              export class Caption extends FieldDef {
+                static displayName = "Caption";
+                @field text = contains(StringField);
+              }
+              export class Photo extends CardDef {
+                static displayName = "Photo";
+                @field caption = contains(Caption);
+              }
+              export class PhotoFile extends FileDef {
+                static displayName = "PhotoFile";
+              }
+            `,
             '1.json': {
               data: {
                 attributes: {
@@ -257,6 +274,71 @@ module(basename(import.meta.filename), function () {
           },
         });
       },
+    });
+
+    // A file has a URL and read-only, content-derived metadata, so a consumer
+    // deciding what a target supports has to be able to tell it apart from a
+    // field — which means the kind the indexer derived has to survive into the
+    // row a loaderless reader consults. Read straight off the row the fixture
+    // realm's own indexing wrote, so this covers the real classification and
+    // its persistence rather than either alone.
+    test('the indexer records each BaseDef family under its own kind', async function (assert) {
+      // The realm was from-scratch indexed during setup, and families.gts has
+      // no instances and is imported by nothing, so the realm-wide sweep is
+      // what put its row here. A module is addressable by either alias.
+      let rows = (await dbAdapter.execute(
+        `SELECT definitions FROM modules WHERE url = ANY($1) OR file_alias = ANY($1)`,
+        { bind: [[`${realmURL}families`, `${realmURL}families.gts`]] },
+      )) as { definitions: unknown }[];
+      assert.ok(rows.length > 0, 'the sweep cached the module');
+      let raw = rows[0].definitions;
+      let persisted =
+        typeof raw === 'string'
+          ? (JSON.parse(raw) as Record<string, any>)
+          : (raw as Record<string, any>);
+      let byExportName = Object.fromEntries(
+        Object.entries(persisted).map(([key, entry]) => [
+          key.split('/').pop(),
+          (entry as any).definition,
+        ]),
+      );
+      assert.deepEqual(
+        {
+          Photo: byExportName.Photo?.type,
+          Caption: byExportName.Caption?.type,
+          PhotoFile: byExportName.PhotoFile?.type,
+        },
+        {
+          Photo: 'card-def',
+          Caption: 'field-def',
+          PhotoFile: 'file-def',
+        },
+        'each family is recorded under its own kind',
+      );
+      // `displayName` names the thing a user sees, which a card and a file
+      // both have and a field does not.
+      assert.strictEqual(
+        byExportName.Photo?.displayName,
+        'Photo',
+        "a card def's display name",
+      );
+      assert.strictEqual(
+        byExportName.PhotoFile?.displayName,
+        'PhotoFile',
+        "a file def's display name",
+      );
+      assert.strictEqual(
+        byExportName.Caption?.displayName,
+        null,
+        'a field def carries none',
+      );
+      // A file def's own fields are captured the way a card's are, so a
+      // consumer reads a file's metadata off its entry without loading the
+      // module.
+      assert.ok(
+        'contentType' in (byExportName.PhotoFile?.fields ?? {}),
+        "a file def's fields are captured",
+      );
     });
 
     test('lookupDefinition', async function (assert) {

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -290,12 +290,15 @@ module(basename(import.meta.filename), function () {
         `SELECT definitions FROM modules WHERE url = ANY($1) OR file_alias = ANY($1)`,
         { bind: [[`${realmURL}families`, `${realmURL}families.gts`]] },
       )) as { definitions: unknown }[];
-      assert.ok(rows.length > 0, 'the sweep cached the module');
-      let raw = rows[0].definitions;
+      // Exactly one row: `modules` is keyed on (url, cache_scope, auth_user_id),
+      // so a second row for this module would mean the lookup below is reading
+      // an arbitrary one of them.
+      assert.strictEqual(rows.length, 1, 'the sweep cached the module once');
+      let raw = rows[0]?.definitions;
       let persisted =
         typeof raw === 'string'
           ? (JSON.parse(raw) as Record<string, any>)
-          : (raw as Record<string, any>);
+          : ((raw ?? {}) as Record<string, any>);
       let byExportName = Object.fromEntries(
         Object.entries(persisted).map(([key, entry]) => [
           key.split('/').pop(),
@@ -330,7 +333,7 @@ module(basename(import.meta.filename), function () {
       assert.strictEqual(
         byExportName.Caption?.displayName,
         null,
-        'a field def carries none',
+        'the entry for a field def records none',
       );
       // A file def's own fields are captured the way a card's are, so a
       // consumer reads a file's metadata off its entry without loading the

--- a/packages/runtime-common/card-operations/bxl-mirror-check.ts
+++ b/packages/runtime-common/card-operations/bxl-mirror-check.ts
@@ -1,0 +1,24 @@
+import type { BxlBoxelSourceDefinition } from '@cardstack/bxl/mutation';
+
+import type { DefinitionKind } from '../definitions.ts';
+
+// `BxlBoxelSourceDefinition` is a loaderless mirror of `Definition`, and it is
+// kept in step by hand: no call site hands a `Definition` to the mutation
+// planner, so nothing would notice the two drifting apart until the first one
+// tried. This record is what notices. `Record<DefinitionKind, …>` fails to
+// compile when the definition cache learns a family the mirror has no legal
+// value for, which is the direction that strands a caller.
+//
+// It lives here rather than in `definitions.ts` because reaching for a bxl type
+// pulls bxl's sources into the typecheck program of whatever imports it, and
+// lowering is the one entry that already pays that. Nothing imports this file:
+// the package's own typecheck covers every file under it, which is exactly the
+// reach this guard wants.
+export const bxlMirroredDefinitionKinds = {
+  'card-def': 'card-def',
+  'field-def': 'field-def',
+  'file-def': 'file-def',
+} satisfies Record<
+  DefinitionKind,
+  NonNullable<BxlBoxelSourceDefinition['type']>
+>;

--- a/packages/runtime-common/definitions.ts
+++ b/packages/runtime-common/definitions.ts
@@ -1,5 +1,7 @@
 import {
   identifyCard,
+  isCardDef,
+  isFileDef,
   primitive,
   fieldSerializer,
   isResolvedCodeRef,
@@ -26,6 +28,34 @@ export interface FieldDefinition {
   searchable?: Searchable;
 }
 
+// Which of the three `BaseDef` families a definition describes. A card has its
+// own URL and is the target of card operations; a field is a value that only
+// exists inside a card and has no URL; a file describes uploaded bytes, which
+// have a URL and read-only, content-derived metadata. Files are a sibling of
+// cards under `BaseDef`, not a kind of field, and consumers that reason about
+// what a target supports — operation dispatch, lowering, authorization — read
+// this to tell the three apart without loading the type's module.
+export type DefinitionKind = 'card-def' | 'field-def' | 'file-def';
+
+// Classify a def for its definition entry. This is the single test the
+// definition producers share, so every entry in the cache answers the question
+// the same way.
+export function definitionKind(def: typeof BaseDef): DefinitionKind {
+  if (isCardDef(def)) {
+    return 'card-def';
+  }
+  if (isFileDef(def)) {
+    return 'file-def';
+  }
+  return 'field-def';
+}
+
+// A def's `displayName` is only meaningful for the families that name a thing
+// a user sees — a card or a file. A field def carries none.
+export function definitionDisplayName(def: typeof BaseDef): string | null {
+  return isCardDef(def) || isFileDef(def) ? def.displayName : null;
+}
+
 // `Definition.fields` only carries the **immediate** field map. Dotted
 // paths like `cardInfo.theme.cardInfo.name` are resolved at lookup time
 // by chasing each segment's `fieldOrCard` codeRef through
@@ -34,7 +64,7 @@ export interface FieldDefinition {
 // `cardInfo.theme`), and the per-segment cost at lookup time is
 // dominated by the `CachingDefinitionLookup`'s warm-cache hit.
 export interface Definition {
-  type: 'card-def' | 'field-def';
+  type: DefinitionKind;
   codeRef: CodeRef;
   displayName: string | null;
   fields: { [fieldName: string]: string };

--- a/packages/runtime-common/definitions.ts
+++ b/packages/runtime-common/definitions.ts
@@ -29,12 +29,11 @@ export interface FieldDefinition {
 }
 
 // Which of the three `BaseDef` families a definition describes. A card has its
-// own URL and is the target of card operations; a field is a value that only
-// exists inside a card and has no URL; a file describes uploaded bytes, which
-// have a URL and read-only, content-derived metadata. Files are a sibling of
-// cards under `BaseDef`, not a kind of field, and consumers that reason about
-// what a target supports — operation dispatch, lowering, authorization — read
-// this to tell the three apart without loading the type's module.
+// own URL; a field is a value that only exists inside a card and has no URL; a
+// file describes uploaded bytes, which have a URL and read-only,
+// content-derived metadata. Files are a sibling of cards under `BaseDef`, not a
+// kind of field, so recording the family is what lets a reader holding only the
+// cached entry tell a file from a field without loading the type's module.
 export type DefinitionKind = 'card-def' | 'field-def' | 'file-def';
 
 // Classify a def for its definition entry. This is the single test the
@@ -50,10 +49,13 @@ export function definitionKind(def: typeof BaseDef): DefinitionKind {
   return 'field-def';
 }
 
-// A def's `displayName` is only meaningful for the families that name a thing
-// a user sees — a card or a file. A field def carries none.
+// The display name a definition entry records. Every family declares one on its
+// class, but the entry carries it only for the families a consumer can address
+// by URL — a card or a file — where the name identifies something the reader
+// can go and fetch. Derived from `definitionKind` so the two cannot disagree
+// about which families those are.
 export function definitionDisplayName(def: typeof BaseDef): string | null {
-  return isCardDef(def) || isFileDef(def) ? def.displayName : null;
+  return definitionKind(def) === 'field-def' ? null : def.displayName;
 }
 
 // `Definition.fields` only carries the **immediate** field map. Dotted

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1376,7 +1376,6 @@ export * from './searchable-parity.ts';
 export * from './infer-content-type.ts';
 export * from './index-query-engine.ts';
 export * from './index-writer.ts';
-export * from './definitions.ts';
 export * from './index-structure.ts';
 export * from './db.ts';
 export * from './tasks/index.ts';


### PR DESCRIPTION
## What this does

A card module can export three kinds of `BaseDef`. A `CardDef` is a card with its own URL. A `FieldDef` is a value that lives inside a card and has no URL. A `FileDef` describes uploaded bytes — an image, a PDF, a spreadsheet — whose metadata is derived from the content and served read-only; it is a sibling of `CardDef` under `BaseDef`, not a subclass of either.

The definition cache is how a server learns a type's shape without loading its JavaScript: the module route reads each exported type off its class and stores a `Definition` as JSON in the `modules` table. Its `type` field carried only `card-def` and `field-def`, and both producers decided with a single `isCardDef` test — so every `FileDef` subclass landed in the cache as a field def. That is wrong in a way that matters as soon as a consumer asks the cache what a target is: a field has no URL and supports no operations, while a file has a URL and supports `read`.

This widens `Definition['type']` to `'card-def' | 'field-def' | 'file-def'` and gives the two producers in `packages/host/app/routes/module.ts` a shared `definitionKind` / `definitionDisplayName` pair, so both sites answer the question the same way rather than drifting.

## Treating a file as a first-class kind, not a half one

Recording the kind is only half of it — the rest of the entry has to stop treating a file as a non-card:

- **`displayName`.** Every family declares one on its class, and the entry now records it for both families a consumer can address by URL. A def that declares none of its own inherits its family's placeholder — `Card` or `File`, which names the family rather than the type — so the class name is used instead, for either family.
- **`types`.** A file has an ancestry worth filtering on exactly as a card does, so it is recorded rather than left empty. `getTypes` walks whichever family it is handed, up to that family's own root (`CardDef` for a card, `FileDef` for a file) and stays inside it, so the root it stops at is what says which family the walk covered. A field def has no URL and still records none.

## Keeping the bxl mirror honest

`BxlBoxelSourceDefinition` in `packages/bxl/src/mutation/boxel-source-adapter.ts` is a documented loaderless subset of the same `Definition` shape, so it carries the same three kinds. Nothing in that package branches on the value and no `Definition` is handed to it today, which is exactly the problem: drift would surface only when the first caller tried, and nothing would have caught the two-kind mirror this PR widens.

`packages/runtime-common/card-operations/bxl-mirror-check.ts` makes the compiler catch it — a `satisfies Record<DefinitionKind, …>` that fails to build when the cache learns a family the mirror has no legal value for. It sits outside the package barrel deliberately: reaching for a bxl type pulls bxl's sources into the typecheck program of whatever imports it, and lowering is the one entry that already pays that. Nothing imports the file; the package's own typecheck covers every file under it, which is the reach this guard wants.

## Scope

Nothing switches on the two old values anywhere, so the cache change is additive:

- Definitions for card and field types are byte-identical.
- No cache migration: the cache is rebuilt on demand and cleared on realm-server boot, so any stale `field-def` row for a file type heals on its next miss.
- `ModuleDefinitionResult.types` has no production reader today, so filling it for files changes no behaviour — it removes an asymmetry that would otherwise read as an oversight.

## Test plan

- `packages/host/tests/acceptance/prerender-module-test.gts` — a `families.gts` fixture exports a `FieldDef`, a `CardDef`, and two `FileDef` subclasses (one declaring a display name, one not). A single visit asserts the module route classifies each under its own kind, records `displayName` for the card and the files only, resolves the undeclared file def's inherited name, captures the file def's own fields, and walks each family's ancestry to its own root and no further.
- `packages/realm-server/tests/definition-lookup-test.ts` — the same module is added to the permissioned-realm fixture, and a new test reads the `modules` row the realm's own from-scratch indexing wrote. The module has no instances and is imported by nothing, so the realm-wide pre-warm sweep is what put it there — which makes this cover the real classification and its persistence together rather than either alone.
- The mirror guard was verified to bite: narrowing the bxl union back to two kinds fails `runtime-common`'s typecheck on that file.
- Existing definition tests are untouched.

Locally: `lint:types` and `eslint` are green for `runtime-common`, `host`, `realm-server`, and `bxl`, and bxl's own suite passes 71/71 — including `tests/boxel/card-source-mutation.ts`, which drives the adapter's `Definition` schema. The host and realm-server suites need the full stack, so they run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJ7J3K5k9aSdqaKWqX6BB1