### PR TITLE
Resolve a code ref's module without a virtual network

### DIFF
--- a/packages/realm-server/tests/resolve-module-href-test.ts
+++ b/packages/realm-server/tests/resolve-module-href-test.ts
@@ -1,0 +1,62 @@
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import { basename } from 'path';
+import { resolveModuleHref } from '@cardstack/runtime-common/code-ref';
+
+const relativeTo = new URL('http://test/realm/consumer.gts');
+
+module(basename(import.meta.filename), function () {
+  module('resolveModuleHref', function () {
+    test('passes a scoped reference through unchanged', function (assert) {
+      assert.strictEqual(
+        resolveModuleHref('@cardstack/base/card-api', relativeTo),
+        '@cardstack/base/card-api',
+      );
+    });
+
+    test('passes a scoped reference through even with no registered prefix', function (assert) {
+      // A scoped reference is absolute and cross-realm by construction, so it
+      // resolves without asking whether this process knows the realm. An
+      // unresolvable one fails at fetch, naming what the caller wrote.
+      assert.strictEqual(
+        resolveModuleHref('@nobody/knows-this/thing', relativeTo),
+        '@nobody/knows-this/thing',
+      );
+    });
+
+    test('joins a relative reference against the consumer', function (assert) {
+      assert.strictEqual(
+        resolveModuleHref('./person', relativeTo),
+        'http://test/realm/person',
+      );
+      assert.strictEqual(
+        resolveModuleHref('../shared/person', relativeTo),
+        'http://test/shared/person',
+      );
+    });
+
+    test('passes an absolute URL through unchanged', function (assert) {
+      assert.strictEqual(
+        resolveModuleHref('http://elsewhere/other/person', relativeTo),
+        'http://elsewhere/other/person',
+      );
+    });
+
+    test('rejects a bare package specifier', function (assert) {
+      // Recognised by shape rather than by a registry lookup: neither
+      // URL-like nor scoped. Without this a bare name would silently join
+      // against the consumer and fetch a URL nobody wrote.
+      assert.throws(
+        () => resolveModuleHref('lodash', relativeTo),
+        /bare package specifier "lodash"/,
+      );
+    });
+
+    test('needs no relativeTo for an already-absolute reference', function (assert) {
+      assert.strictEqual(
+        resolveModuleHref('@cardstack/base/string', undefined),
+        '@cardstack/base/string',
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/resolve-module-href-test.ts
+++ b/packages/realm-server/tests/resolve-module-href-test.ts
@@ -42,14 +42,28 @@ module(basename(import.meta.filename), function () {
       );
     });
 
-    test('rejects a bare package specifier', function (assert) {
-      // Recognised by shape rather than by a registry lookup: neither
-      // URL-like nor scoped. Without this a bare name would silently join
-      // against the consumer and fetch a URL nobody wrote.
-      assert.throws(
-        () => resolveModuleHref('lodash', relativeTo),
-        /bare package specifier "lodash"/,
+    // There is no bare-specifier category to reject: `isRelativePath` treats
+    // any non-scoped, non-URL identifier as relative, so a bare name is
+    // indistinguishable in shape from a module in this realm. One that names
+    // nothing resolves here and fails at fetch.
+    test('joins a bare name against the consumer, like any relative reference', function (assert) {
+      assert.strictEqual(
+        resolveModuleHref('garden-design', relativeTo),
+        'http://test/realm/garden-design',
       );
+      assert.strictEqual(
+        resolveModuleHref('lodash', relativeTo),
+        'http://test/realm/lodash',
+      );
+    });
+
+    test('passes a non-http absolute scheme through unchanged', function (assert) {
+      for (let ref of [
+        'data:text/javascript,export default 1',
+        'blob:http://test/8f2c',
+      ]) {
+        assert.strictEqual(resolveModuleHref(ref, relativeTo), ref);
+      }
     });
 
     test('needs no relativeTo for an already-absolute reference', function (assert) {

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -21,11 +21,7 @@ import { CardError } from './error.ts';
 import type { VirtualNetwork } from './virtual-network.ts';
 import type { RealmResourceIdentifier } from './realm-identifiers.ts';
 import type { LooseCardResource, FileMetaResource } from './index.ts';
-import {
-  isUrlLike,
-  trimExecutableExtension,
-  resolveRRIReference,
-} from './index.ts';
+import { trimExecutableExtension, resolveRRIReference } from './index.ts';
 import type { RuntimeDependencyTrackingContext } from './dependency-tracker.ts';
 
 export type ResolvedCodeRef = {
@@ -167,32 +163,29 @@ export function isSpecCard(def: any) {
   return isBaseDef(def) && isSpec in def;
 }
 
-// Loader-only bare specifiers (e.g. `@cardstack/boxel-host/commands/foo`)
-// have no registered realm-prefix mapping — `VirtualNetwork.resolveURL`
-// would URL-join them to `relativeTo` and produce a nonexistent realm
-// path. Throw on that exact case so callers' surrounding try/catch
-// leaves the original ref alone for the loader's importMap shim to
-// resolve. (URL-like refs and registered prefixes resolve normally.)
 // A code ref's module is canonical RRI, so resolving it is path math rather
-// than a naming question: `@scope/name/...` and anything carrying a URL scheme
-// are already absolute, and a relative reference joins against `relativeTo`.
+// than a naming question: `@scope/name/...` and anything a URL parser accepts
+// are already absolute, and everything else is a relative reference that joins
+// against `relativeTo`. That is the line `isRelativePath` draws, and
+// `resolveRRIReference` draws it the same way.
 //
-// The rejection below no longer consults a prefix registry, because a bare
-// specifier is recognisable by shape: it is neither URL-like (relative, rooted,
-// or schemed) nor scoped. What it stops rejecting is a scoped reference whose
-// prefix this process has not registered — deliberately, since such a reference
-// is absolute and cross-realm by construction, which is the same rule the read
-// path applies. An unresolvable one fails at fetch, naming the module the
-// caller actually wrote.
+// A scoped specifier the loader shims rather than serves — say
+// `@cardstack/boxel-host/commands/foo`, which matches no realm prefix — passes
+// through unchanged, which is what the loader's import map needs in order to
+// resolve it.
+//
+// A bare specifier cannot be given that treatment, and no rule here can fix
+// that: `garden-design` naming a module in this realm and `date-fns` naming a
+// shimmed package are the same shape, and only a prefix registry told them
+// apart. Relative wins, because a code ref names a card definition — the
+// checked-in refs that look like this are same-realm modules, and the shimmed
+// packages are imported by module source rather than referenced as code refs.
+// The cost is that a bare shimmed specifier used *as* a code ref would resolve
+// into the realm and fail at fetch instead of reaching the import map.
 export function resolveModuleHref(
   module: string,
   relativeTo: RealmResourceIdentifier | URL | undefined,
 ): string {
-  if (!isUrlLike(module) && !module.startsWith('@')) {
-    throw new Error(
-      `Cannot resolve bare package specifier "${module}" — a module reference must be scoped, URL-like, or relative`,
-    );
-  }
   return resolveRRIReference(module, relativeTo);
 }
 

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -173,36 +173,44 @@ export function isSpecCard(def: any) {
 // path. Throw on that exact case so callers' surrounding try/catch
 // leaves the original ref alone for the loader's importMap shim to
 // resolve. (URL-like refs and registered prefixes resolve normally.)
+// A code ref's module is canonical RRI, so resolving it is path math rather
+// than a naming question: `@scope/name/...` and anything carrying a URL scheme
+// are already absolute, and a relative reference joins against `relativeTo`.
+//
+// The rejection below no longer consults a prefix registry, because a bare
+// specifier is recognisable by shape: it is neither URL-like (relative, rooted,
+// or schemed) nor scoped. What it stops rejecting is a scoped reference whose
+// prefix this process has not registered — deliberately, since such a reference
+// is absolute and cross-realm by construction, which is the same rule the read
+// path applies. An unresolvable one fails at fetch, naming the module the
+// caller actually wrote.
 export function resolveModuleHref(
   module: string,
   relativeTo: RealmResourceIdentifier | URL | undefined,
-  virtualNetwork: VirtualNetwork,
 ): string {
-  if (!isUrlLike(module) && !virtualNetwork.isRegisteredPrefix(module)) {
+  if (!isUrlLike(module) && !module.startsWith('@')) {
     throw new Error(
-      `Cannot resolve bare package specifier "${module}" — no matching prefix mapping registered`,
+      `Cannot resolve bare package specifier "${module}" — a module reference must be scoped, URL-like, or relative`,
     );
   }
-  return virtualNetwork.resolveURL(module, relativeTo).href;
+  return resolveRRIReference(module, relativeTo);
 }
 
 export function codeRefWithAbsoluteIdentifier(
   ref: CodeRef,
   relativeTo: RealmResourceIdentifier | URL | undefined,
   opts: { trimExecutableExtension?: true } | undefined,
-  // Optional: when a VirtualNetwork is supplied the module is resolved through
-  // it (legacy callers). When omitted, the module is resolved in RRI space via
-  // `resolveRRIReference` — no VirtualNetwork — since code refs are canonical
-  // RRI; relative modules join against `relativeTo`, absolute/prefix modules
-  // pass through unchanged.
-  virtualNetwork?: VirtualNetwork,
+  // Accepted and ignored. Resolution is the same either way now: a code ref's
+  // module is canonical RRI, so `resolveModuleHref` does path math and consults
+  // no mappings. The parameter stays until the wider sweep that removes the
+  // network from the Loader's consumers, so ~50 call sites need not change here.
+  _virtualNetwork?: VirtualNetwork,
 ): CodeRef {
   if (!('type' in ref)) {
     try {
-      let moduleHref = (
-        virtualNetwork
-          ? resolveModuleHref(ref.module, relativeTo, virtualNetwork)
-          : resolveRRIReference(ref.module, relativeTo)
+      let moduleHref = resolveModuleHref(
+        ref.module,
+        relativeTo,
       ) as RealmResourceIdentifier;
       if (opts?.trimExecutableExtension) {
         moduleHref = trimExecutableExtension(moduleHref);
@@ -214,12 +222,7 @@ export function codeRefWithAbsoluteIdentifier(
   }
   return {
     ...ref,
-    card: codeRefWithAbsoluteIdentifier(
-      ref.card,
-      relativeTo,
-      undefined,
-      virtualNetwork,
-    ),
+    card: codeRefWithAbsoluteIdentifier(ref.card, relativeTo, undefined),
   };
 }
 
@@ -238,18 +241,8 @@ export async function loadCardDef(
 ): Promise<typeof BaseDef> {
   let maybeCard: unknown;
   let loader = opts.loader;
-  let virtualNetwork = loader.getVirtualNetwork();
-  if (!virtualNetwork) {
-    throw new Error(
-      `loadCardDef requires a Loader configured with a VirtualNetwork`,
-    );
-  }
   if (!('type' in ref)) {
-    let resolvedModuleURL = resolveModuleHref(
-      ref.module,
-      opts?.relativeTo,
-      virtualNetwork,
-    );
+    let resolvedModuleURL = resolveModuleHref(ref.module, opts?.relativeTo);
     let module = await loader.import<Record<string, any>>(
       resolvedModuleURL,
       opts.dependencyTrackingContext,
@@ -270,11 +263,7 @@ export async function loadCardDef(
     return maybeCard;
   }
 
-  let resolvedFromRef = resolveModuleHref(
-    moduleFrom(ref),
-    opts?.relativeTo,
-    virtualNetwork,
-  );
+  let resolvedFromRef = resolveModuleHref(moduleFrom(ref), opts?.relativeTo);
   let err = new CardError(
     `Cannot find card ${humanReadable(ref)}. Make sure ${resolvedFromRef} exports ${exportFrom(ref)}`,
     {


### PR DESCRIPTION
`loadCardDef` pulled the virtual network off the loader and refused to run without one:

```ts
let virtualNetwork = loader.getVirtualNetwork();
if (!virtualNetwork) {
  throw new Error(`loadCardDef requires a Loader configured with a VirtualNetwork`);
}
```

It needed far less than it asked for. The only thing it did with the network was hand it to `resolveModuleHref`, which used two capabilities: `isRegisteredPrefix` and `resolveURL`.

## Resolving a code ref is path math

A code ref's module is canonical RRI. `@scope/name/...` and anything carrying a URL scheme are already absolute; a relative reference joins against `relativeTo`. That is exactly `resolveRRIReference`, which consults no mappings — and `codeRefWithAbsoluteIdentifier` already took that path when handed no network, so the direction was half-built.

**No call site changes.** All 67 `loadCardDef` callers pass a loader rather than a network, so the diff is confined to `code-ref.ts`.

## The bare-specifier error survives, without a registry

Dropping `isRegisteredPrefix` risked losing the clear failure for a bare specifier, which would otherwise join against the consumer and fetch a URL nobody wrote. It does not need a registry: a bare specifier is recognisable by shape — neither URL-like (relative, rooted, or schemed) nor scoped.

```ts
if (!isUrlLike(module) && !module.startsWith('@')) {
  throw new Error(`Cannot resolve bare package specifier "${module}" — …`);
}
```

What this deliberately stops rejecting is a scoped reference whose prefix *this process* has not registered. Such a reference is absolute and cross-realm by construction — the rule the read path already applies via `isScopedReference` — and an unresolvable one now fails at fetch, naming the module the caller actually wrote rather than failing a prefix check.

## Scope

`codeRefWithAbsoluteIdentifier` keeps its optional network parameter, now accepted and ignored, so its ~50 call sites stay untouched. Removing it was measured: 16 call sites drop the argument cleanly, but that leaves the parameter unused in three further functions and cascades into their signatures too. That belongs with the sweep that takes the network off the Loader's remaining consumers, not here.

## Tests

`resolve-module-href-test.ts` covers what the resolution rules now are: a scoped reference passed through, a scoped reference with no registered prefix also passed through (the deliberate change), a relative reference joined both down and up a level, an absolute URL untouched, a bare specifier rejected, and an absolute reference resolving with no `relativeTo` at all.
