### PR TITLE
Baseline every Percy build against main

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -696,6 +696,23 @@ jobs:
           # failure) is visible in the shard log for each snapshot.
           PERCY_LOGLEVEL: debug
           PERCY_TOKEN: ${{ needs.check-percy.outputs.percy_needed == 'true' && secrets.PERCY_TOKEN_HOST || '' }}
+          # Compare against main, not against whatever branch this one was cut
+          # from. Left unset, Percy infers the baseline from git history, so a
+          # branch stacked on another feature branch baselines against its
+          # parent and inherits whatever that parent's last build contained.
+          #
+          # A parent build that lost snapshots is the bad case. The child
+          # compares its full set against a partial one, every snapshot with no
+          # counterpart reads as new, and most of the suite lands needing review
+          # for a reason nothing on the build explains. The reject step below
+          # keeps a partial build from becoming a baseline on `main`, but a
+          # partial build on a feature branch is not rejected and can still be
+          # inherited by anything stacked on it.
+          #
+          # Set here rather than on the finalize step: the baseline is chosen
+          # when the build is created by the first shard to upload, and finalize
+          # only seals it.
+          PERCY_TARGET_BRANCH: main
           PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
           HOST_TEST_PARTITION: ${{ matrix.shardIndex }}
           HOST_TEST_PARTITION_COUNT: ${{ matrix.shardTotal }}


### PR DESCRIPTION
Percy picks a build's baseline from git history when nothing tells it otherwise. A branch stacked on another feature branch is therefore compared against its parent rather than against main, and inherits whatever that parent's most recent build happened to contain.

The case that hurts is a parent build that lost snapshots. The child compares its full set against a partial one, every snapshot with no counterpart reads as new, and the build lands with most of the suite needing review — with nothing on the build explaining why.

## The build that prompted this

A 59-snapshot build was baselined against a **four-snapshot** build on a sibling branch, whose own review state was `missing_snapshots`. 55 snapshots reported as changed, at `diff-ratio: 1` — the ratio for "no counterpart to compare against", not for a visual change. None of the 55 were real.

That has now happened on two branches, and it is indistinguishable at a glance from a change that genuinely moved the whole suite.

## Why the existing gate does not cover it

The reject step in this workflow already stops a partial build becoming a baseline **on `main`**, and its comment describes exactly this failure: a partial set becomes the baseline every later branch is compared against. What it cannot do is stop a partial build on a *feature* branch from being inherited by something stacked on it — nothing rejects those, because nothing needs to until they are used as a baseline.

Pinning the target branch closes that path without having to extend the gate.

## What changes

Every build now compares against main, which is gated by that reject step and auto-approved. For a stacked PR the diff becomes its cumulative effect against main rather than only its increment over its parent — the same comparison an unstacked branch already gets, and the one a reviewer of the eventual merge cares about.

Set on the step that takes snapshots rather than the finalize step: the baseline is chosen when the build is created by the first shard to upload, and finalize only seals it.
