### PR TITLE
Give the definition-container header a whole-pixel min-height

### DIFF
--- a/packages/boxel-ui/src/components/header/usage.gts
+++ b/packages/boxel-ui/src/components/header/usage.gts
@@ -102,7 +102,10 @@ export default class HeaderUsage extends Component {
     </FreestyleUsage>
     <style scoped>
       .definition-container {
-        --boxel-header-min-height: 1.56rem;
+        /* 25px exactly. 1.56rem is 24.96px, and a fractional height
+           leaves every engine to round it its own way — which is how
+           the same content lands a pixel apart between browsers. */
+        --boxel-header-min-height: 1.5625rem;
         --boxel-header-padding: var(--boxel-sp-5xs) var(--boxel-sp-xs);
         --boxel-header-background-color: var(--boxel-300);
         --boxel-header-text-color: var(--boxel-dark);

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -39,7 +39,10 @@ const BaseContainerHeader: TemplateOnlyComponent<BaseContainerHeaderSignature> =
     </Header>
     <style scoped>
       .base-container-header {
-        --boxel-header-min-height: 1.56rem;
+        /* 25px exactly. 1.56rem is 24.96px, and a fractional height
+           leaves every engine to round it its own way — which is how
+           the same content lands a pixel apart between browsers. */
+        --boxel-header-min-height: 1.5625rem;
         --boxel-header-padding: var(--boxel-sp-5xs) var(--boxel-sp-xs);
         --boxel-header-background-color: var(--boxel-300);
         --boxel-header-text-color: var(--boxel-dark);


### PR DESCRIPTION
This is meant to address this pattern of Percy diffs, which only shows in Firefox, a tiny shift in the sidebare:

<img width="2486" height="1388" alt="s 2026-09-10 at 15 55 04@2x" src="https://github.com/user-attachments/assets/6619c100-0189-4044-be81-b70a1b1b41ed" />


Claude: `--boxel-header-min-height: 1.56rem` is **24.96px** at the default root size. A fractional height leaves each engine to round it however it likes, so the same content can land a pixel apart between browsers, and everything below the header shifts with it.

The value reads as a conversion that lost precision: 25 ÷ 16 is 1.5625, and `1.56` is that rounded to two places. `1.5625rem` is 25px exactly. The surrounding declarations already sit on whole pixels — the button min-height two rules down is `1.5rem`, a clean 24px.

## Why this is worth changing

An inspector-sidebar snapshot has been reporting a **Firefox-only** diff, one comparison out of 118, at a `diff-ratio` of `0.00091737` — stable to six figures across builds and across two unrelated branches. That is the signature of a single region shifting by a fixed amount, not of anything either branch changed, and not of random rounding noise.

A fractional header height in that sidebar accounts for it. Of every `rem` value in the host component tree, only six fail to land on a whole pixel, and this is the one inside the affected component.

## This is a candidate, not a confirmed cause

I have not seen the rendered images, so the mechanism is inferred from the value and the diff's shape rather than observed. The test is whether the recurring diff stops. If it does not, the next thing to look at is what else in that sidebar computes to a fraction.

Expect a small one-time diff from this change itself: the header moves from 24.96px to 25px, so whichever engine was rounding down now agrees with the other.

The same declaration is duplicated in boxel-ui's header usage page. It is changed too, since that is where it would be copied from next.
