### PR TITLE
Coalesce realm-event-triggered live search re-runs behind a jittered window

### DIFF
--- a/packages/host/app/lib/live-search-refresh-scheduler.ts
+++ b/packages/host/app/lib/live-search-refresh-scheduler.ts
@@ -36,10 +36,6 @@ export class LiveSearchRefreshScheduler {
     this.#flush = flush;
   }
 
-  get isScheduled(): boolean {
-    return this.#timer !== undefined;
-  }
-
   schedule(): void {
     if (this.#timer !== undefined) {
       return;

--- a/packages/host/app/lib/live-search-refresh-scheduler.ts
+++ b/packages/host/app/lib/live-search-refresh-scheduler.ts
@@ -1,0 +1,75 @@
+import { buildWaiter } from '@ember/test-waiters';
+
+import { isTesting } from '@embroider/macros';
+
+const waiter = buildWaiter('live-search-refresh-scheduler:flush-waiter');
+
+// How long a live search waits after a realm event before re-running, so a
+// burst of events — one write's index event plus its prerender_html
+// follow-ups, or many concurrent writers — triggers one re-run instead of one
+// per event. Sized against the write cadence it exists to absorb: a steady
+// stream of saves (autosave, a busy shared realm) emits events more often
+// than once a second, and every re-run is a server-side search per open
+// client. Trailing-edge, so the run that fires reflects everything the
+// window accumulated.
+export const LIVE_SEARCH_REFRESH_WINDOW_MS = isTesting() ? 10 : 2000;
+
+// Random extra delay added per scheduled flush, so the many clients that all
+// receive the same realm event don't re-query in lockstep — without it a
+// popular realm turns every write into a synchronized thundering herd
+// against the search endpoints.
+export const LIVE_SEARCH_REFRESH_MAX_JITTER_MS = isTesting() ? 0 : 1000;
+
+// Coalesces schedule() calls into one deferred flush: the first call of a
+// burst arms the timer, later calls ride the armed flush, and the timer is
+// never extended — a continuous event stream still flushes once per window
+// rather than starving. The caller accumulates *what* to refresh (realm
+// sets, invalidation maps) in its own state; this class only owns *when* the
+// refresh runs. A test waiter spans arm-to-flush so `settled()` waits out
+// the window.
+export class LiveSearchRefreshScheduler {
+  #timer: ReturnType<typeof setTimeout> | undefined;
+  #token: unknown;
+  #flush: () => void;
+
+  constructor(flush: () => void) {
+    this.#flush = flush;
+  }
+
+  get isScheduled(): boolean {
+    return this.#timer !== undefined;
+  }
+
+  schedule(): void {
+    if (this.#timer !== undefined) {
+      return;
+    }
+    this.#token = waiter.beginAsync();
+    let delay =
+      LIVE_SEARCH_REFRESH_WINDOW_MS +
+      Math.random() * LIVE_SEARCH_REFRESH_MAX_JITTER_MS;
+    this.#timer = setTimeout(() => {
+      this.#timer = undefined;
+      let token = this.#token;
+      this.#token = undefined;
+      try {
+        this.#flush();
+      } finally {
+        waiter.endAsync(token as Parameters<typeof waiter.endAsync>[0]);
+      }
+    }, delay);
+  }
+
+  // Drops the armed flush without running it. For teardown and for a query
+  // change, where the events the window accumulated describe a result set
+  // that no longer exists.
+  cancel(): void {
+    if (this.#timer === undefined) {
+      return;
+    }
+    clearTimeout(this.#timer);
+    this.#timer = undefined;
+    waiter.endAsync(this.#token as Parameters<typeof waiter.endAsync>[0]);
+    this.#token = undefined;
+  }
+}

--- a/packages/host/app/resources/file-tree-from-index.ts
+++ b/packages/host/app/resources/file-tree-from-index.ts
@@ -1,4 +1,8 @@
-import { registerDestructor } from '@ember/destroyable';
+import {
+  isDestroyed,
+  isDestroying,
+  registerDestructor,
+} from '@ember/destroyable';
 import { service } from '@ember/service';
 import { buildWaiter } from '@ember/test-waiters';
 import { cached } from '@glimmer/tracking';
@@ -16,6 +20,8 @@ import {
   type CodeRef,
   type SearchEntryWireQuery,
 } from '@cardstack/runtime-common';
+
+import { LiveSearchRefreshScheduler } from '../lib/live-search-refresh-scheduler';
 
 import type StoreService from '../services/store';
 import type { RealmEventContent } from '@cardstack/base/matrix-event';
@@ -48,6 +54,14 @@ export class FileTreeFromIndexResource extends Resource<Args> {
   #fileTypeFilter: CodeRef | undefined;
   #fileFieldFilter: Record<string, unknown> | undefined;
   #subscription: { realmURL: string; unsubscribe: () => void } | undefined;
+  // Defers the event-triggered re-run so a burst of realm events — a write's
+  // index event plus its prerender_html follow-ups, or many concurrent
+  // writers — costs one `store.searchEntries` (a `_federated-search` POST),
+  // not one per event. Only event-triggered re-runs are deferred; the initial
+  // modify() search still runs immediately.
+  #refreshScheduler = new LiveSearchRefreshScheduler(() =>
+    this.#flushEventRefresh(),
+  );
   // @ts-ignore we use this.loaded for test instrumentation.
   private loaded: Promise<void> | undefined;
   private _fileURLs = new TrackedArray<string>();
@@ -55,6 +69,7 @@ export class FileTreeFromIndexResource extends Resource<Args> {
   constructor(owner: object) {
     super(owner);
     registerDestructor(this, () => {
+      this.#refreshScheduler.cancel();
       this.#subscription?.unsubscribe();
     });
   }
@@ -83,7 +98,7 @@ export class FileTreeFromIndexResource extends Resource<Args> {
             ) {
               return;
             }
-            this.search.perform();
+            this.#refreshScheduler.schedule();
           },
         ),
       };
@@ -93,6 +108,16 @@ export class FileTreeFromIndexResource extends Resource<Args> {
       return;
     }
     this.loaded = this.search.perform();
+  }
+
+  // The deferred arm of the subscription callback: performs one search over
+  // the burst the scheduler's window accumulated. Guarded against a teardown
+  // (or a not-yet-modified resource) between arm and flush.
+  #flushEventRefresh(): void {
+    if (isDestroyed(this) || isDestroying(this) || !this.#realmURL) {
+      return;
+    }
+    this.search.perform();
   }
 
   get isLoading(): boolean {

--- a/packages/host/app/resources/search-entries.ts
+++ b/packages/host/app/resources/search-entries.ts
@@ -43,6 +43,7 @@ import {
 } from '@cardstack/runtime-common';
 
 import { knownFileMetaUrls } from '../lib/known-file-meta-urls';
+import { LiveSearchRefreshScheduler } from '../lib/live-search-refresh-scheduler';
 import { normalizeRealms } from '../lib/realm-utils';
 import { searchErrorEntry } from '../lib/search-error-entry';
 
@@ -146,6 +147,17 @@ export class SearchEntriesResource extends Resource<Args> {
   // would keep fetching members the replacement run already owns.
   #refreshEpoch = 0;
 
+  // Defers the event-triggered re-run so a burst of realm events — one
+  // write's index event plus its prerender_html follow-ups, or a stream of
+  // concurrent writes — costs one search, not one per event. The subscription
+  // callback accumulates what to refresh (`realmsNeedingRefresh`,
+  // `pendingSelectiveRefresh`) and arms this; the flush performs the search
+  // over everything accumulated. Only event-triggered re-runs are deferred —
+  // a query/realm change in modify() still searches immediately.
+  #refreshScheduler = new LiveSearchRefreshScheduler(() =>
+    this.#flushEventRefresh(),
+  );
+
   // A partial refresh splices fetched-realm rows into the standing result
   // set, so it is only sound once a full run has populated that set. Until
   // then every run fetches all realms (an event arriving during the initial
@@ -177,6 +189,7 @@ export class SearchEntriesResource extends Resource<Args> {
     super(owner);
     registerDestructor(this, () => {
       this.search.cancelAll();
+      this.#refreshScheduler.cancel();
       for (let subscription of this.subscriptions) {
         subscription.unsubscribe();
       }
@@ -250,6 +263,7 @@ export class SearchEntriesResource extends Resource<Args> {
       this.#previousRealms = undefined;
       this.realmsNeedingRefresh.clear();
       this.pendingSelectiveRefresh = undefined;
+      this.#refreshScheduler.cancel();
       // An in-flight selective refresh must stop issuing GETs for the
       // cleared query, same as on teardown.
       this.#refreshEpoch++;
@@ -336,7 +350,7 @@ export class SearchEntriesResource extends Resource<Args> {
               `prerender_html event on ${realm}; scheduling selective per-member refresh`,
             );
             this.#recordSelectiveRefresh(event);
-            this.#trackSearchLoad(this.search.perform());
+            this.#refreshScheduler.schedule();
             return;
           }
 
@@ -344,7 +358,7 @@ export class SearchEntriesResource extends Resource<Args> {
             `${event.eventName === 'prerender_html' ? 'prerender_html' : 'incremental index'} event on ${realm}; scheduling partial refresh`,
           );
           this.realmsNeedingRefresh.add(realm);
-          this.#trackSearchLoad(this.search.perform());
+          this.#refreshScheduler.schedule();
         }),
       }));
     }
@@ -358,7 +372,10 @@ export class SearchEntriesResource extends Resource<Args> {
     // in place would otherwise be compared against itself and never re-run.
     this.#previousQuery = structuredClone(query);
     this.#previousRealms = realms;
-    // A query/realm change owns the whole result set again.
+    // A query/realm change owns the whole result set again — including any
+    // event-triggered refresh still waiting in the scheduler's window, whose
+    // accumulated state was just cleared.
+    this.#refreshScheduler.cancel();
     this.realmsNeedingRefresh.clear();
     this.pendingSelectiveRefresh = undefined;
     this.hasCompletedFullRun = false;
@@ -422,6 +439,22 @@ export class SearchEntriesResource extends Resource<Args> {
 
   get errors() {
     return this._errors;
+  }
+
+  // The deferred arm of the subscription callback: performs one search over
+  // everything the window accumulated. Guarded the same way the callback is —
+  // the query may have been cleared (or the resource destroyed) between arm
+  // and flush, and cancel() on those paths makes this mostly belt and
+  // suspenders.
+  #flushEventRefresh(): void {
+    if (
+      isDestroyed(this) ||
+      isDestroying(this) ||
+      this.#previousQuery === undefined
+    ) {
+      return;
+    }
+    this.#trackSearchLoad(this.search.perform());
   }
 
   private search = restartableTask(async () => {

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -45,6 +45,7 @@ import {
 } from '@cardstack/runtime-common';
 import type { Filter, Query } from '@cardstack/runtime-common/query';
 
+import { LiveSearchRefreshScheduler } from '../lib/live-search-refresh-scheduler';
 import { searchErrorEntry } from '../lib/search-error-entry';
 
 import type LoaderService from '../services/loader-service';
@@ -260,6 +261,21 @@ export class SearchResource<
   // side exact means stamping the resolution's own generation on the umbrella
   // relationship where the indexer resolves it.
   #resultGenerations = new Map<string, number>();
+  // Per realm, the highest generation carried by the realm events waiting on
+  // the scheduler's window — the coalesced form of what each event used to
+  // pass to its own `search.perform`. Consumed by the flush, which hands the
+  // batch to the search task to raise the floors above once the run
+  // succeeds. Untracked, like `#resultGenerations`: only the subscription
+  // callback writes it and only the flush reads it.
+  #pendingRefreshFloors = new Map<string, number>();
+  // Defers the event-triggered re-run so a burst of realm events costs one
+  // search, not one per event. The subscription callback accumulates the
+  // generation floors above and arms this; the flush performs the search.
+  // Only event-triggered re-runs are deferred — a query/realm change in
+  // modify() and a reseed's shortfall query still search immediately.
+  #refreshScheduler = new LiveSearchRefreshScheduler(() =>
+    this.#flushLiveRefresh(),
+  );
   // No match count is known yet and one must not be inferred. Tracked, because
   // `totalMatchCount` is read during render and has to re-derive when a seed or
   // a live search supplies a real count.
@@ -442,6 +458,7 @@ export class SearchResource<
   constructor(owner: object) {
     super(owner);
     registerDestructor(this, () => {
+      this.#refreshScheduler.cancel();
       for (let instance of this._instances) {
         this.runtimeStore.dropReference(instance.id);
       }
@@ -600,15 +617,21 @@ export class SearchResource<
             // The generation the indexing pass committed, and the realm whose
             // counter it belongs to. A search answering this event reads the
             // index at or after it, so together they stand as the floor for
-            // what the result set reflects of that realm.
+            // what the result set reflects of that realm. Accumulated rather
+            // than performed: the scheduler coalesces this event's re-run
+            // with the rest of its burst, and the flush passes the batch of
+            // floors to the one search that answers them all.
             let generation =
               'generation' in event && typeof event.generation === 'number'
                 ? event.generation
                 : undefined;
-            this.trackStoreLoad(
-              this.search.perform(this.#previousQuery, generation, realm),
-              'live-refresh',
-            );
+            if (generation !== undefined) {
+              let current = this.#pendingRefreshFloors.get(realm);
+              if (current === undefined || generation > current) {
+                this.#pendingRefreshFloors.set(realm, generation);
+              }
+            }
+            this.#refreshScheduler.schedule();
           }),
         };
       });
@@ -632,7 +655,13 @@ export class SearchResource<
     this.#previousRealms = realms;
     this.#previousQuery = query;
     this.#previousQueryString = queryString;
-    this.trackStoreLoad(this.search.perform(query), 'search');
+    // This run reads the index at least as fresh as any event still waiting
+    // on the scheduler's window, so fold the pending flush into it rather
+    // than letting a second search fire after it.
+    this.#refreshScheduler.cancel();
+    let floors = this.#pendingRefreshFloors;
+    this.#pendingRefreshFloors = new Map();
+    this.trackStoreLoad(this.search.perform(query, floors), 'search');
   }
 
   // Spelling-tolerant query identity, so a server-produced seed query
@@ -1088,8 +1117,31 @@ export class SearchResource<
     },
   );
 
+  // The deferred arm of the subscription callback: performs one search over
+  // the burst the scheduler's window accumulated, consuming the pending
+  // generation floors so the run carries them as its own. An event arriving
+  // after this consumes them lands in a fresh map and arms a fresh flush, so
+  // nothing is lost to the handoff; a run that fails (or is restarted by a
+  // query change) drops its batch, which only forgoes a floor raise — floors
+  // are a monotonic safety net, never load-bearing state.
+  #flushLiveRefresh(): void {
+    if (
+      isDestroyed(this) ||
+      isDestroying(this) ||
+      this.#previousQuery === undefined
+    ) {
+      return;
+    }
+    let floors = this.#pendingRefreshFloors;
+    this.#pendingRefreshFloors = new Map();
+    this.trackStoreLoad(
+      this.search.perform(this.#previousQuery, floors),
+      'live-refresh',
+    );
+  }
+
   private search = restartableTask(
-    async (query: Query, generation?: number, realm?: string) => {
+    async (query: Query, refreshFloors?: Map<string, number>) => {
       this.#log.info(
         `search task start; realms=${this.realmsToSearch.join(',')}; query=${JSON.stringify(query)}`,
       );
@@ -1129,7 +1181,9 @@ export class SearchResource<
           // restoring the very set the search moved off. What orders this set
           // against a later document is the generation instead.
           this.#appliedSeedIdentity = undefined;
-          this.#raiseResultGeneration(realm, generation);
+          for (let [realm, generation] of refreshFloors ?? []) {
+            this.#raiseResultGeneration(realm, generation);
+          }
           this._meta = meta;
           this._errors = undefined;
           await this.updateInstances(instances, dependencyTrackingContext);

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -265,8 +265,12 @@ export class SearchResource<
   // the scheduler's window — the coalesced form of what each event used to
   // pass to its own `search.perform`. Consumed by the flush, which hands the
   // batch to the search task to raise the floors above once the run
-  // succeeds. Untracked, like `#resultGenerations`: only the subscription
-  // callback writes it and only the flush reads it.
+  // succeeds. Untracked, like `#resultGenerations`: the subscription callback
+  // writes it, and it is drained by the flush and by `modify()` (which folds
+  // any pending batch into the run its query/realm change performs). A plain
+  // Map is safe for that `modify()` read because it is untracked — unlike the
+  // tracked-state hazard the sibling comment on `realmsNeedingRefresh` warns
+  // about.
   #pendingRefreshFloors = new Map<string, number>();
   // Defers the event-triggered re-run so a burst of realm events costs one
   // search, not one per event. The subscription callback accumulates the
@@ -657,9 +661,16 @@ export class SearchResource<
     this.#previousQueryString = queryString;
     // This run reads the index at least as fresh as any event still waiting
     // on the scheduler's window, so fold the pending flush into it rather
-    // than letting a second search fire after it.
+    // than letting a second search fire after it. Scope the fold to the
+    // realms this run actually searches: a realm-set change drops the
+    // realms it removed, and a floor for one of those would otherwise be
+    // stamped on success though this run never read that realm's index.
     this.#refreshScheduler.cancel();
-    let floors = this.#pendingRefreshFloors;
+    let floors = new Map(
+      [...this.#pendingRefreshFloors].filter(([realm]) =>
+        this.realmsToSearch.includes(realm),
+      ),
+    );
     this.#pendingRefreshFloors = new Map();
     this.trackStoreLoad(this.search.perform(query, floors), 'search');
   }
@@ -1121,9 +1132,11 @@ export class SearchResource<
   // the burst the scheduler's window accumulated, consuming the pending
   // generation floors so the run carries them as its own. An event arriving
   // after this consumes them lands in a fresh map and arms a fresh flush, so
-  // nothing is lost to the handoff; a run that fails (or is restarted by a
-  // query change) drops its batch, which only forgoes a floor raise — floors
-  // are a monotonic safety net, never load-bearing state.
+  // nothing is lost to the handoff. The floor itself is load-bearing — it is
+  // the ordering `reseed` uses to decline a stale document — but dropping a
+  // batch on a run that fails (or is restarted by a query change) is still
+  // correct: such a run applied no result set, so there is no coverage for a
+  // floor raise to claim. Only a run that applied a set may raise floors.
   #flushLiveRefresh(): void {
     if (
       isDestroyed(this) ||

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -271,7 +271,7 @@ export class SearchResource<
   // Map is safe for that `modify()` read because it is untracked — unlike the
   // tracked-state hazard the sibling comment on `realmsNeedingRefresh` warns
   // about.
-  #pendingRefreshFloors = new Map<string, number>();
+  #pendingRefreshFloors = new Map<RealmIdentifier, number>();
   // Defers the event-triggered re-run so a burst of realm events costs one
   // search, not one per event. The subscription callback accumulates the
   // generation floors above and arms this; the flush performs the search.
@@ -1154,7 +1154,7 @@ export class SearchResource<
   }
 
   private search = restartableTask(
-    async (query: Query, refreshFloors?: Map<string, number>) => {
+    async (query: Query, refreshFloors?: Map<RealmIdentifier, number>) => {
       this.#log.info(
         `search task start; realms=${this.realmsToSearch.join(',')}; query=${JSON.stringify(query)}`,
       );

--- a/packages/host/tests/integration/resources/file-tree-from-index-test.ts
+++ b/packages/host/tests/integration/resources/file-tree-from-index-test.ts
@@ -1,3 +1,5 @@
+import { settled } from '@ember/test-helpers';
+
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
@@ -123,5 +125,44 @@ module('Integration | file-tree-from-index resource', function (hooks) {
       ],
       'all markdown files are in the tree when unscoped',
     );
+  });
+
+  test('a burst of realm events coalesces into a single tree re-run', async function (assert) {
+    let store = getService('store');
+    let searchCount = 0;
+    let originalSearchEntries = store.searchEntries.bind(store);
+    store.searchEntries = (async () => {
+      searchCount++;
+      return { data: [{ id: `${testRealmURL}notes/plain.md` }] };
+    }) as unknown as typeof store.searchEntries;
+
+    try {
+      let tree = getTreeForTest(
+        getService('loader-service'),
+        () => markdownRef,
+        () => undefined,
+      );
+      await tree.loaded;
+      let baseline = searchCount;
+      let messageService = getService('message-service');
+
+      for (let i = 1; i <= 5; i++) {
+        messageService.relayRealmEvent({
+          eventName: 'index',
+          indexType: 'incremental',
+          invalidations: [`${testRealmURL}notes/plain.md`],
+          realmURL: testRealmURL,
+        });
+      }
+      await settled();
+
+      assert.strictEqual(
+        searchCount,
+        baseline + 1,
+        'five index events inside one window produce one tree re-run',
+      );
+    } finally {
+      store.searchEntries = originalSearchEntries;
+    }
   });
 });

--- a/packages/host/tests/integration/resources/search-entries-test.gts
+++ b/packages/host/tests/integration/resources/search-entries-test.gts
@@ -587,6 +587,60 @@ module('Integration | search-entries resource', function (hooks) {
     }
   });
 
+  test('a query change inside the window cancels the armed re-run', async function (assert) {
+    let searchCount = 0;
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async () => {
+      searchCount++;
+      return entryCollectionDoc([
+        {
+          id: `${testRealmURL}books/1`,
+          indexGen: 1,
+          htmlGen: 1,
+          html: '<div>Mango</div>',
+        },
+      ]);
+    };
+
+    try {
+      let search = getResourceForTest(storeService, () => ({
+        named: {
+          query: { filter: { 'item.on': bookRef }, realms: [testRealmURL] },
+        },
+      }));
+      await search.loaded;
+      let baseline = searchCount;
+      let messageService = getService('message-service');
+
+      // Arm the scheduler with an event, then change the query before the
+      // window flushes. The query change owns the whole result set again and
+      // must cancel the armed flush — the events it accumulated describe a
+      // result set that no longer exists. Without the cancel a redundant
+      // second search fires a window later.
+      messageService.relayRealmEvent({
+        eventName: 'index',
+        indexType: 'incremental',
+        invalidations: [`${testRealmURL}books/1.json`],
+        realmURL: testRealmURL,
+      });
+      search.modify([], {
+        query: {
+          filter: { 'item.on': bookRef, eq: { 'item.status': 'ready' } },
+          realms: [testRealmURL],
+        },
+      });
+      await settled();
+
+      assert.strictEqual(
+        searchCount,
+        baseline + 1,
+        'the query change cancels the armed flush; only its own search runs',
+      );
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+    }
+  });
+
   // A prerender_html event can't change a structured query's membership, so a
   // live search refreshes only the invalidated members' HTML through a
   // conditional card+html GET — it never re-queries the whole search.

--- a/packages/host/tests/integration/resources/search-entries-test.gts
+++ b/packages/host/tests/integration/resources/search-entries-test.gts
@@ -526,6 +526,67 @@ module('Integration | search-entries resource', function (hooks) {
     );
   });
 
+  test('a burst of realm events coalesces into a single re-run', async function (assert) {
+    let searchCount = 0;
+    let originalSearchEntries = storeService.searchEntries.bind(storeService);
+    storeService.searchEntries = async () => {
+      searchCount++;
+      return entryCollectionDoc([
+        {
+          id: `${testRealmURL}books/1`,
+          indexGen: 1,
+          htmlGen: 1,
+          html: '<div>Mango</div>',
+        },
+      ]);
+    };
+
+    try {
+      let search = getResourceForTest(storeService, () => ({
+        named: {
+          query: { filter: { 'item.on': bookRef }, realms: [testRealmURL] },
+        },
+      }));
+      await search.loaded;
+      let baseline = searchCount;
+      let messageService = getService('message-service');
+
+      for (let i = 1; i <= 5; i++) {
+        messageService.relayRealmEvent({
+          eventName: 'index',
+          indexType: 'incremental',
+          invalidations: [`${testRealmURL}books/${i}.json`],
+          realmURL: testRealmURL,
+        });
+      }
+      await settled();
+
+      assert.strictEqual(
+        searchCount,
+        baseline + 1,
+        'five index events inside one window produce one re-run',
+      );
+
+      // The scheduler re-arms after a flush: a later event is not starved by
+      // the earlier burst.
+      messageService.relayRealmEvent({
+        eventName: 'index',
+        indexType: 'incremental',
+        invalidations: [`${testRealmURL}books/1.json`],
+        realmURL: testRealmURL,
+      });
+      await settled();
+
+      assert.strictEqual(
+        searchCount,
+        baseline + 2,
+        'an event after the flush schedules its own re-run',
+      );
+    } finally {
+      storeService.searchEntries = originalSearchEntries;
+    }
+  });
+
   // A prerender_html event can't change a structured query's membership, so a
   // live search refreshes only the invalidated members' HTML through a
   // conditional card+html GET — it never re-queries the whole search.

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -594,6 +594,70 @@ module(`Integration | search resource`, function (hooks) {
     }
   });
 
+  test(`a query change inside the window folds the pending re-run into it`, async function (assert) {
+    let realmServer = getService('realm-server') as RealmServerService;
+    let fetchCalls = 0;
+    let originalMaybeAuthedFetchForRealms =
+      realmServer.maybeAuthedFetchForRealms.bind(realmServer);
+    realmServer.maybeAuthedFetchForRealms = (async (...args) => {
+      fetchCalls++;
+      return await originalMaybeAuthedFetchForRealms(...args);
+    }) as RealmServerService['maybeAuthedFetchForRealms'];
+
+    try {
+      let args = {
+        query: {
+          filter: {
+            on: { module: testRRI('book'), name: 'Book' },
+            eq: { 'author.lastName': 'Abdel-Rahman' },
+          },
+        },
+        realms: [testRealmURL],
+        isLive: true,
+        isAutoSaved: false,
+        storeService,
+        owner: this.owner,
+      } satisfies SearchResourceArgs['named'];
+      let search = getSearchResourceForTest(loaderService, () => ({
+        named: args,
+      }));
+      await search.loaded;
+      let baseline = fetchCalls;
+      let messageService = getService('message-service');
+
+      // Arm the scheduler with an event, then change the query before the
+      // window flushes. The query change must cancel the armed flush and fold
+      // its pending floors into its own run — otherwise a redundant second
+      // search over the new query fires a window later (the cost this change
+      // exists to remove), invisible because it still returns the right rows.
+      messageService.relayRealmEvent({
+        eventName: 'index',
+        indexType: 'incremental',
+        invalidations: [`${testRealmURL}books/1.json`],
+        generation: 1,
+        realmURL: testRealmURL,
+      });
+      search.modify([], {
+        ...args,
+        query: {
+          filter: {
+            on: { module: testRRI('book'), name: 'Book' },
+            eq: { 'author.lastName': 'Jones' },
+          },
+        },
+      });
+      await settled();
+
+      assert.strictEqual(
+        fetchCalls,
+        baseline + 1,
+        'the query change folds the armed flush into its own run; no redundant second search fires',
+      );
+    } finally {
+      realmServer.maybeAuthedFetchForRealms = originalMaybeAuthedFetchForRealms;
+    }
+  });
+
   test(`cards in search results live update`, async function (assert) {
     let query: Query = {
       filter: {

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -520,6 +520,80 @@ module(`Integration | search resource`, function (hooks) {
     assert.strictEqual(search.instances[2].id, `${testRealmURL}books/3`);
   });
 
+  test(`a burst of realm events coalesces into a single live re-run`, async function (assert) {
+    let realmServer = getService('realm-server') as RealmServerService;
+    let fetchCalls = 0;
+    let originalMaybeAuthedFetchForRealms =
+      realmServer.maybeAuthedFetchForRealms.bind(realmServer);
+    realmServer.maybeAuthedFetchForRealms = (async (...args) => {
+      fetchCalls++;
+      return await originalMaybeAuthedFetchForRealms(...args);
+    }) as RealmServerService['maybeAuthedFetchForRealms'];
+
+    try {
+      let query: Query = {
+        filter: {
+          on: {
+            module: testRRI('book'),
+            name: 'Book',
+          },
+          eq: {
+            'author.lastName': 'Abdel-Rahman',
+          },
+        },
+      };
+      let search = getSearchResourceForTest(loaderService, () => ({
+        named: {
+          query,
+          realms: [testRealmURL],
+          isLive: true,
+          isAutoSaved: false,
+          storeService,
+          owner: this.owner,
+        },
+      }));
+      await search.loaded;
+      let baseline = fetchCalls;
+      let messageService = getService('message-service');
+
+      for (let generation = 1; generation <= 5; generation++) {
+        messageService.relayRealmEvent({
+          eventName: 'index',
+          indexType: 'incremental',
+          invalidations: [`${testRealmURL}books/1.json`],
+          generation,
+          realmURL: testRealmURL,
+        });
+      }
+      await settled();
+
+      assert.strictEqual(
+        fetchCalls,
+        baseline + 1,
+        'five index events inside one window produce one search fetch',
+      );
+
+      // The scheduler re-arms after a flush: a later event is not starved by
+      // the earlier burst.
+      messageService.relayRealmEvent({
+        eventName: 'index',
+        indexType: 'incremental',
+        invalidations: [`${testRealmURL}books/1.json`],
+        generation: 6,
+        realmURL: testRealmURL,
+      });
+      await settled();
+
+      assert.strictEqual(
+        fetchCalls,
+        baseline + 2,
+        'an event after the flush schedules its own re-run',
+      );
+    } finally {
+      realmServer.maybeAuthedFetchForRealms = originalMaybeAuthedFetchForRealms;
+    }
+  });
+
   test(`cards in search results live update`, async function (assert) {
     let query: Query = {
       filter: {


### PR DESCRIPTION
Every live search resource in the host re-runs its whole search on every incremental index / prerender_html event it is subscribed to. In a busy shared realm — a steady stream of saves from many concurrent writers — that multiplies into one server-side search per event per open client: the demand amplifier behind the recent federated-search overload (the server-side guardrails from #6059 and #6061 ration the resulting load; this cuts it at the source).

Linear: [CS-12909](https://linear.app/cardstack/issue/CS-12909)

## What changed

- **`LiveSearchRefreshScheduler`** (new, `packages/host/app/lib/live-search-refresh-scheduler.ts`): a trailing-edge, non-extending coalescer. The first event of a burst arms one flush after a 2s window plus up to 1s of random jitter (10ms / no jitter under tests); later events ride the armed flush. The timer never extends, so a continuous write stream still refreshes once per window instead of starving. A test waiter spans arm-to-flush so `settled()` covers the window.
- **`SearchEntriesResource`**: the realm-event subscription callback still accumulates its refresh state (`realmsNeedingRefresh`, the selective-refresh invalidation map) exactly as before, but now arms the scheduler instead of performing the search per event. A query/realm change cancels the armed flush along with the state it described.
- **`SearchResource`** (v1): same deferral. The per-event `(realm, generation)` floor that each `perform` used to carry becomes a per-realm batch (`#pendingRefreshFloors`, max generation per realm) that the coalesced run raises after success. A query change folds any pending batch into its own immediate run.

The jitter also decorrelates the many clients that receive the same realm event, so a popular realm's writes no longer produce lockstep re-query herds.

## Testing

New coalescing tests in both resource suites: a burst of five index events inside one window produces exactly one re-run, and an event arriving after the flush schedules its own (the scheduler re-arms rather than starving). Ran the affected and adjacent host integration modules locally against the dev stack — search-entries resource (33), search resource (51), store search public API (10), query-field render-cycle barrier (1), Store (91) — all passing.

## Out of scope

The paged card-side `loadPaged` pattern (N sequential page fetches per collection per re-run) multiplies whatever re-runs remain; reusing page cursors there is a separate host-level affordance, tracked on the Linear ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)