### PR TITLE
Add displayContainer option to search results component

### DIFF
--- a/packages/host/app/components/search/card-context-search-results.gts
+++ b/packages/host/app/components/search/card-context-search-results.gts
@@ -36,6 +36,7 @@ export default class CardContextSearchResults extends Component<SearchResultsCom
         @query={{@query}}
         @mode={{@mode}}
         @overlays={{@overlays}}
+        @displayContainer={{@displayContainer}}
         @cardInitiated={{true}}
         @getDefaultRealm={{this.getDefaultRealm}}
         ...attributes
@@ -48,6 +49,7 @@ export default class CardContextSearchResults extends Component<SearchResultsCom
         @query={{@query}}
         @mode={{@mode}}
         @overlays={{@overlays}}
+        @displayContainer={{@displayContainer}}
         @cardInitiated={{true}}
         @getDefaultRealm={{this.getDefaultRealm}}
         ...attributes

--- a/packages/host/app/components/search/hydratable-card.gts
+++ b/packages/host/app/components/search/hydratable-card.gts
@@ -100,6 +100,12 @@ interface Signature {
     // and no overlay (chip / options menu / selection toggle) ever anchors to
     // it — for a consumer that lays results out in its own UI.
     overlays?: boolean;
+    // Whether the row renders its card container chrome — the boundary ring
+    // (defaults to `true`). `false` hides it on both the inert HTML (via the
+    // container's `hide-boundaries` class) and the hydrated live card (via
+    // `@displayContainer={{false}}`), matching the `@fields` switch, so a row
+    // looks the same before and after hydration either way.
+    displayContainer?: boolean;
     // The format the live/hydrated card renders as, so it matches the
     // prerendered HTML the query selected (defaults to `fitted`).
     format?: Format;
@@ -266,6 +272,10 @@ export default class HydratableCard extends Component<Signature> {
     return cardContext;
   }
 
+  private get displayContainer(): boolean {
+    return this.args.displayContainer ?? true;
+  }
+
   @action private hydrate() {
     if (this.args.isError) {
       return;
@@ -284,13 +294,14 @@ export default class HydratableCard extends Component<Signature> {
         @card={{this.liveCard}}
         @format={{this.format}}
         @codeRef={{@renderType}}
-        @displayContainer={{false}}
+        @displayContainer={{this.displayContainer}}
         data-hydration={{this.hydrationState}}
         data-test-hydratable-card={{@cardId}}
         ...attributes
       />
     {{else if @component}}
       <@component
+        class={{unless this.displayContainer 'hide-boundaries'}}
         {{hydrationTrigger this.mode this.hydrate}}
         {{this.trackElement
           cardId=@cardId

--- a/packages/host/app/components/search/hydratable-card.gts
+++ b/packages/host/app/components/search/hydratable-card.gts
@@ -100,11 +100,11 @@ interface Signature {
     // and no overlay (chip / options menu / selection toggle) ever anchors to
     // it — for a consumer that lays results out in its own UI.
     overlays?: boolean;
-    // Whether the row renders its card container chrome — the boundary ring
-    // (defaults to `true`). `false` hides it on both the inert HTML (via the
-    // container's `hide-boundaries` class) and the hydrated live card (via
-    // `@displayContainer={{false}}`), matching the `@fields` switch, so a row
-    // looks the same before and after hydration either way.
+    // Whether the hydrated live card renders its card container chrome
+    // (defaults to `true`), matching the `@fields` switch. The inert HTML is
+    // not touched here — a caller passing `false` hands in `@component` with
+    // its container classes already rewritten (see `RenderableSearchEntry`),
+    // so a row looks the same before and after hydration.
     displayContainer?: boolean;
     // The format the live/hydrated card renders as, so it matches the
     // prerendered HTML the query selected (defaults to `fitted`).
@@ -301,7 +301,6 @@ export default class HydratableCard extends Component<Signature> {
       />
     {{else if @component}}
       <@component
-        class={{unless this.displayContainer 'hide-boundaries'}}
         {{hydrationTrigger this.mode this.hydrate}}
         {{this.trackElement
           cardId=@cardId

--- a/packages/host/app/components/search/search-results.gts
+++ b/packages/host/app/components/search/search-results.gts
@@ -65,6 +65,10 @@ export default class SearchResults extends Component<HostSearchResultsSignature>
     return this.args.overlays ?? true;
   }
 
+  private get displayContainer(): boolean {
+    return this.args.displayContainer ?? true;
+  }
+
   // Created once per component: the view-model layer memoizes render-stable
   // entries on top of a search resource. With `@resource` it wraps the
   // caller-owned resource (whose subscriptions and re-runs outlive this
@@ -77,12 +81,14 @@ export default class SearchResults extends Component<HostSearchResultsSignature>
         this.args.resource,
         () => this.mode,
         () => this.overlays,
+        () => this.displayContainer,
       )
     : getRenderableSearchEntries(
         this,
         () => this.args.query,
         () => this.mode,
         () => this.overlays,
+        () => this.displayContainer,
         {
           cardInitiated: this.args.cardInitiated,
           getDefaultRealm: this.args.getDefaultRealm,

--- a/packages/host/app/lib/html-component.ts
+++ b/packages/host/app/lib/html-component.ts
@@ -39,14 +39,24 @@ type TopElement = ComponentLike<{
 export function htmlComponent(
   html: string,
   extraAttributes: Record<string, string> = {},
+  // Runs on the parsed root before its attributes are read into the template,
+  // so a caller can adjust the root's classes without reserializing the HTML.
+  transformRoot?: (root: Element) => void,
 ): HTMLComponent {
   let testContainer = document.createElement('div');
   testContainer.innerHTML = html;
+  // Prerendered atom / isolated / head HTML is captured as the render root's
+  // innerHTML and so arrives wrapped in the route template's whitespace; only
+  // non-blank text counts against the single-root shape.
+  let significantNodes = [...testContainer.childNodes].filter(
+    (node) => node.nodeType !== Node.TEXT_NODE || node.textContent?.trim(),
+  );
   if (
-    testContainer.childNodes.length === 1 &&
-    testContainer.children.length === 1
+    significantNodes.length === 1 &&
+    significantNodes[0].nodeType === Node.ELEMENT_NODE
   ) {
-    let cardElement = testContainer.children[0];
+    let cardElement = significantNodes[0] as Element;
+    transformRoot?.(cardElement);
     let tagName = cardElement.tagName.toLowerCase();
 
     let sourceParts: string[] = [];

--- a/packages/host/app/lib/hydratable-entry-component.ts
+++ b/packages/host/app/lib/hydratable-entry-component.ts
@@ -57,6 +57,9 @@ export interface HydratableEntryArgs {
   // Whether the row registers with the operator-mode overlay; `false` renders
   // it plainly (no chip / options menu / selection toggle).
   overlays: boolean;
+  // Whether the row renders its card container chrome (the boundary ring);
+  // `false` hides it, as `@displayContainer={{false}}` does on `@fields`.
+  displayContainer: boolean;
 }
 
 class _HydratableEntryComponent {
@@ -71,6 +74,7 @@ class _HydratableEntryComponent {
     readonly errorDoc: ErrorEntry | undefined,
     readonly mode: HydrationMode,
     readonly overlays: boolean,
+    readonly displayContainer: boolean,
   ) {}
 }
 
@@ -87,6 +91,7 @@ setComponentTemplate(
       @errorDoc={{this.errorDoc}}
       @mode={{this.mode}}
       @overlays={{this.overlays}}
+      @displayContainer={{this.displayContainer}}
       ...attributes
     />`,
     {
@@ -133,5 +138,6 @@ export function hydratableEntryComponent(
     args.errorDoc,
     args.mode,
     args.overlays,
+    args.displayContainer,
   ) as unknown as EntryComponent;
 }

--- a/packages/host/app/resources/renderable-search-entries.ts
+++ b/packages/host/app/resources/renderable-search-entries.ts
@@ -52,6 +52,17 @@ function extraAttributesFor(
   return attrs;
 }
 
+// Prerendered HTML always captures its root container with the chrome on
+// (`--boundaries` ring, `display-container-true` layout). A row rendered with
+// `displayContainer: false` swaps those for exactly the classes the live card
+// renders with under `@displayContainer={{false}}`, so the inert and hydrated
+// states share one layout — for an atom that is `display: contents` versus an
+// inline-block with padding, not just a missing ring.
+function removeContainerChrome(root: Element): void {
+  root.classList.remove('boxel-card-container--boundaries');
+  root.classList.replace('display-container-true', 'display-container-false');
+}
+
 // The query's requested render type, echoed once at the document level. Used
 // to render an item-only (live) fallback as the same ancestor its HTML
 // siblings would have rendered as. Only a single `eq` leaf names one type; a
@@ -202,7 +213,11 @@ export class RenderableSearchEntry {
       let { html } = this;
       let inert =
         html && html.html != null
-          ? htmlComponent(html.html, extraAttributesFor(html, this.iconHtml))
+          ? htmlComponent(
+              html.html,
+              extraAttributesFor(html, this.iconHtml),
+              this.displayContainer ? undefined : removeContainerChrome,
+            )
           : undefined;
       this.#component = hydratableEntryComponent({
         cardId: this.id,

--- a/packages/host/app/resources/renderable-search-entries.ts
+++ b/packages/host/app/resources/renderable-search-entries.ts
@@ -94,6 +94,7 @@ export class RenderableSearchEntry {
     private fallbackFormat: PrerenderedHtmlFormat,
     private mode: HydrationMode,
     private overlays: boolean,
+    private displayContainer: boolean,
   ) {}
 
   get id(): string {
@@ -214,6 +215,7 @@ export class RenderableSearchEntry {
         errorDoc: this.errorDoc,
         mode: this.mode,
         overlays: this.overlays,
+        displayContainer: this.displayContainer,
       });
     }
     return this.#component;
@@ -242,6 +244,7 @@ export class RenderableSearchEntries {
     private resource: ReturnType<typeof getSearchEntriesResource>,
     private getMode: () => HydrationMode,
     private getOverlays: () => boolean,
+    private getDisplayContainer: () => boolean,
   ) {}
 
   private get fallbackRenderType(): ResolvedCodeRef | undefined {
@@ -257,9 +260,11 @@ export class RenderableSearchEntries {
     let fallbackFormat = this.fallbackFormat;
     let mode = this.getMode();
     let overlays = this.getOverlays();
+    let displayContainer = this.getDisplayContainer();
     let inputsKey = JSON.stringify([
       mode,
       overlays,
+      displayContainer,
       fallbackRenderType,
       fallbackFormat,
     ]);
@@ -282,6 +287,7 @@ export class RenderableSearchEntries {
         fallbackFormat,
         mode,
         overlays,
+        displayContainer,
       );
       // Pure memoization keyed on the resource's stable entry identity — it
       // dirties no tracked state, and keeping unchanged rows' view-models (and
@@ -317,6 +323,7 @@ export function getRenderableSearchEntries(
   getQuery: () => SearchEntryWireQuery | undefined,
   getMode: () => HydrationMode,
   getOverlays: () => boolean = () => true,
+  getDisplayContainer: () => boolean = () => true,
   opts?: {
     // Forwarded to the underlying resource: scope a no-realm card search to the
     // current realm instead of fanning out. Set only by the card-facing
@@ -329,5 +336,6 @@ export function getRenderableSearchEntries(
     getSearchEntriesResource(owner, getQuery, opts),
     getMode,
     getOverlays,
+    getDisplayContainer,
   );
 }

--- a/packages/host/tests/integration/components/card-context-search-results-test.gts
+++ b/packages/host/tests/integration/components/card-context-search-results-test.gts
@@ -201,8 +201,9 @@ module(
     });
 
     test('@displayContainer=false reaches the rows through the card-facing wrapper', async function (assert) {
-      // The wrapper forwards the arg explicitly; a row must lose its container
-      // boundaries both while inert and once hydrated.
+      // The wrapper forwards the arg explicitly; a row must carry the same
+      // container-off classes while inert as the live card renders with, so
+      // the swap causes no layout shift.
       let query: SearchEntryWireQuery = {
         filter: { 'item.on': bookRef },
         realms: [testRealmURL],
@@ -224,7 +225,15 @@ module(
 
       assert
         .dom(`[data-test-hydratable-card="${BOOK_1}"]`)
-        .hasClass('hide-boundaries', 'the inert row suppresses its ring');
+        .doesNotHaveClass(
+          'boxel-card-container--boundaries',
+          'the inert row has no ring',
+        )
+        .hasClass(
+          'display-container-false',
+          'the inert row carries the container-off layout class',
+        )
+        .doesNotHaveClass('display-container-true');
 
       await triggerEvent(
         `[data-test-hydratable-card="${BOOK_1}"]`,

--- a/packages/host/tests/integration/components/card-context-search-results-test.gts
+++ b/packages/host/tests/integration/components/card-context-search-results-test.gts
@@ -200,6 +200,47 @@ module(
       );
     });
 
+    test('@displayContainer=false reaches the rows through the card-facing wrapper', async function (assert) {
+      // The wrapper forwards the arg explicitly; a row must lose its container
+      // boundaries both while inert and once hydrated.
+      let query: SearchEntryWireQuery = {
+        filter: { 'item.on': bookRef },
+        realms: [testRealmURL],
+      };
+      await render(
+        <template>
+          <CardSearchContext as |context|>
+            <context.searchResultsComponent
+              @query={{query}}
+              @mode='hover'
+              @displayContainer={{false}}
+            />
+          </CardSearchContext>
+        </template>,
+      );
+      await waitUntil(() =>
+        Boolean(document.querySelector('[data-test-search-result]')),
+      );
+
+      assert
+        .dom(`[data-test-hydratable-card="${BOOK_1}"]`)
+        .hasClass('hide-boundaries', 'the inert row suppresses its ring');
+
+      await triggerEvent(
+        `[data-test-hydratable-card="${BOOK_1}"]`,
+        'mouseenter',
+      );
+
+      assert
+        .dom(
+          `[data-test-hydratable-card="${BOOK_1}"][data-hydration="hydrated"]`,
+        )
+        .doesNotHaveClass(
+          'boxel-card-container--boundaries',
+          'the live container renders without boundaries',
+        );
+    });
+
     test('a no-realm card search scopes to the context default realm', async function (assert) {
       // The query carries no `realms`. Card-initiated, it targets the realm the
       // `@context` was provided with rather than fanning out across every

--- a/packages/host/tests/integration/components/html-component-test.gts
+++ b/packages/host/tests/integration/components/html-component-test.gts
@@ -28,4 +28,51 @@ module('Integration | Component | html-component', function (hooks) {
       .dom('[data-test-second-mount] [data-test-inert-body]')
       .hasText('Body', 'the second mount has its own content');
   });
+
+  // Prerendered atom HTML arrives wrapped in the route template's whitespace.
+  // It must still resolve to a single root so splatted attributes land on it.
+  test('surrounding whitespace does not stop the root element from taking attributes', async function (assert) {
+    let Inert = htmlComponent(
+      `\n    \n  <div class='card'><span>Body</span></div>\n\n  `,
+    );
+
+    await render(<template><Inert data-test-root /></template>);
+
+    assert
+      .dom('[data-test-root]')
+      .exists('the splatted attribute reached the root')
+      .hasClass('card', 'the root is the prerendered element')
+      .hasText('Body');
+  });
+
+  test('transformRoot edits the parsed root before it is rendered', async function (assert) {
+    let Inert = htmlComponent(
+      `<div class='card ring'><span>Body</span></div>`,
+      {},
+      (root) => root.classList.replace('ring', 'plain'),
+    );
+
+    await render(<template><Inert data-test-root /></template>);
+
+    assert
+      .dom('[data-test-root]')
+      .hasClass('plain', 'the replacement class is rendered')
+      .doesNotHaveClass('ring', 'the original class is gone');
+  });
+
+  test('transformRoot is skipped when the HTML has no single root', async function (assert) {
+    let calls = 0;
+    let Inert = htmlComponent(`<span>One</span><span>Two</span>`, {}, () => {
+      calls++;
+    });
+
+    await render(
+      <template>
+        <div data-test-wrap><Inert /></div>
+      </template>,
+    );
+
+    assert.strictEqual(calls, 0, 'the hook never ran');
+    assert.dom('[data-test-wrap]').hasText('OneTwo', 'the HTML still renders');
+  });
 });

--- a/packages/host/tests/integration/components/hydratable-card-test.gts
+++ b/packages/host/tests/integration/components/hydratable-card-test.gts
@@ -298,8 +298,8 @@ module('Integration | Component | hydratable-card', function (hooks) {
   });
 
   // The boundary ring is on by default and survives hydration: the inert HTML
-  // keeps whatever boundary class it was prerendered with, and the live card
-  // renders inside its own bounded container.
+  // is rendered as handed in, and the live card renders inside its own bounded
+  // container.
   test('displayContainer defaults to true — the hydrated card keeps its container boundaries', async function (assert) {
     let inert = htmlComponent(BOUNDED_INERT_HTML);
     await render(
@@ -316,8 +316,7 @@ module('Integration | Component | hydratable-card', function (hooks) {
 
     assert
       .dom('[data-test-inert-card]')
-      .hasClass('boxel-card-container--boundaries', 'inert ring is kept')
-      .doesNotHaveClass('hide-boundaries', 'nothing hides the inert ring');
+      .hasClass('boxel-card-container--boundaries', 'inert ring is kept');
 
     await triggerEvent('[data-test-hydratable-card]', 'mouseenter');
 
@@ -329,10 +328,12 @@ module('Integration | Component | hydratable-card', function (hooks) {
       );
   });
 
-  // `@displayContainer={{false}}` hides the ring on both sides of the swap, the
-  // way `<@fields.x @displayContainer={{false}} />` does for a field render.
-  test('displayContainer=false — hides the boundaries on the inert HTML and the live card alike', async function (assert) {
-    let inert = htmlComponent(BOUNDED_INERT_HTML);
+  // `@displayContainer={{false}}` reaches the live card the way
+  // `<@fields.x @displayContainer={{false}} />` does for a field render. The
+  // inert HTML is the caller's to shape (RenderableSearchEntry rewrites its
+  // container classes), so it renders exactly as handed in.
+  test('displayContainer=false — the hydrated card renders without container boundaries', async function (assert) {
+    let inert = htmlComponent(INERT_HTML);
     await render(
       <template>
         <TestContext>
@@ -348,7 +349,7 @@ module('Integration | Component | hydratable-card', function (hooks) {
 
     assert
       .dom('[data-test-inert-card]')
-      .hasClass('hide-boundaries', 'the inert ring is suppressed');
+      .exists('the inert HTML renders as handed in');
 
     await triggerEvent('[data-test-hydratable-card]', 'mouseenter');
 

--- a/packages/host/tests/integration/components/hydratable-card-test.gts
+++ b/packages/host/tests/integration/components/hydratable-card-test.gts
@@ -71,6 +71,9 @@ class TestContext extends GlimmerComponent<TestContextSignature> {
 
 const HASSAN = `${testRealmURL}Person/hassan`;
 const INERT_HTML = `<div class='inert' data-test-inert-card>Inert</div>`;
+// Inert HTML as the prerender captures it: the card-api container with its
+// boundary class already on it.
+const BOUNDED_INERT_HTML = `<div class='boxel-card-container boxel-card-container--boundaries inert' data-test-inert-card>Inert</div>`;
 
 // Drives a mount/unmount toggle so a teardown test can destroy the rendered
 // HydratableCard and assert it releases its Store reference.
@@ -292,6 +295,72 @@ module('Integration | Component | hydratable-card', function (hooks) {
       0,
       'the live element stays out of the tracker too',
     );
+  });
+
+  // The boundary ring is on by default and survives hydration: the inert HTML
+  // keeps whatever boundary class it was prerendered with, and the live card
+  // renders inside its own bounded container.
+  test('displayContainer defaults to true — the hydrated card keeps its container boundaries', async function (assert) {
+    let inert = htmlComponent(BOUNDED_INERT_HTML);
+    await render(
+      <template>
+        <TestContext>
+          <HydratableCard
+            @cardId={{HASSAN}}
+            @component={{inert}}
+            @mode='hover'
+          />
+        </TestContext>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-inert-card]')
+      .hasClass('boxel-card-container--boundaries', 'inert ring is kept')
+      .doesNotHaveClass('hide-boundaries', 'nothing hides the inert ring');
+
+    await triggerEvent('[data-test-hydratable-card]', 'mouseenter');
+
+    assert
+      .dom('[data-test-hydratable-card]')
+      .hasClass(
+        'boxel-card-container--boundaries',
+        'the live container draws its boundaries too',
+      );
+  });
+
+  // `@displayContainer={{false}}` hides the ring on both sides of the swap, the
+  // way `<@fields.x @displayContainer={{false}} />` does for a field render.
+  test('displayContainer=false — hides the boundaries on the inert HTML and the live card alike', async function (assert) {
+    let inert = htmlComponent(BOUNDED_INERT_HTML);
+    await render(
+      <template>
+        <TestContext>
+          <HydratableCard
+            @cardId={{HASSAN}}
+            @component={{inert}}
+            @mode='hover'
+            @displayContainer={{false}}
+          />
+        </TestContext>
+      </template>,
+    );
+
+    assert
+      .dom('[data-test-inert-card]')
+      .hasClass('hide-boundaries', 'the inert ring is suppressed');
+
+    await triggerEvent('[data-test-hydratable-card]', 'mouseenter');
+
+    assert
+      .dom('[data-test-live-card]')
+      .hasText('Live: Hassan', 'still hydrates');
+    assert
+      .dom('[data-test-hydratable-card]')
+      .doesNotHaveClass(
+        'boxel-card-container--boundaries',
+        'the live container renders without boundaries',
+      );
   });
 
   // `none` stays inert with the diagnostic attribute and never fetches.

--- a/packages/runtime-common/search-results-component.ts
+++ b/packages/runtime-common/search-results-component.ts
@@ -102,6 +102,11 @@ export interface SearchResultsComponentSignature {
     // pass `false` for a card that lays results out in its own UI and wants
     // them rendered plainly, with no overlay even inside operator mode.
     overlays?: boolean;
+    // Whether each result renders inside its card container chrome (the
+    // boundary ring), the same switch `<@fields.x @displayContainer={{false}} />`
+    // offers. Defaults to `true`; pass `false` for a consumer that frames
+    // results itself.
+    displayContainer?: boolean;
   };
   Blocks: {
     default: [SearchResultsYield];


### PR DESCRIPTION
Adds an optional `@displayContainer` arg (default `true`) to the `SearchResults` component, threaded through to `HydratableCard`. Passing `false` removes the card container chrome from every row: the inert prerendered root has `boxel-card-container--boundaries` dropped and `display-container-true` swapped for `display-container-false` (via a new `transformRoot` hook on `htmlComponent`), and the hydrated live card renders with `@displayContainer={{false}}`, so a row keeps the same layout across hydration. Mirrors the existing `<@fields.x @displayContainer={{false}} />` switch, for cards that frame results in their own UI. The card-facing `CardContextSearchResults` wrapper forwards the arg.

**Side fix:** `htmlComponent` now ignores whitespace-only text nodes when locating the single root element. Prerendered atom/isolated/head HTML is captured as `innerHTML` and arrives wrapped in the route template's whitespace, which sent every such row into the plain-string fallback with no root element — so splatted attributes, hover hydration, and the operator-mode overlay never applied to inert atom or isolated search rows.

Linear: [CS-12932](https://linear.app/cardstack/issue/CS-12932)

🤖 Generated with [Claude Code](https://claude.com/claude-code)