### PR TITLE
Speed up the card-source-endpoints realm-server suite (per-module boots + template dedupe)

### DIFF
--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -78,9 +78,14 @@ module(basename(import.meta.filename), function () {
 
     module('card source GET request', function (_hooks) {
       module('public readable realm', function (hooks) {
+        // Read-only module: every test either reads fixture files that no
+        // test mutates or writes to a path unique to that test, so the boot
+        // is safe to share across tests. `mode: 'before'` boots the realm
+        // once for the module instead of once per test.
         setupPermissionedRealmCached(hooks, {
           fixture: 'realistic',
           realmURL,
+          mode: 'before',
           permissions: {
             '*': ['read'],
             '@node-test_realm:localhost': ['read', 'realm-owner'],
@@ -498,9 +503,12 @@ module(basename(import.meta.filename), function () {
       });
 
       module('permissioned realm', function (hooks) {
+        // Read-only module (auth checks on GET /person.gts): shared boot is
+        // safe since no test mutates realm state.
         setupPermissionedRealmCached(hooks, {
           fixture: 'simple',
           realmURL,
+          mode: 'before',
           permissions: {
             john: ['read'],
             '@node-test_realm:localhost': ['read', 'realm-owner'],
@@ -550,9 +558,12 @@ module(basename(import.meta.filename), function () {
 
     module('card source HEAD request', function (_hooks) {
       module('public readable realm', function (hooks) {
+        // Read-only module: HEAD requests plus one write to a unique path
+        // (notes.md), so the boot is safe to share across tests.
         setupPermissionedRealmCached(hooks, {
           fixture: 'simple',
           realmURL,
+          mode: 'before',
           permissions: {
             '*': ['read'],
             '@node-test_realm:localhost': ['read', 'realm-owner'],
@@ -1149,6 +1160,10 @@ module(basename(import.meta.filename), function () {
       });
 
       module('public writable realm with size limit', function (hooks) {
+        // Carry the same file/audio/video limits as the binary size-limit
+        // module below so both share one cached template (the template cache
+        // key includes the limits). The audio/video limits are inert for this
+        // module's single .gts test but let it dedupe the template build.
         setupPermissionedRealmCached(hooks, {
           fixture: 'simple',
           realmURL,
@@ -1157,6 +1172,8 @@ module(basename(import.meta.filename), function () {
             '@node-test_realm:localhost': ['read', 'realm-owner'],
           },
           fileSizeLimitBytes: 512,
+          audioSizeLimitBytes: 2048,
+          videoSizeLimitBytes: 8192,
           onRealmSetup,
         });
 


### PR DESCRIPTION
## What

`tests/card-source-endpoints-test.ts` (55 tests) paid a full-stack realm boot **per test** — clone the template Postgres DB → tmp dir + fixture copy → construct a `Worker` → boot the `Realm` → `logInToMatrix()` → build a `RealmServer` → start a supertest server → tear down — because the harness default is `mode: 'beforeEach'`. It also built two distinct templates for size-limit modules that differ only by request-time limits.

This lands the two lowest-risk, highest-impact items from CS-12935.

### 1. `mode: 'before'` for the read-only modules

Boot once per module instead of once per test for the three modules that don't mutate shared realm state:

- `card source GET request › public readable realm` (12 tests)
- `card source GET request › permissioned realm` (4 tests)
- `card source HEAD request › public readable realm` (3 tests)

Each test either reads fixture files that no test mutates or writes to a path unique to that test, so a shared boot stays order-independent. The harness (`setupDB`) already pairs `before`/`after` and clones the template DB once under `mode: 'before'`, so this is a mechanical change that removes ~16 per-test boots.

### 2. Consolidate the two size-limit templates

`public writable realm with size limit` now carries the same `{file: 512, audio: 2048, video: 8192}` limits as `public writable realm with size limit for binary`, so both hash to one cached template. The template cache key includes the limits, but limits are request-time config and don't affect indexed content, so the extra two are inert for the `.gts` test and collapse two identical builds into one.

## Deferred (follow-ups from the ticket)

- **Fixture downgrade (GET public-readable realistic → simple):** the `simple` fixture lacks `person-with-error.gts` and `hello.test.gts` that the module reads, and adding them would perturb the shared `simple` fixture for other modules. Once `mode: 'before'` collapses that module to a single boot, the realistic-vs-simple boot differential is paid only once, so the remaining value is small.
- Worker-less boots for read-only modules, Matrix-login memoization, and a pooled-realm harness — larger harness lifts.

## Verification

Changes are lint-clean. End-to-end timing was intended via `scripts/measure-test-file.sh` per the ticket's method note, but local runs are currently blocked by an unrelated stale local dev stack; CI runs this suite against a built host and is the authoritative source for the green run and before/after shard timings. The `mode: 'before'` path is already exercised by existing suites, and the size-limit consolidation preserves each module's own runtime limits (only the shared template is deduped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)