### PR TITLE
Keep a readRealmFile url list from looping the model to its output limit

### DIFF
--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -4,6 +4,7 @@ import { AI_BOT_EXECUTOR } from '@cardstack/runtime-common/commands';
 import {
   READ_REALM_FILE_TOOL_NAME,
   readFilesLabel,
+  urlsFromReadRealmFileArguments,
 } from '../read-realm-file.ts';
 import {
   maxOutputTokensErrorMessage,
@@ -54,7 +55,9 @@ export function toCommandRequest(
     result.executedBy = AI_BOT_EXECUTOR;
     result.arguments = {
       ...(result.arguments ?? {}),
-      description: readFilesLabel(result.arguments?.urls),
+      description: readFilesLabel(
+        f.arguments ? urlsFromReadRealmFileArguments(f.arguments) : undefined,
+      ),
     };
   }
   return result;

--- a/packages/ai-bot/lib/read-realm-file-fulfillment.ts
+++ b/packages/ai-bot/lib/read-realm-file-fulfillment.ts
@@ -12,7 +12,7 @@ import type { ChatCompletionMessageToolCall } from 'openai/resources';
 import {
   executeReadRealmFile,
   fileLabelFromUrl,
-  type ReadRealmFileArgs,
+  urlsFromReadRealmFileArguments,
   type ReadRealmFileTool,
 } from './read-realm-file.ts';
 import type { DiscoveredToolDefinition } from '@cardstack/base/matrix-event';
@@ -223,21 +223,10 @@ async function fulfillOne(
   deps: ReadRealmFileFulfillmentDeps,
   upload: (content: string, contentType: string) => Promise<string>,
 ): Promise<ReadRealmFileFulfillmentOutcome> {
-  let args: ReadRealmFileArgs | undefined;
-  try {
-    args = JSON.parse(call.function.arguments) as ReadRealmFileArgs;
-  } catch {
-    args = undefined;
-  }
-  // Dedupe within the call so a repeated URL doesn't attach (and inline into
-  // every later prompt) twice.
-  let urls = [
-    ...new Set(
-      (Array.isArray(args?.urls) ? args.urls : []).filter(
-        (url): url is string => typeof url === 'string' && url.length > 0,
-      ),
-    ),
-  ];
+  // Deduplicated within the call so a repeated URL doesn't attach (and inline
+  // into every later prompt) twice; recovered from the raw text when the
+  // arguments were cut off before the JSON closed.
+  let urls = urlsFromReadRealmFileArguments(call.function.arguments);
   if (urls.length === 0) {
     return await publishFailure(
       call.id,

--- a/packages/ai-bot/lib/read-realm-file.ts
+++ b/packages/ai-bot/lib/read-realm-file.ts
@@ -18,38 +18,50 @@ export const READ_REALM_FILE_TOOL_NAME = 'readRealmFile';
 // On-demand file reading. The model calls `readRealmFile` to pull files'
 // contents only when it needs them — most often a skill's SKILL.md or the
 // references it lists, but it works for any file in the realm. One call reads
-// any number of files: each model turn that requests reads costs a full
-// round-trip (fulfillment + a fresh generation), so the tool takes a list and
-// the description pushes the model to batch everything it already knows it
-// needs. ai-bot executes it in-process: it mints a delegated, user-scoped
+// several files: each model turn that requests reads costs a full round-trip
+// (fulfillment + a fresh generation), so the tool takes a list. The list is
+// capped, and the description says so: asked to "read everything in one
+// call", a small model given a skill index with thirty-odd reference links
+// can fall into repeating the same URLs until it hits its output limit,
+// which wastes minutes and money and yields a call that cannot be parsed.
+// ai-bot executes it in-process: it mints a delegated, user-scoped
 // realm token and fetches each file over HTTP, so the bot can only read what
 // the requesting human can already read, and the content is always live (no
 // Matrix snapshots, no host round-trip).
+// How many files one call may name. Ten covers a skill plus its most relevant
+// references in one round-trip while staying far below the list lengths at
+// which models start repeating entries.
+export const READ_REALM_FILE_MAX_URLS = 10;
+
 export const readRealmFileTool: Tool = {
   type: 'function',
   function: {
     name: READ_REALM_FILE_TOOL_NAME,
     description:
       "Read files from a realm on demand — e.g. a skill's SKILL.md, or the " +
-      'reference files it lists. Reads all the given URLs at once, so when ' +
-      'you already know several files you need (a skill’s reference ' +
-      'list usually tells you), request them all in a single call rather ' +
-      'than a few at a time — every extra round of reads delays your answer. ' +
-      "Reading a skill's markdown file also unlocks the tools that skill " +
-      'declares: they become callable on your next turn, so read the skill ' +
-      'file first when you intend to use its tools.',
+      `reference files it lists. Reads up to ${READ_REALM_FILE_MAX_URLS} ` +
+      'files in one call, so batch the files you already know you need ' +
+      'rather than reading one at a time — every extra round of reads ' +
+      'delays your answer. Pick the most relevant files first and read ' +
+      "more on a later turn if you still need them. Reading a skill's " +
+      'markdown file also unlocks the tools that skill declares: they ' +
+      'become callable on your next turn, so read the skill file first ' +
+      'when you intend to use its tools.',
     parameters: {
       type: 'object',
       properties: {
         urls: {
           type: 'array',
           minItems: 1,
+          maxItems: READ_REALM_FILE_MAX_URLS,
+          uniqueItems: true,
           items: { type: 'string' },
           description:
             'Full URLs of the files to read, each exactly as it appears in ' +
             "the skill (a link there is already absolute — don't shorten " +
-            'or rewrite it). The realm each file lives in is worked out ' +
-            'for you.',
+            'or rewrite it). List each URL once, at most ' +
+            `${READ_REALM_FILE_MAX_URLS} per call. The realm each file ` +
+            'lives in is worked out for you.',
         },
       },
       required: ['urls'],
@@ -61,6 +73,37 @@ export interface ReadRealmFileArgs {
   // Full URLs of the files to read. The realm each belongs to is discovered
   // from the realm server's response, so the caller supplies only URLs.
   urls: string[];
+}
+
+// The urls a readRealmFile call names, deduplicated and in order. When the
+// arguments are not valid JSON — a generation cut off at the provider's output
+// limit leaves the list unterminated — every complete quoted URL is still
+// recovered from the text, so the files the model asked for get read instead
+// of the call failing and the model re-requesting them on the next turn.
+export function urlsFromReadRealmFileArguments(
+  argumentsJson: string,
+): string[] {
+  let urls: unknown[] = [];
+  try {
+    let parsed = JSON.parse(argumentsJson) as Partial<ReadRealmFileArgs>;
+    urls = Array.isArray(parsed?.urls) ? parsed.urls : [];
+  } catch {
+    let listStart = argumentsJson.indexOf('"urls"');
+    if (listStart !== -1) {
+      for (let match of argumentsJson
+        .slice(listStart)
+        .matchAll(/"(https?:\/\/[^"\s]+)"/g)) {
+        urls.push(match[1]);
+      }
+    }
+  }
+  return [
+    ...new Set(
+      urls.filter(
+        (url): url is string => typeof url === 'string' && url.length > 0,
+      ),
+    ),
+  ];
 }
 
 // Realm servers echo the owning realm's root on every response — success or

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -269,7 +269,11 @@ export class Responder {
     // Record the finish_reason regardless of streaming mode: the final
     // consolidated edit surfaces an error to the user when the provider cut
     // the generation at its output-token limit ('length').
-    this.responseState.updateFinishReason(chunk.choices?.[0]?.finish_reason);
+    this.responseState.updateFinishReason(
+      chunk.choices?.[0]?.finish_reason,
+      (chunk.choices?.[0] as { native_finish_reason?: string | null })
+        ?.native_finish_reason,
+    );
 
     // When we're not sending mid-turn, `finalize()` owns the
     // `isStreamingFinished` transition — otherwise the flag would flip here,

--- a/packages/ai-bot/lib/response-state.ts
+++ b/packages/ai-bot/lib/response-state.ts
@@ -12,10 +12,24 @@ export default class ResponseState {
   isCanceled = false;
   // The provider's finish_reason for this turn. Only the chunk that ends the
   // generation carries one; keep the last non-null value so trailing chunks
-  // (e.g. the usage report) cannot clear it.
+  // (e.g. the usage report) cannot clear it. OpenRouter normalizes the
+  // upstream reason: a generation that hit the output-token limit while
+  // emitting a tool call arrives as 'tool_calls', with the cut visible only
+  // in `native_finish_reason` ('max_output_tokens' / 'length'). Record that
+  // here as 'length' so the cut is reported to the user either way.
   finishReason: string | undefined;
 
-  updateFinishReason(finishReason: string | null | undefined) {
+  updateFinishReason(
+    finishReason: string | null | undefined,
+    nativeFinishReason?: string | null,
+  ) {
+    if (
+      nativeFinishReason === 'max_output_tokens' ||
+      nativeFinishReason === 'length'
+    ) {
+      this.finishReason = 'length';
+      return;
+    }
     if (finishReason) {
       this.finishReason = finishReason;
     }

--- a/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-fulfillment-test.ts
@@ -413,6 +413,44 @@ module('fulfillReadRealmFileCalls', () => {
     assert.strictEqual(sent[0].content['m.relates_to'].key, 'invalid');
   });
 
+  test('arguments cut off mid-list still read the urls that arrived, once each', async () => {
+    let { client, sent } = fakeClient();
+    let fetched: string[] = [];
+    let fetch = (async (url: string) => {
+      fetched.push(url);
+      return new Response('# Trip Planner', { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    // A generation stopped at the output-token limit while repeating urls:
+    // the list never closes and the last entry is partial. A non-markdown
+    // file, so each url costs exactly one fetch.
+    let rawUrl =
+      'https://localhost:4201/user/jane/skills/trip-planner/cities.txt';
+    let truncated = `{"urls":["${rawUrl}","${rawUrl}","${rawUrl}","https://localhost:4201/user/jane/skills/trip-pl`;
+    let outcomes = await fulfillReadRealmFileCalls(
+      [
+        {
+          id: 'c1',
+          type: 'function',
+          function: { name: READ_REALM_FILE_TOOL_NAME, arguments: truncated },
+        } as any,
+      ],
+      baseDeps(client, {
+        fetch,
+        uploadText: async () => 'https://localhost/media/trip-planner',
+      }),
+    );
+
+    assert.deepEqual(outcomes, [{ commandRequestId: 'c1', ok: true }]);
+    assert.strictEqual(
+      fetched.filter((url) => url === rawUrl).length,
+      1,
+      'a url repeated in the cut-off list is fetched once',
+    );
+    assert.strictEqual(sent[0].content['m.relates_to'].key, 'applied');
+    assert.strictEqual(dataOf(sent[0]).attachedFiles.length, 1);
+  });
+
   test('an empty urls list fails without fetching', async () => {
     let { client, sent } = fakeClient();
     let fetched = false;

--- a/packages/ai-bot/tests/read-realm-file-test.ts
+++ b/packages/ai-bot/tests/read-realm-file-test.ts
@@ -9,7 +9,9 @@ import {
   classifyToolCalls,
   fileLabelFromUrl,
   readFilesLabel,
+  READ_REALM_FILE_MAX_URLS,
   READ_REALM_FILE_TOOL_NAME,
+  urlsFromReadRealmFileArguments,
 } from '../lib/read-realm-file.ts';
 
 const ON_BEHALF_OF = '@user:localhost';
@@ -135,6 +137,56 @@ module('readRealmFile tool definition', () => {
       readRealmFileTool.function.description.includes('next turn'),
       'description tells the model that reading a skill file unlocks its ' +
         'tools on the next turn — without this the mechanism goes unused',
+    );
+  });
+
+  test('caps the url list and asks for each url once', () => {
+    let urls = (readRealmFileTool.function.parameters as any).properties.urls;
+    assert.strictEqual(
+      urls.maxItems,
+      READ_REALM_FILE_MAX_URLS,
+      'an uncapped list invites a small model to repeat urls until it hits ' +
+        'its output limit',
+    );
+    assert.true(urls.uniqueItems, 'each url is listed once');
+    assert.true(
+      urls.description.includes(`at most ${READ_REALM_FILE_MAX_URLS}`),
+      'the cap is spelled out for models that ignore schema constraints',
+    );
+    assert.false(
+      readRealmFileTool.function.description.includes(
+        'request them all in a single call',
+      ),
+      'the description no longer pushes the model to list everything at once',
+    );
+  });
+});
+
+module('urlsFromReadRealmFileArguments', () => {
+  test('parses a complete call and drops duplicates and non-strings', () => {
+    assert.deepEqual(
+      urlsFromReadRealmFileArguments(
+        JSON.stringify({ urls: [FILE_URL, RAW_FILE_URL, FILE_URL, 42, ''] }),
+      ),
+      [FILE_URL, RAW_FILE_URL],
+    );
+  });
+
+  test('recovers the complete urls from arguments cut off mid-list', () => {
+    // What a generation stopped at the output-token limit leaves behind: the
+    // list never closes and the last entry may be partial.
+    let truncated = `{"urls":["${FILE_URL}","${RAW_FILE_URL}","${FILE_URL}","https://localhost:4201/user/jane/skills/trip-pl`;
+    assert.deepEqual(urlsFromReadRealmFileArguments(truncated), [
+      FILE_URL,
+      RAW_FILE_URL,
+    ]);
+  });
+
+  test('malformed arguments without a url list yield nothing', () => {
+    assert.deepEqual(urlsFromReadRealmFileArguments('{not json'), []);
+    assert.deepEqual(
+      urlsFromReadRealmFileArguments('{"description":"https://x.test/a"'),
+      [],
     );
   });
 });

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -640,6 +640,44 @@ module('Responding', (hooks) => {
     assert.true(last.isStreamingFinished, 'the answer is marked finished');
   });
 
+  test('a tool call cut off at the output-token limit surfaces the error even though the router reports tool_calls', async () => {
+    await responder.ensureThinkingMessageSent();
+    let toolRequest = {
+      id: 'c1',
+      name: 'readRealmFile',
+      arguments: { urls: ['https://localhost:4201/user/jane/a.md'] },
+    };
+    await responder.onChunk({} as any, snapshotWithToolCall(toolRequest));
+    await clock.tickAsync(300);
+    // OpenRouter normalizes the upstream stop reason: a generation that hit
+    // its output limit mid tool call arrives as finish_reason 'tool_calls',
+    // and only native_finish_reason tells that it was cut.
+    await responder.onChunk(
+      {
+        choices: [
+          {
+            delta: {},
+            finish_reason: 'tool_calls',
+            native_finish_reason: 'max_output_tokens',
+            index: 0,
+          },
+        ],
+      } as any,
+      snapshotWithToolCall(toolRequest),
+    );
+    await clock.tickAsync(300);
+    await responder.finalize();
+
+    let sentEvents = fakeMatrixClient.getSentEvents();
+    let last = sentEvents[sentEvents.length - 1].content;
+    assert.equal(
+      last.errorMessage,
+      maxOutputTokensErrorMessage,
+      'the final event carries the output-limit error',
+    );
+    assert.true(last.isStreamingFinished, 'the answer is marked finished');
+  });
+
   test('an answer split across continuation events carries the output-limit error only on its final part', async () => {
     responder.matrixResponsePublisher.eventSizeMax = 1024; // 1KB max event size
     let longContent = 'a'.repeat(512) + 'b'.repeat(1024) + 'c'.repeat(1024);


### PR DESCRIPTION
Asking GPT-5.6 Luna to create a card right after it had read five skill files left the room on "Generating results" for seven minutes, then showed a "readRealmFile needs a non-empty list of urls" error, then did it again. The bot log showed chunks arriving the whole time.

What happened: the model answered with one `readRealmFile` call whose `urls` list repeated the same thirty-odd reference files of the boxel skill until the generation hit its 65,536 output-token limit (110 urls, 33 unique, in the first 2,500 tokens of a replay). The cut-off arguments were not valid JSON, so the bot read them as an empty list, posted an "invalid" result, and that result triggered a fresh generation into the same loop. Each round cost about eight cents. OpenRouter reported the stop as `finish_reason: tool_calls`, so the existing output-limit error never fired; only `native_finish_reason` said `max_output_tokens`.

Reasoning effort was not the cause: the replay looped identically with the room's `null`, with the parameter omitted, and with `medium`.

Three changes:

- The tool's `urls` list is capped at ten unique entries (`maxItems`, `uniqueItems`, and the same limit spelled out in the description), and the description no longer tells the model to request every file in one call. Replaying the exact failing prompt against the same model with this schema produced a normal seven-url call in 292 tokens.
- Urls are recovered from cut-off arguments. A truncated call still reads the files it named, once each, instead of failing and re-prompting the model. The timeline label names the recovered files too.
- The responder reads `native_finish_reason` as well, so an output-limit stop during a tool call is reported on the final room event the same way a cut-off text answer already is.

Tests cover the schema cap, url recovery from truncated and malformed arguments, fulfilment of a truncated call, and the native finish reason path. The two `AI Bot Locking` tests fail on my machine with and without this change because the local Postgres has no role for my user; they are unrelated.

Not in this PR: a guard that stops the bot from re-generating after its own self-fulfilled tool call fails the same way twice in a row. With url recovery the failing case no longer reaches that path, but the loop shape is still possible for a different malformed call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
