### PR TITLE
Allow brand guide custom CSS variables to differ between light and dark mode

### DIFF
--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -439,7 +439,14 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
                   {{/if}}
                 {{else if (eq section.id 'custom-css')}}
                   {{#if this.editMode}}
-                    <@fields.customCssVariables />
+                    {{! the toggle picks which value column is shown, like the
+                    color system's light/dark variables }}
+                    <div
+                      class='custom-css-edit
+                        {{if this.isDarkMode "is-dark-mode" "is-light-mode"}}'
+                    >
+                      <@fields.customCssVariables />
+                    </div>
                   {{else}}
                     <p class='brand-guide-vars-description'>These variables are
                       all of the custom CSS properties for usage by this theme
@@ -807,6 +814,10 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
       }
 
       /* Custom CSS / color variables section */
+      .custom-css-edit.is-light-mode :deep(.custom-css-variable-dark-value),
+      .custom-css-edit.is-dark-mode :deep(.custom-css-variable-light-value) {
+        display: none;
+      }
       .brand-guide-custom-css-block {
         position: relative;
       }
@@ -1219,17 +1230,29 @@ export class CustomCssVariable extends FieldDef {
         <FieldContainer @label='Variable Name' @vertical={{true}}>
           <@fields.name />
         </FieldContainer>
-        <FieldContainer @label='Light Value' @vertical={{true}}>
+        <FieldContainer
+          class='custom-css-variable-light-value'
+          @label='Value'
+          @vertical={{true}}
+          data-test-custom-css-variable-value='light'
+        >
           <@fields.value />
         </FieldContainer>
-        <FieldContainer @label='Dark Value (optional)' @vertical={{true}}>
+        <FieldContainer
+          class='custom-css-variable-dark-value'
+          @label='Dark Value (optional)'
+          @vertical={{true}}
+          data-test-custom-css-variable-value='dark'
+        >
           <@fields.darkValue />
         </FieldContainer>
       </div>
       <style scoped>
         .custom-css-variable-edit {
           display: grid;
-          grid-template-columns: 1fr 1fr 1fr;
+          /* a hidden value column leaves no empty track behind */
+          grid-auto-flow: column;
+          grid-auto-columns: 1fr;
           gap: var(--boxel-sp-sm);
         }
       </style>

--- a/packages/base/brand-guide.gts
+++ b/packages/base/brand-guide.gts
@@ -1100,11 +1100,17 @@ class BrandGuideIsolated extends Component<typeof BrandGuide> {
     return lines.join('\n');
   }
 
+  // shows the value for the previewed color scheme
   private get customCssVarEntries() {
     if (!entriesToCssRuleMap || !this.args.model?.customCssVariables?.length) {
       return [];
     }
-    let rules = entriesToCssRuleMap(this.args.model?.customCssVariables);
+    let rules = entriesToCssRuleMap(
+      customCssEntriesFor(
+        this.args.model.customCssVariables,
+        this.isDarkMode ? { darkMode: true } : undefined,
+      ),
+    );
     return [...rules.entries()].map(([name, value]) => ({
       name: buildCssVariableName(name),
       value,
@@ -1204,6 +1210,8 @@ export class CustomCssVariable extends FieldDef {
   static displayName = 'Custom CSS Variable';
   @field name = contains(StringField);
   @field value = contains(StringField);
+  // optional; dark mode falls back to `value` when unset
+  @field darkValue = contains(StringField);
 
   static edit = class Edit extends Component<typeof this> {
     <template>
@@ -1211,20 +1219,36 @@ export class CustomCssVariable extends FieldDef {
         <FieldContainer @label='Variable Name' @vertical={{true}}>
           <@fields.name />
         </FieldContainer>
-        <FieldContainer @label='Value' @vertical={{true}}>
+        <FieldContainer @label='Light Value' @vertical={{true}}>
           <@fields.value />
+        </FieldContainer>
+        <FieldContainer @label='Dark Value (optional)' @vertical={{true}}>
+          <@fields.darkValue />
         </FieldContainer>
       </div>
       <style scoped>
         .custom-css-variable-edit {
           display: grid;
-          grid-template-columns: 1fr 1fr;
+          grid-template-columns: 1fr 1fr 1fr;
           gap: var(--boxel-sp-sm);
         }
       </style>
     </template>
   };
 }
+
+// resolves each custom variable to the value for one color scheme, so the
+// normalizing helpers can treat the result like any other entry list
+export const customCssEntriesFor = (
+  entries: CustomCssVariable[] | undefined,
+  opts?: { darkMode: true },
+): CssVariableEntry[] =>
+  (entries ?? []).map((entry) => ({
+    name: entry.name,
+    value: opts?.darkMode
+      ? entry.darkValue?.trim() || entry.value
+      : entry.value,
+  }));
 
 export class CompoundImageField extends FieldDef {
   static displayName = 'Named Image';
@@ -1327,7 +1351,9 @@ export default class BrandGuide extends DetailedStyleRef {
     }
   }
 
-  private calculateBrandRuleMap(): Map<string, string> | undefined {
+  private calculateBrandRuleMap(opts?: {
+    darkMode: true;
+  }): Map<string, string> | undefined {
     let brandRules = new Map<string, string>();
 
     // add brand functional palette variables
@@ -1367,8 +1393,8 @@ export default class BrandGuide extends DetailedStyleRef {
       if (!brandRules.has(varName)) brandRules.set(varName, `url(${url})`);
     }
 
-    // add custom CSS variables
-    for (let cssVar of this.customCssVariables ?? []) {
+    // add custom CSS variables, resolved for the requested color scheme
+    for (let cssVar of customCssEntriesFor(this.customCssVariables, opts)) {
       let name = cssVar.name?.trim();
       let value = cssVar.value?.trim();
       if (!name || !value) continue;
@@ -1460,6 +1486,7 @@ export default class BrandGuide extends DetailedStyleRef {
         return;
       }
       let brandRules = this.calculateBrandRuleMap();
+      let darkBrandRules = this.calculateBrandRuleMap({ darkMode: true });
       let markMap = this.markUsage?.cssRuleMap;
       const toUrlValue = (url?: string) => (url ? `url(${url})` : undefined);
       let rootMarkAliases = new Map(
@@ -1529,7 +1556,7 @@ export default class BrandGuide extends DetailedStyleRef {
       );
       let darkRules = mergeRuleMaps(
         this.calculatedRules({ darkMode: true }),
-        brandRules,
+        darkBrandRules,
         darkMarkAliases,
       );
       return generateCssVariables(

--- a/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-custom-css-test.gts
@@ -1,4 +1,4 @@
-import type { RenderingTestContext } from '@ember/test-helpers';
+import { click, type RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -188,6 +188,90 @@ module('Integration | brand-guide | custom-css section', function (hooks) {
     assert.notOk(
       css.includes('should-be-excluded'),
       'entry with empty name is excluded from cssVariables',
+    );
+  });
+
+  test('custom CSS variables with a dark value emit it under .dark and fall back to the light value otherwise', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      customCssVariables: [
+        new CustomCssVariable({
+          name: 'surfaceTint',
+          value: '#ffffff',
+          darkValue: '#111111',
+        }),
+        new CustomCssVariable({ name: 'spacing', value: '1.5rem' }),
+        new CustomCssVariable({
+          name: 'blankDark',
+          value: 'solid',
+          darkValue: '   ',
+        }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let css = card.cssVariables ?? '';
+    let darkStart = css.indexOf('.dark');
+    assert.ok(darkStart > 0, 'a .dark block is emitted');
+    let rootBlock = css.slice(0, darkStart);
+    let darkBlock = css.slice(darkStart);
+
+    assert.ok(
+      rootBlock.includes('--surface-tint: #ffffff;'),
+      'light value is emitted under :root',
+    );
+    assert.ok(
+      darkBlock.includes('--surface-tint: #111111;'),
+      'dark value is emitted under .dark',
+    );
+    assert.notOk(
+      darkBlock.includes('#ffffff'),
+      'light value does not leak into .dark when a dark value is set',
+    );
+    assert.ok(
+      darkBlock.includes('--spacing: 1.5rem;'),
+      'a variable without a dark value keeps the light value in .dark',
+    );
+    assert.ok(
+      darkBlock.includes('--blank-dark: solid;'),
+      'a whitespace-only dark value falls back to the light value',
+    );
+  });
+
+  test('custom-css listing and copy block follow the dark-mode toggle', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      customCssVariables: [
+        new CustomCssVariable({
+          name: 'surfaceTint',
+          value: '#ffffff',
+          darkValue: '#111111',
+        }),
+        new CustomCssVariable({ name: 'spacing', value: '1.5rem' }),
+      ],
+    });
+    await renderCard(loader, card, 'isolated');
+
+    let values = () =>
+      [
+        ...document.querySelectorAll('[data-test-brand-guide-css-var-value]'),
+      ].map((el) => el.textContent);
+    assert.deepEqual(
+      values(),
+      ['#ffffff', '1.5rem'],
+      'light values are listed by default',
+    );
+
+    await click('[data-test-mode="toggle-dark"]');
+    assert.deepEqual(
+      values(),
+      ['#111111', '1.5rem'],
+      'dark value replaces the light value; unset dark values keep the light value',
+    );
+
+    await click('[data-test-mode="toggle-light"]');
+    assert.deepEqual(
+      values(),
+      ['#ffffff', '1.5rem'],
+      'toggling back restores light values',
     );
   });
 

--- a/packages/host/tests/integration/components/brand-guide-edit-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-edit-test.gts
@@ -1,9 +1,12 @@
-import { click, type RenderingTestContext } from '@ember/test-helpers';
+import { click, fillIn, type RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import type { Loader } from '@cardstack/runtime-common';
+import { PermissionsContextName } from '@cardstack/runtime-common';
+
+import { provideConsumeContext } from '../../helpers';
 
 import { setupBaseRealm } from '../../helpers/base-realm';
 import { renderCard } from '../../helpers/render-component';
@@ -98,6 +101,74 @@ module('Integration | brand-guide | edit view', function (hooks) {
     assert
       .dom('[data-test-brand-image-attachment-var]')
       .doesNotExist('read-only attachment listing is not rendered in edit');
+  });
+
+  test('custom CSS variable editor shows the value column for the previewed color scheme', async function (this: RenderingTestContext, assert) {
+    let card = new BrandGuide({
+      rootVariables: new ThemeVarField({ background: '#f6e6ee' }),
+      customCssVariables: [
+        new CustomCssVariable({ name: 'spacing-sm', value: '0.5rem' }),
+      ],
+    });
+    await renderCard(loader, card, 'edit');
+
+    assert
+      .dom('[data-test-custom-css-variable-value="light"]')
+      .isVisible('light value is edited by default');
+    assert
+      .dom('[data-test-custom-css-variable-value="dark"]')
+      .isNotVisible('dark value stays out of the way in light mode');
+
+    await click('[data-test-mode="toggle-dark"]');
+    assert
+      .dom('[data-test-custom-css-variable-value="dark"]')
+      .isVisible('dark mode edits the optional dark value');
+    assert
+      .dom('[data-test-custom-css-variable-value="light"]')
+      .isNotVisible('light value is hidden in dark mode');
+
+    await click('[data-test-mode="toggle-light"]');
+    assert
+      .dom('[data-test-custom-css-variable-value="light"]')
+      .isVisible('toggling back restores the light value column');
+  });
+
+  test('a custom CSS variable typed in the editor appears in the generated CSS', async function (this: RenderingTestContext, assert) {
+    provideConsumeContext(PermissionsContextName, { canWrite: true });
+    let card = new BrandGuide({
+      rootVariables: new ThemeVarField({ background: '#f6e6ee' }),
+    });
+    await renderCard(loader, card, 'edit');
+
+    await click(
+      '[data-test-brand-guide-section="custom-css"] [data-test-add-new]',
+    );
+    let inputs = document.querySelectorAll<HTMLInputElement>(
+      '[data-test-brand-guide-section="custom-css"] input',
+    );
+    await fillIn(inputs[0], 'ikea main');
+    await fillIn(
+      '[data-test-custom-css-variable-value="light"] input',
+      '#0051ba',
+    );
+
+    assert
+      .dom('[data-test-brand-guide-section="view-code"] [data-test-css-field]')
+      .includesText(
+        '--ikea-main: #0051ba;',
+        'the new variable shows up under View Code without saving',
+      );
+
+    await click('[data-test-mode="toggle-dark"]');
+    await fillIn(
+      '[data-test-custom-css-variable-value="dark"] input',
+      'lightblue',
+    );
+    let css = card.cssVariables ?? '';
+    assert.ok(
+      css.slice(css.indexOf('.dark')).includes('--ikea-main: lightblue;'),
+      'the dark value is emitted under .dark',
+    );
   });
 
   test('theme-less edit view leads with the import and generated css sections', async function (this: RenderingTestContext, assert) {

--- a/packages/host/tests/integration/components/brand-guide-edit-test.gts
+++ b/packages/host/tests/integration/components/brand-guide-edit-test.gts
@@ -88,7 +88,10 @@ module('Integration | brand-guide | edit view', function (hooks) {
       .exists('brand color palette entries are editable');
     assert
       .dom('[data-test-brand-guide-section="custom-css"] input')
-      .exists('custom CSS variables are editable');
+      .exists(
+        { count: 3 },
+        'custom CSS variables expose name, light value and dark value inputs',
+      );
     assert
       .dom('[data-test-brand-guide-css-var]')
       .doesNotExist('read-only custom CSS listing is not rendered in edit');


### PR DESCRIPTION
Fixes CS-12901 (https://linear.app/cardstack/issue/CS-12901).

Each `CustomCssVariable` on the brand guide gains an optional `darkValue`. The generated CSS emits it under `.dark`, falling back to the light `value` when blank, so existing cards produce the same output as before. The editor shows a third column for the dark value, and the custom-css listing and copy block in the isolated view follow the dashboard's dark-mode toggle.

Not covered here: pasting CSS through the importer still drops `--` properties that aren't declared theme fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)