### PR TITLE
Avoid loading unused columns during card JSON assembly

### DIFF
--- a/packages/realm-server/tests/index-entry-projection-test.ts
+++ b/packages/realm-server/tests/index-entry-projection-test.ts
@@ -1,0 +1,267 @@
+import { basename } from 'path';
+import QUnit from 'qunit';
+const { module, test } = QUnit;
+import type { PgAdapter } from '@cardstack/postgres';
+import {
+  CachingDefinitionLookup,
+  IndexQueryEngine,
+  VirtualNetwork,
+} from '@cardstack/runtime-common';
+import { setupDB } from './helpers/index.ts';
+
+const realmURL = 'https://json-reads.example/';
+const cardURL = new URL('person.json', realmURL);
+const aliasURL = new URL('person', realmURL);
+const fileURL = new URL('photo.png', realmURL);
+const largeValue = 'unused output '.repeat(80_000);
+const screenshots = {
+  card: {
+    specHash: 'spec',
+    objectKey: 'object',
+    contentType: 'image/png',
+    width: 320,
+    height: 200,
+    deviceScaleFactor: 1,
+  },
+};
+const omittedHtml = {
+  headHtml: null,
+  atomHtml: null,
+  embeddedHtml: null,
+  fittedHtml: null,
+  markdown: null,
+};
+
+module(basename(import.meta.filename), function (hooks) {
+  let db: PgAdapter;
+  let engine: IndexQueryEngine;
+  setupDB(hooks, {
+    beforeEach: async (adapter) => {
+      db = adapter;
+      let network = new VirtualNetwork();
+      // These direct row reads never resolve definitions or prerender.
+      let lookup = new CachingDefinitionLookup(
+        db,
+        undefined!,
+        network,
+        () => '',
+      );
+      engine = new IndexQueryEngine(db, lookup, network);
+      for (let suffix of ['', '_working']) {
+        for (let [url, alias, type] of [
+          [cardURL.href, aliasURL.href, 'instance'],
+          [fileURL.href, fileURL.href, 'file'],
+        ]) {
+          await db.execute(
+            `INSERT INTO boxel_index${suffix}
+              (url, file_alias, type, realm_url, generation, pristine_doc,
+               search_doc, deps, types, display_names, icon_html,
+               last_modified, resource_created_at, indexed_at)
+             VALUES ($1, $2, $3, $4, 7, $5, $6, $7, $8, $9, $10, 12, 10, 15)`,
+            {
+              bind: [
+                url,
+                alias,
+                type,
+                realmURL,
+                JSON.stringify({
+                  id: alias,
+                  type: type === 'file' ? 'file-meta' : 'card',
+                  attributes: { name: 'Example' },
+                  meta: {
+                    adoptsFrom: { module: `${realmURL}person`, name: 'Person' },
+                  },
+                }),
+                JSON.stringify(
+                  type === 'file'
+                    ? { width: 320, height: 200, contentType: 'image/png' }
+                    : { cardTitle: 'Example', expandedGraph: largeValue },
+                ),
+                JSON.stringify([`${realmURL}person.gts`]),
+                JSON.stringify([`${realmURL}person/Person`]),
+                JSON.stringify(['Example']),
+                largeValue,
+              ],
+            },
+          );
+          await db.execute(
+            `INSERT INTO prerendered_html${suffix}
+              (url, realm_url, type, file_alias, generation, isolated_html, head_html,
+               atom_html, embedded_html, fitted_html, markdown, screenshots)
+             VALUES ($1, $2, $3, $7, 7, $4::text, $4::text, $4::text, $5, $5, $4::text, $6)`,
+            {
+              bind: [
+                url,
+                realmURL,
+                type,
+                largeValue,
+                JSON.stringify({ Person: largeValue }),
+                JSON.stringify(screenshots),
+                alias,
+              ],
+            },
+          );
+        }
+      }
+    },
+  });
+
+  for (let useWorkInProgressIndex of [false, true]) {
+    test(`data-only instance and file reads preserve JSON metadata (working=${useWorkInProgressIndex})`, async function (assert) {
+      let opts = { useWorkInProgressIndex };
+      let full = await engine.getInstance(cardURL, opts);
+      if (!full) {
+        throw new Error('Expected fixture card');
+      }
+      let narrow = await engine.getInstance(aliasURL, {
+        ...opts,
+        dataOnly: true,
+      });
+      assert.ok(full?.isolatedHtml, 'fixture has large rendered output');
+      assert.deepEqual(
+        narrow,
+        {
+          ...full,
+          ...omittedHtml,
+          isolatedHtml: null,
+          searchDoc: null,
+        },
+        'only unused fields differ; timestamps, dependencies and screenshots survive',
+      );
+      let batch = await engine.getInstances([cardURL, aliasURL, aliasURL], {
+        ...opts,
+        dataOnly: true,
+      });
+      assert.strictEqual(
+        batch.size,
+        2,
+        'canonical and alias lookups are retained',
+      );
+      assert.deepEqual(batch.get(cardURL.href), narrow);
+      assert.deepEqual(batch.get(aliasURL.href), narrow);
+
+      let fullFile = await engine.getFile(fileURL, opts);
+      if (!fullFile) {
+        throw new Error('Expected fixture file');
+      }
+      let file = await engine.getFile(fileURL, { ...opts, dataOnly: true });
+      assert.deepEqual(
+        file,
+        {
+          ...fullFile,
+          ...omittedHtml,
+          isolatedHtml: null,
+          iconHtml: null,
+        },
+        'file search attributes and screenshots survive',
+      );
+      assert.deepEqual(file?.searchDoc, {
+        width: 320,
+        height: 200,
+        contentType: 'image/png',
+      });
+      assert.deepEqual(
+        (
+          await engine.getFiles([fileURL], {
+            ...opts,
+            dataOnly: true,
+          })
+        ).get(fileURL.href),
+        file,
+      );
+      assert.ok(
+        JSON.stringify(narrow).length < JSON.stringify(full).length / 100,
+        'unused multi-megabyte fields do not enter the JSON assembly result',
+      );
+    });
+  }
+
+  test('error presentation and source/render error precedence are preserved', async function (assert) {
+    for (let [sourceError, renderGeneration] of [
+      [false, 7],
+      [true, 7],
+      [false, 6],
+    ] as const) {
+      await db.execute(
+        `UPDATE boxel_index SET has_error = $1, error_doc = $2 WHERE url = $3`,
+        {
+          bind: [
+            sourceError,
+            sourceError ? JSON.stringify({ message: 'source failed' }) : null,
+            cardURL.href,
+          ],
+        },
+      );
+      await db.execute(
+        `UPDATE prerendered_html SET error_doc = $1, generation = $2 WHERE url = $3`,
+        {
+          bind: [
+            JSON.stringify({ message: 'render failed' }),
+            renderGeneration,
+            cardURL.href,
+          ],
+        },
+      );
+      let full = await engine.getInstance(cardURL);
+      if (!full) {
+        throw new Error('Expected fixture card');
+      }
+      let narrow = await engine.getInstance(cardURL, { dataOnly: true });
+      let expectedError = sourceError || renderGeneration === 7;
+      assert.strictEqual(
+        narrow?.type,
+        expectedError ? 'instance-error' : 'instance',
+      );
+      assert.deepEqual(
+        narrow,
+        {
+          ...full,
+          ...omittedHtml,
+          ...(!expectedError ? { isolatedHtml: null, searchDoc: null } : {}),
+        },
+        'current errors keep the last-known-good HTML, title and dependencies',
+      );
+      assert.deepEqual(
+        (await engine.getInstances([aliasURL], { dataOnly: true })).get(
+          aliasURL.href,
+        ),
+        narrow,
+      );
+    }
+  });
+
+  test('missing renderings, deleted rows and file errors retain their existing semantics', async function (assert) {
+    await db.execute('DELETE FROM prerendered_html');
+    let card = await engine.getInstance(cardURL, { dataOnly: true });
+    assert.strictEqual(card?.type, 'instance');
+    assert.strictEqual(card?.screenshots, null);
+    assert.ok(await engine.getFile(fileURL, { dataOnly: true }));
+    await db.execute(
+      'UPDATE boxel_index SET has_error = TRUE WHERE type = $1',
+      { bind: ['file'] },
+    );
+    assert.strictEqual(
+      await engine.getFile(fileURL, { dataOnly: true }),
+      undefined,
+    );
+    assert.strictEqual(
+      (await engine.getFiles([fileURL], { dataOnly: true })).size,
+      0,
+    );
+    await db.execute('UPDATE boxel_index SET is_deleted = TRUE');
+    assert.strictEqual(
+      await engine.getInstance(aliasURL, { dataOnly: true }),
+      undefined,
+    );
+    assert.strictEqual(
+      (await engine.getInstances([cardURL], { dataOnly: true })).size,
+      0,
+    );
+    assert.strictEqual(
+      await engine.getInstance(new URL('missing', realmURL), {
+        dataOnly: true,
+      }),
+      undefined,
+    );
+  });
+});

--- a/packages/realm-server/tests/load-links-batching-test.ts
+++ b/packages/realm-server/tests/load-links-batching-test.ts
@@ -140,7 +140,28 @@ module(basename(import.meta.filename), function () {
               perLinkLookupCount++;
             }
           }
-          return originalExecute(sql, opts);
+          let rows = await originalExecute(sql, opts);
+          if (isLinkTargetInstanceLookup) {
+            assert.ok(rows.length > 0, 'linked rows were read from the index');
+            for (let row of rows) {
+              assert.strictEqual(
+                row.head_html,
+                null,
+                'JSON expansion omits head HTML',
+              );
+              assert.strictEqual(
+                row.embedded_html,
+                null,
+                'JSON expansion omits embedded HTML',
+              );
+              assert.strictEqual(
+                row.search_doc,
+                null,
+                'JSON expansion omits the search document',
+              );
+            }
+          }
+          return rows;
         };
 
         let result = await searchCardsForTest(

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -251,7 +251,12 @@ interface InstanceError extends Partial<
 
 export type InstanceOrError = IndexedInstance | InstanceError;
 
-type GetEntryOptions = WIPOptions;
+type GetEntryOptions = WIPOptions & {
+  // JSON assembly needs neither rendered output nor healthy cards' search
+  // documents. Omitted fields are null; error presentation and file metadata
+  // retain the columns they need. Full reads remain the default.
+  dataOnly?: true;
+};
 export type QueryOptions = WIPOptions & {
   includeErrors?: true;
   // Restrict the result set to this subset of URLs (SQL `i.url IN (...)`) —
@@ -378,7 +383,7 @@ export class IndexQueryEngine {
     opts?: GetEntryOptions,
   ): Promise<InstanceOrError | undefined> {
     let result = (await this.#query([
-      `SELECT i.*, ${PRERENDERED_HTML_SELECTS}, ${EFFECTIVE_ERROR_SELECTS}`,
+      `SELECT ${entryColumns(opts)}`,
       `FROM ${tableFromOpts(opts)} as i ${prerenderedJoin(opts)}
        WHERE`,
       ...every([
@@ -415,7 +420,7 @@ export class IndexQueryEngine {
       let chunkSet = new Set(chunk);
       let chunkParams = chunk.map((href) => [param(href)]);
       let rows = (await this.#query([
-        `SELECT i.*, ${PRERENDERED_HTML_SELECTS}, ${EFFECTIVE_ERROR_SELECTS}`,
+        `SELECT ${entryColumns(opts)}`,
         `FROM ${tableFromOpts(opts)} as i ${prerenderedJoin(opts)}
          WHERE`,
         ...every([
@@ -644,7 +649,7 @@ export class IndexQueryEngine {
     opts?: GetEntryOptions,
   ): Promise<IndexedFile | undefined> {
     let result = (await this.#query([
-      `SELECT i.*, ${PRERENDERED_HTML_SELECTS}, ${EFFECTIVE_ERROR_SELECTS}`,
+      `SELECT ${entryColumns(opts)}`,
       `FROM ${tableFromOpts(opts)} as i ${prerenderedJoin(opts)}
        WHERE`,
       ...every([
@@ -679,7 +684,7 @@ export class IndexQueryEngine {
       let chunkSet = new Set(chunk);
       let chunkParams = chunk.map((href) => [param(href)]);
       let rows = (await this.#query([
-        `SELECT i.*, ${PRERENDERED_HTML_SELECTS}, ${EFFECTIVE_ERROR_SELECTS}`,
+        `SELECT ${entryColumns(opts)}`,
         `FROM ${tableFromOpts(opts)} as i ${prerenderedJoin(opts)}
          WHERE`,
         ...every([
@@ -2456,6 +2461,25 @@ const PRERENDERED_HTML_SELECTS = [
 ]
   .map((col) => `ph.${col} AS ${col}`)
   .join(', ');
+
+function entryColumns(opts?: GetEntryOptions): string {
+  if (!opts?.dataOnly) {
+    return `i.*, ${PRERENDERED_HTML_SELECTS}, ${EFFECTIVE_ERROR_SELECTS}`;
+  }
+  // Project in SQL: discarding these values after the driver parses JSONB
+  // would still pay the transfer and allocation costs. Keep the HTML join
+  // for effective errors and screenshots, even on successful JSON reads.
+  return `i.url, i.file_alias, i.type, i.is_deleted, i.pristine_doc,
+    i.types, i.display_names, i.deps, i.generation, i.realm_url, i.indexed_at,
+    i.last_modified, i.resource_created_at,
+    CASE WHEN i.type = 'file' OR ${effectiveHasError()}
+      THEN i.search_doc ELSE NULL END AS search_doc,
+    CASE WHEN ${effectiveHasError()}
+      THEN ph.isolated_html ELSE NULL END AS isolated_html,
+    NULL AS head_html, NULL AS atom_html, NULL AS embedded_html,
+    NULL AS fitted_html, NULL AS markdown, NULL AS icon_html,
+    ph.screenshots AS screenshots, ${EFFECTIVE_ERROR_SELECTS}`;
+}
 
 // SQLite LIKE treats `%` and `_` as wildcards. With `ESCAPE '\'` we can
 // neutralize user-supplied wildcards by prefixing them (and the escape

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -744,7 +744,10 @@ export class RealmIndexQueryEngine {
     opts?: Options,
   ): Promise<SearchResult | undefined> {
     let doc: SingleCardDocument | undefined;
-    let instance = await this.instance(url, opts);
+    let instance = await this.#indexQueryEngine.getInstance(url, {
+      ...opts,
+      dataOnly: true,
+    });
     if (!instance) {
       return undefined;
     }
@@ -1923,13 +1926,13 @@ export class RealmIndexQueryEngine {
           inRealmCardURLs.size > 0
             ? this.#indexQueryEngine.getInstances(
                 [...inRealmCardURLs].map((u) => new URL(u)),
-                opts,
+                { ...opts, dataOnly: true },
               )
             : Promise.resolve(new Map<string, InstanceOrError>()),
           inRealmFileURLs.size > 0
             ? this.#indexQueryEngine.getFiles(
                 [...inRealmFileURLs].map((u) => new URL(u)),
-                opts,
+                { ...opts, dataOnly: true },
               )
             : Promise.resolve(new Map<string, IndexedFile>()),
           crossRealmURLs.size > 0


### PR DESCRIPTION
## Background and Goal

Card JSON assembly still performs broad index reads: individual card reads and linked-card/file expansion select `i.*` plus every rendered HTML format and markdown. Healthy card assembly does not use most of those columns, but Postgres transfers them and the driver parses the JSONB values before Node discards them. Root search results already have a narrower projection; this change targets the follow-up entry reads.

Add an internal `dataOnly` projection and use it in `cardDocument()` and the batched lookups in `loadLinks()`. Full reads remain the default for other callers. Query predicates, graph traversal, authorization, response formatting, and the public API are unchanged. No migrations or card-definition changes.

## Where to start

- `packages/runtime-common/index-query-engine.ts`: `entryColumns()` selects the columns needed for JSON assembly. Healthy instances omit their search documents and rendered output; file rows retain search attributes. Both retain dependencies, timestamps, and screenshots. Effective source/render errors retain their error document, title source, and last-known-good isolated HTML.
- `packages/runtime-common/realm-index-query-engine.ts`: opt the card-document read and the existing linked-card/file batches into that projection.

## Handoff

The implementation is deliberately small: 35 added production lines across two files, plus focused regression coverage. The new database tests compare full and narrow results using multi-megabyte unused fields, cover canonical URLs/aliases, production and working tables, missing/deleted rows, file metadata, screenshots, and source/render error precedence. The existing linked-card integration test now also checks that its actual database results omit unused fields.

Locally, all 50 tests in `index-entry-projection-test` and `prerender-html-split-test` pass. `pnpm lint` passes in runtime-common and realm-server. A separate SQLite query smoke check passed for all four entry methods and both table pairs; this does not substitute for the host/browser suite.

Before taking this out of draft:

- Run the updated `load-links-batching-test` and existing card/file endpoint and host tests in a healthy test environment. The local services required for browser integration returned 502, so that integration test was not run here.
- Profile representative search/card workloads before and after, including concurrent readers. This patch reduces avoidable database transfer and allocation; it does not eliminate necessary pristine-document parsing, graph assembly, or final JSON serialization, and does not yet establish a production latency improvement or resolution of the 502/503 incidents.
